### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Getting started guide and documentation you can find in [docs](./docs) folder.
 ### es6 via npm
 
 ```bash
-npm install --save lightweight-charts
+npm install lightweight-charts
 ```
 
 ```js


### PR DESCRIPTION
npm install don't have flag `--save` from v5 and saves dependencies just with `install` command

```
list of flags: [--save-prod|--save-dev|--save-optional] [--save-exact] [--no-save]
```