### PR TITLE
mathex: max: array iteration

### DIFF
--- a/src/helpers/mathex.ts
+++ b/src/helpers/mathex.ts
@@ -38,7 +38,7 @@ export function min(arr: number[]): number {
 	}
 
 	let minVal = arr[0];
-	for (let i = 0; i < arr.length; ++i) {
+	for (let i = 1; i < arr.length; ++i) {
 		if (arr[i] < minVal) {
 			minVal = arr[i];
 		}


### PR DESCRIPTION
Continue array iteration from the index `1`. (Do not uselessly compare `arr[0]` with itself)