### PR TITLE
Cursor changes to double arrows when hovering Percentage axis

### DIFF
--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -340,8 +340,12 @@ export class PriceAxisWidget implements IDestroyable {
 	}
 
 	private _mouseEnterEvent(e: TouchMouseEvent): void {
+		if (this._priceScale === null) {
+			return;
+		}
+
 		const model = this._pane.chart().model();
-		if (model.options().handleScale.axisPressedMouseMove) {
+		if (model.options().handleScale.axisPressedMouseMove && !this._priceScale.isPercentage() && !this._priceScale.isIndexedTo100()) {
 			this._setCursor(CursorType.NsResize);
 		}
 	}


### PR DESCRIPTION
<!-- markdownlint-disable -->

**Type of PR:** bugfix

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

Fixed changing cursor to "double arrows" when hovering the price axis with `Percentage` or `IndexedTo100` mode
