### PR TITLE
Fixed vertical touch scroll

### DIFF
--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -92,7 +92,7 @@ export class PaneWidget implements IDestroyable {
 		chart.model().mainPriceScaleOptionsChanged().subscribe(this._recreatePriceAxisWidget.bind(this), this);
 		this.updatePriceAxisWidget();
 
-		this._mouseEventHandler = new MouseEventHandler(this._topCanvas, this, true, !this.chart().options().handleScroll.pressedMouseMove);
+		this._mouseEventHandler = new MouseEventHandler(this._topCanvas, this, true, !this.chart().options().handleScale.mouseWheel || !this.chart().options().handleScroll.pressedMouseMove);
 	}
 
 	public destroy(): void {


### PR DESCRIPTION
Fixes #80

**Type of PR:**
Bugfix

**PR checklist:**
- [x] Addresses issue #80
- [x] Tests update – not applicable
- [x] Documentation – the updated behavior fits current documentation

**Overview of change:**
Allow vertical touch scroll when `handleScale.mouseWheel` is set to `false`. This way, scroll behavior between pointer and touch devices is normalized when `handleScale.mouseWheel` option is used.
