### PR TITLE
Added new options to handle the chart's scroll on touch devices

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -287,8 +287,10 @@ You can disable any of them using `handleScroll` and `handleScale` options.
 
 |Name                        |Type   |Default  |Description|
 |----------------------------|-------|---------|-|
-|`mouseWheel`|`boolean`|`true`|If true, series scrolling with horizontal mouse wheel is enabled|
-|`pressedMouseMove`|`boolean`|`true`|If true, series scrolling with left mouse button pressed is allowed|
+|`mouseWheel`|`boolean`|`true`|If true, chart scrolling with horizontal mouse wheel is enabled|
+|`pressedMouseMove`|`boolean`|`true`|If true, chart scrolling with left mouse button pressed is allowed|
+|`horzTouchDrag`|`boolean`|`true`|If true, the chart handles horizontal pointer movements on touch screens. In this case the webpage is not scrolled. If you set it to false, the webpage is scrolled instead. Keep in mind that if the user starts scrolling the chart vertically or horizontally, scrolling is continued in any direction until the user releases the finger|
+|`vertTouchDrag`|`boolean`|`true`|If true, the chart handles vertical pointer movements on touch screens. In this case the webpage is not scrolled. If you set it to false, the webpage is scrolled instead. Keep in mind that if the user starts scrolling the chart vertically or horizontally, scrolling is continued in any direction until the user releases the finger.|
 
 ### Scaling options
 

--- a/src/api/options/chart-options-defaults.ts
+++ b/src/api/options/chart-options-defaults.ts
@@ -23,6 +23,8 @@ export const chartOptionsDefaults: ChartOptions = {
 	handleScroll: {
 		mouseWheel: true,
 		pressedMouseMove: true,
+		horzTouchDrag: true,
+		vertTouchDrag: true,
 	},
 	handleScale: {
 		axisPressedMouseMove: true,

--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -394,6 +394,13 @@ export class MouseEventHandler implements IDestroyable {
 		}
 
 		this._initPinch();
+
+		// Hey mobile Safari, what's up?
+		// If mobile Safari doesn't have any touchmove handler with passive=false
+		// it treats a touchstart and the following touchmove events as cancelable=false,
+		// so we can't prevent them (as soon we subscribe on touchmove inside touchstart's handler).
+		// And we'll get the page's scroll along with chart's one instead of only chart's scroll.
+		this._target.addEventListener('touchmove', () => {}, { passive: false });
 	}
 
 	private _initPinch(): void {

--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -43,7 +43,6 @@ export interface TouchMouseEvent {
 
 	target: MouseEvent['target'];
 	view: MouseEvent['view'];
-	preventDefault(): void;
 }
 
 export interface Position {
@@ -536,12 +535,6 @@ export class MouseEventHandler implements IDestroyable {
 
 			target: eventLike.target,
 			view: event.view,
-
-			preventDefault: () => {
-				if (event.cancelable) {
-					event.preventDefault();
-				}
-			},
 		};
 	}
 }

--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -347,14 +347,6 @@ export class MouseEventHandler implements IDestroyable {
 			this._clickCount = 0;
 			this._clickTimeoutId = setTimeout(this._resetClickTimeout.bind(this), Delay.ResetClick);
 		}
-
-		if (this._preventDefault) {
-			try {
-				window.focus();
-			} catch (er) {
-				// empty block
-			}
-		}
 	}
 
 	private _init(): void {

--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -265,7 +265,7 @@ export class MouseEventHandler implements IDestroyable {
 			}
 		}
 
-		// prevent safari's pinch-to-zoom
+		// prevent safari's dblclick-to-zoom
 		// we handle mouseDoubleClickEvent here by ourself
 		if (mouseUpEvent.type === 'touchend') {
 			preventDefault(mouseUpEvent);

--- a/src/gui/pane-separator.ts
+++ b/src/gui/pane-separator.ts
@@ -59,7 +59,14 @@ export class PaneSeparator implements IDestroyable {
 				pressedMouseMoveEvent: this._pressedMouseMoveEvent.bind(this),
 				mouseUpEvent: this._mouseUpEvent.bind(this),
 			};
-			this._mouseEventHandler = new MouseEventHandler(this._handle, handlers, true, false);
+			this._mouseEventHandler = new MouseEventHandler(
+				this._handle,
+				handlers,
+				{
+					treatVertTouchDragAsPageScroll: false,
+					treatHorzTouchDragAsPageScroll: true,
+				}
+			);
 		}
 	}
 

--- a/src/gui/pane-separator.ts
+++ b/src/gui/pane-separator.ts
@@ -110,7 +110,6 @@ export class PaneSeparator implements IDestroyable {
 	}
 
 	private _pressedMouseMoveEvent(event: TouchMouseEvent): void {
-		event.preventDefault();
 		this._deltaY = (event.pageY - this._startY);
 		const upperHeight = this._paneA.getSize().h;
 		const newUpperPaneHeight = clamp(upperHeight + this._deltaY, this._minPaneHeight, this._maxPaneHeight);

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -101,7 +101,15 @@ export class PaneWidget implements IDestroyable {
 		chart.model().mainPriceScaleOptionsChanged().subscribe(this._recreatePriceAxisWidget.bind(this), this);
 		this.updatePriceAxisWidget();
 
-		this._mouseEventHandler = new MouseEventHandler(this._topCanvas, this, true, !this.chart().options().handleScroll.pressedMouseMove);
+		const scrollOptions = this.chart().options().handleScroll;
+		this._mouseEventHandler = new MouseEventHandler(
+			this._topCanvas,
+			this,
+			{
+				treatVertTouchDragAsPageScroll: !scrollOptions.vertTouchDrag,
+				treatHorzTouchDragAsPageScroll: !scrollOptions.horzTouchDrag,
+			}
+		);
 	}
 
 	public destroy(): void {
@@ -283,7 +291,15 @@ export class PaneWidget implements IDestroyable {
 			this._setCrosshairPosition(x, y);
 		}
 
-		if (model.timeScale().isEmpty() || !this._chart.options().handleScroll.pressedMouseMove) {
+		if (model.timeScale().isEmpty()) {
+			return;
+		}
+
+		const scrollOptions = this._chart.options().handleScroll;
+		if (
+			(!scrollOptions.pressedMouseMove || event.type === 'touch') &&
+			(!scrollOptions.horzTouchDrag && !scrollOptions.vertTouchDrag || event.type === 'mouse')
+		) {
 			return;
 		}
 

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -95,7 +95,14 @@ export class PriceAxisWidget implements IDestroyable {
 			mouseEnterEvent: this._mouseEnterEvent.bind(this),
 			mouseLeaveEvent: this._mouseLeaveEvent.bind(this),
 		};
-		this._mouseEventHandler = new MouseEventHandler(this._topCanvas, handler, true, false);
+		this._mouseEventHandler = new MouseEventHandler(
+			this._topCanvas,
+			handler,
+			{
+				treatVertTouchDragAsPageScroll: false,
+				treatHorzTouchDragAsPageScroll: true,
+			}
+		);
 	}
 
 	public destroy(): void {

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -99,7 +99,7 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 		this._chart.model().mainPriceScaleOptionsChanged().subscribe(this._recreateStub.bind(this), this);
 
 		this._mouseEventHandler = new MouseEventHandler(
-			this._cell,
+			this._topCanvas,
 			this,
 			{
 				treatVertTouchDragAsPageScroll: true,

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -98,7 +98,14 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 		this._recreateStub();
 		this._chart.model().mainPriceScaleOptionsChanged().subscribe(this._recreateStub.bind(this), this);
 
-		this._mouseEventHandler = new MouseEventHandler(this._cell, this, true, false);
+		this._mouseEventHandler = new MouseEventHandler(
+			this._cell,
+			this,
+			{
+				treatVertTouchDragAsPageScroll: true,
+				treatHorzTouchDragAsPageScroll: false,
+			}
+		);
 	}
 
 	public destroy(): void {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -28,6 +28,8 @@ import { Watermark, WatermarkOptions } from './watermark';
 export interface HandleScrollOptions {
 	mouseWheel: boolean;
 	pressedMouseMove: boolean;
+	horzTouchDrag: boolean;
+	vertTouchDrag: boolean;
 }
 
 export interface HandleScaleOptions {


### PR DESCRIPTION
Fixes #80

<!-- markdownlint-disable -->

**Type of PR:** bugfix, enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #80
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

Added 2 new options to `handleScroll`:

- `horzTouchDrag` - If `true`, the chart handles horizontal pointer movements on touch screens. In this case the webpage is not scrolled. If you set it to false, the webpage is scrolled instead.
- `vertTouchDrag` - If `true`, the chart handles vertical pointer movements on touch screens. In this case the webpage is not scrolled. If you set it to `false`, the webpage is scrolled instead.

Note: Keep in mind that if the user starts scrolling the chart vertically or horizontally, scrolling is continued _in any direction_ until the user releases the finger. They does not prevent scrolling in a specific direction at all.

/cc @kirchet @ezhukovskiy @vladmoroz