### PR TITLE
Graphics tests on different devicePixelRatio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,27 @@ commands:
       - checkout
       - restore_cache: *restore-node-modules-cache
 
+  run-graphics-tests:
+    description: "Run graphics tests with specific devicePixelRatio"
+    parameters:
+      devicePixelRatio:
+        type: string
+    steps:
+      - checkout-with-deps
+      - run:
+          name: "Setup Environment Variables"
+          command: |
+            echo 'export NO_SANDBOX="true"' >> $BASH_ENV
+            echo 'export CMP_OUT_DIR="./graphics-cmp-data"' >> $BASH_ENV
+            echo 'export TESTS_REPORT_FILE="test-results/graphics/results.xml"' >> $BASH_ENV
+            echo 'export DEVICE_PIXEL_RATIO=<< parameters.devicePixelRatio >>' >> $BASH_ENV
+      - run: scripts/run-graphics-tests.sh
+      - store_test_results:
+          path: test-results/
+      - store_artifacts:
+          path: ./graphics-cmp-data
+          when: on_fail
+
 
 jobs:
   install-deps:
@@ -109,20 +130,24 @@ jobs:
           path: ./dts-changes
           when: on_fail
 
-  graphics-tests:
+  graphics-tests-dpr1_0:
     executor: node-browsers-latest-executor
-    environment:
-      NO_SANDBOX: "true"
-      CMP_OUT_DIR: ./graphics-cmp-data
-      TESTS_REPORT_FILE: "test-results/graphics/results.xml"
     steps:
-      - checkout-with-deps
-      - run: scripts/run-graphics-tests.sh
-      - store_test_results:
-          path: test-results/
-      - store_artifacts:
-          path: ./graphics-cmp-data
-          when: on_fail
+      - run-graphics-tests:
+          devicePixelRatio: "1.0"
+
+  graphics-tests-dpr1_5:
+    executor: node-browsers-latest-executor
+    steps:
+      - run-graphics-tests:
+          devicePixelRatio: "1.5"
+
+  graphics-tests-dpr2_0:
+    executor: node-browsers-latest-executor
+    steps:
+      - run-graphics-tests:
+          devicePixelRatio: "2.0"
+
 
   memleaks-tests:
     executor: node-browsers-latest-executor
@@ -179,7 +204,23 @@ workflows:
                 - master
           requires:
             - build
-      - graphics-tests:
+      - graphics-tests-dpr1_0:
+          filters:
+            <<: *default-filters
+            branches:
+              ignore:
+                - master
+          requires:
+            - build
+      - graphics-tests-dpr1_5:
+          filters:
+            <<: *default-filters
+            branches:
+              ignore:
+                - master
+          requires:
+            - build
+      - graphics-tests-dpr2_0:
           filters:
             <<: *default-filters
             branches:

--- a/tests/e2e/graphics/helpers/screenshoter.ts
+++ b/tests/e2e/graphics/helpers/screenshoter.ts
@@ -8,11 +8,21 @@ import {
 	Response,
 } from 'puppeteer';
 
+const viewportWidth = 600;
+const viewportHeight = 600;
+
 export class Screenshoter {
 	private _browserPromise: Promise<Browser>;
 
-	public constructor(noSandbox: boolean) {
-		const puppeteerOptions: LaunchOptions = {};
+	public constructor(noSandbox: boolean, devicePixelRatio: number = 1) {
+		const puppeteerOptions: LaunchOptions = {
+			defaultViewport: {
+				deviceScaleFactor: devicePixelRatio,
+				width: viewportWidth,
+				height: viewportHeight,
+			},
+		};
+
 		if (noSandbox) {
 			puppeteerOptions.args = ['--no-sandbox', '--disable-setuid-sandbox'];
 		}
@@ -33,10 +43,6 @@ export class Screenshoter {
 			const browser = await this._browserPromise;
 			page = await browser.newPage();
 
-			const width = 600;
-			const height = 600;
-			await page.setViewport({ width, height });
-
 			const errors: string[] = [];
 			page.on('pageerror', (error: Error) => {
 				errors.push(error.message);
@@ -51,7 +57,7 @@ export class Screenshoter {
 			await page.setContent(pageContent, { waitUntil: 'load' });
 
 			// to avoid random cursor position
-			await page.mouse.move(width / 2, height / 2);
+			await page.mouse.move(viewportWidth / 2, viewportHeight / 2);
 
 			// wait for test case is ready
 			await page.evaluate(() => {


### PR DESCRIPTION
**Type of PR:** tests enhancement

**Overview of change:**

The PR introduce a way to run graphics tests on different `devicePixelRatio`s. By default they run with `devicePixelRatio=1`, but you can override it by passing `DEVICE_PIXEL_RATIO` environment variable.

On CI we run tests for 1, 1.5 and 2 `devicePixelRatio`s.