### PR TITLE
Selection's magnifier on iOS Safari

### DIFF
--- a/src/gui/canvas-utils.ts
+++ b/src/gui/canvas-utils.ts
@@ -38,6 +38,15 @@ export function addCanvasTo(element: HTMLElement, size: Size): HTMLCanvasElement
 	element.appendChild(canvas);
 
 	resizeCanvas(canvas, size);
+	disableSelection(canvas);
 
 	return canvas;
+}
+
+function disableSelection(canvas: HTMLCanvasElement): void {
+	canvas.style.userSelect = 'none';
+	canvas.style.webkitUserSelect = 'none';
+	canvas.style.msUserSelect = 'none';
+	// tslint:disable-next-line:no-any
+	(canvas as any).style.MozUserSelect = 'none';
 }


### PR DESCRIPTION
**Type of PR:** bugfix <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [x] Addresses an existing issue: fixes #93 
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

Applying CCS rules to disable selection on creating canvas.

<!-- optional -->
