### PR TITLE
Fixed palette initialization and updating (release-1.0)

### DIFF
--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -250,7 +250,7 @@ export class DataLayer {
 			}
 		});
 
-		return this._setNewPoints(newPoints, palette);
+		return this._setNewPoints(series, newPoints, palette);
 	}
 
 	public removeSeries(series: Series): UpdatePacket {
@@ -335,7 +335,7 @@ export class DataLayer {
 		};
 	}
 
-	private _setNewPoints(newPoints: Map<UTCTimestamp, TimePointData>, palette?: Palette): UpdatePacket {
+	private _setNewPoints(seriesBeingUpdated: Series, newPoints: Map<UTCTimestamp, TimePointData>, palette?: Palette): UpdatePacket {
 		this._pointDataByTimePoint = newPoints;
 
 		this._sortedTimePoints = Array.from(this._pointDataByTimePoint.values()).map((d: TimePointData) => d.timePoint);
@@ -348,10 +348,11 @@ export class DataLayer {
 			pointData.mapping.forEach((targetData: TimedData, targetSeries: Series) => {
 				// add point to series
 				const packet = seriesUpdates.get(targetSeries) || newSeriesUpdatePacket();
+				const seriesPalette = (seriesBeingUpdated === targetSeries) ? palette : targetSeries.palette();
 				const seriesUpdate: PlotRow<Bar['time'], Bar['value']> = {
 					index: index as TimePointIndex,
 					time,
-					value: getItemValues(targetData, palette),
+					value: getItemValues(targetData, seriesPalette),
 				};
 				packet.update.push(seriesUpdate);
 				seriesUpdates.set(targetSeries, packet);

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -95,12 +95,13 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 	private _barColorerCache: SeriesBarColorer | null = null;
 	private readonly _options: SeriesOptionsMap[T];
 	private _barFunction: BarFunction;
-	private _palette: Palette = new Palette();
+	private _palette: Palette;
 
 	public constructor(model: ChartModel, options: SeriesOptionsMap[T], seriesType: T) {
 		super(model);
 		this._options = options;
 		this._seriesType = seriesType;
+		this._palette = this._createDefaultPalette();
 
 		this.createPaneView();
 
@@ -265,7 +266,7 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 		this._data.clear();
 		this._data.bars().merge(data);
 		if (updatePalette) {
-			this._palette = (palette === undefined) ? new Palette() : palette;
+			this._palette = (palette === undefined) ? this._createDefaultPalette() : palette;
 		}
 		if (this._paneView !== null) {
 			this._paneView.update('data');
@@ -504,5 +505,13 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 	private _updateBarFunction(): void {
 		const priceSource = 'close';
 		this._barFunction = barFunction(priceSource);
+	}
+
+	private _createDefaultPalette(): Palette {
+		const res = new Palette();
+		if (this._seriesType === 'Histogram') {
+			res.addColor((this._options as HistogramStyleOptions).color);
+		}
+		return res;
 	}
 }

--- a/tests/e2e/graphics/test-cases/series/add-series-after-volume.js
+++ b/tests/e2e/graphics/test-cases/series/add-series-after-volume.js
@@ -1,0 +1,18 @@
+// fix the first case from
+// https://github.com/tradingview/lightweight-charts/issues/110
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var areaSeries = chart.addAreaSeries(); // or any other series type
+	var volumeSeries = chart.addHistogramSeries();
+
+	volumeSeries.setData([
+		{ time: '2019-05-24', value: 23714686.00, color: 'red' },
+	]);
+
+	areaSeries.setData([
+		{ time: '2019-05-24', value: 179.66 },
+	]);
+}

--- a/tests/e2e/graphics/test-cases/series/histogram-update-without-set-data.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-update-without-set-data.js
@@ -1,0 +1,19 @@
+// fix the second case from
+// https://github.com/tradingview/lightweight-charts/issues/110
+
+// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var areaSeries = chart.addAreaSeries();
+	var volumeSeries = chart.addHistogramSeries();
+
+	volumeSeries.update(
+		{ time: '2019-05-24', value: 23714686.00 },
+	);
+
+	areaSeries.setData([
+		{ time: '2019-05-24', value: 179.66 },
+	]);
+}

--- a/tests/unittests/data-layer.spec.ts
+++ b/tests/unittests/data-layer.spec.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import { convertTime, DataLayer, SeriesUpdatePacket, stringToBusinessDay } from '../../src/api/data-layer';
 import { ensureDefined } from '../../src/helpers/assertions';
+import { Palette } from '../../src/model/palette';
 import { Series } from '../../src/model/series';
 import { SeriesData } from '../../src/model/series-data';
 import { BusinessDay, TimePointIndex, UTCTimestamp } from '../../src/model/time-data';
@@ -15,6 +16,9 @@ function createSeriesMock(): Series {
 	return {
 		data: () => {
 			return data;
+		},
+		palette: () => {
+			return new Palette();
 		},
 	} as Series;
 }


### PR DESCRIPTION
Fixes #110

**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #110
- [x] Includes tests - added two graphics tests
- [ ] Documentation update

**Overview of change:**
Fixed logic of data recalculating if we have several series, with and without palette
