### PR TITLE
Removed unused params in PriceFormatter::format() method

### DIFF
--- a/src/formatters/percentage-formatter.ts
+++ b/src/formatters/percentage-formatter.ts
@@ -5,7 +5,7 @@ export class PercentageFormatter extends PriceFormatter {
 		super(priceScale);
 	}
 
-	public format(price: number, signPositive?: boolean, tailSize?: number, signNegative?: boolean): string {
-		return `${super.format(price, signPositive, tailSize, signNegative)}%`;
+	public format(price: number): string {
+		return `${super.format(price)}%`;
 	}
 }

--- a/src/formatters/price-formatter.ts
+++ b/src/formatters/price-formatter.ts
@@ -60,37 +60,15 @@ export class PriceFormatter implements IFormatter {
 		this._calculateDecimal();
 	}
 
-	// tailSize > 0 for formatting avg prices
-	public format(
-		price: number,
-		signPositive?: boolean,
-		tailSize?: number,
-		signNegative: boolean = true
-	): string {
-		// split price into integer part and fractional
-		let sign = '';
-		if (price < 0) {
-			if (signPositive === true) {
-				sign = '\u2212';
-			} else if (signNegative === false) {
-				sign = '';
-			} else {
-				sign = '−';
-			}
-			price = -price;
-		} else if (price && signPositive === true) {
-			sign = '+';
-		}
-
-		let value;
+	public format(price: number): string {
+		const sign = price < 0 ? '-' : '';
+		price = Math.abs(price);
 
 		if (this._fractional) {
-			value = sign + this._formatAsFractional(price, tailSize);
-		} else {
-			value = sign + this._formatAsDecimal(price, tailSize);
+			return sign + this._formatAsFractional(price);
 		}
 
-		return value;
+		return sign + this._formatAsDecimal(price);
 	}
 
 	private _calculateDecimal(): void {
@@ -110,14 +88,13 @@ export class PriceFormatter implements IFormatter {
 		}
 	}
 
-	private _formatAsDecimal(price: number, tailSize?: number): string {
+	private _formatAsDecimal(price: number): string {
 		let base: number;
-		tailSize = tailSize || 0;
 		if (this._fractional) {
 			// if you really want to format fractional as decimal
 			base = Math.pow(10, (this._fractionalLength || 0));
 		} else {
-			base = Math.pow(10, tailSize) * this._priceScale / this._minMove;
+			base = this._priceScale / this._minMove;
 		}
 
 		let intPart = Math.floor(price);
@@ -131,41 +108,28 @@ export class PriceFormatter implements IFormatter {
 				intPart += 1;
 			}
 
-			fracString = formatterOptions.decimalSign + numberToStringWithLeadingZero(+fracPart.toFixed(this._fractionalLength) * this._minMove, fracLength + tailSize);
-
-			// remove ending 0 but not more then tailSize
-			fracString = this._removeEndingZeros(fracString, tailSize);
+			fracString = formatterOptions.decimalSign + numberToStringWithLeadingZero(+fracPart.toFixed(this._fractionalLength) * this._minMove, fracLength);
 		} else {
 			// should round int part to minmov
 			intPart = Math.round(intPart * base) / base;
 			// if minmov > 1, fractional part is always = 0
 			if (fracLength > 0) {
-				fracString = formatterOptions.decimalSign + numberToStringWithLeadingZero(0, fracLength + tailSize);
+				fracString = formatterOptions.decimalSign + numberToStringWithLeadingZero(0, fracLength);
 			}
 		}
 
 		return intPart.toFixed(0) + fracString;
 	}
 
-	private _formatAsFractional(price: number, tailSize?: number): string {
+	private _formatAsFractional(price: number): string {
 		// temporary solution - use decimal format with 2 digits
 		const base = this._priceScale / this._minMove;
 		let intPart = Math.floor(price);
-		let fracPart = tailSize ?
-			Math.floor(price * base) - intPart * base :
-			Math.round(price * base) - intPart * base;
+		let fracPart = Math.round(price * base) - intPart * base;
 
 		if (fracPart === base) {
 			fracPart = 0;
 			intPart += 1;
-		}
-
-		let tailStr = '';
-		if (tailSize) {
-			let tail = (price - intPart - fracPart / base) * base;
-			tail = Math.round(tail * Math.pow(10, tailSize));
-			tailStr = numberToStringWithLeadingZero(tail, tailSize);
-			tailStr = this._removeEndingZeros(tailStr, tailSize);
 		}
 
 		if (!this._fractionalLength) {
@@ -194,18 +158,6 @@ export class PriceFormatter implements IFormatter {
 			fracString = numberToStringWithLeadingZero(fracPart * this._minMove, this._fractionalLength);
 		}
 
-		return intPart.toString() + formatterOptions.decimalSignFractional + fracString + tailStr;
-	}
-
-	private _removeEndingZeros(str: string, limit: number): string {
-		for (let i = 0; i < limit; i++) {
-			if (str[str.length - 1] === '0') {
-				str = str.substr(0, str.length - 1);
-			} else {
-				break;
-			}
-		}
-
-		return str;
+		return intPart.toString() + formatterOptions.decimalSignFractional + fracString;
 	}
 }

--- a/src/formatters/price-formatter.ts
+++ b/src/formatters/price-formatter.ts
@@ -61,7 +61,9 @@ export class PriceFormatter implements IFormatter {
 	}
 
 	public format(price: number): string {
-		const sign = price < 0 ? '-' : '';
+		// \u2212 is unicode's minus sign https://www.fileformat.info/info/unicode/char/2212/index.htm
+		// we should use it because it has the same width as plus sign +
+		const sign = price < 0 ? '\u2212' : '';
 		price = Math.abs(price);
 
 		if (this._fractional) {

--- a/tests/unittests/formatters.spec.ts
+++ b/tests/unittests/formatters.spec.ts
@@ -57,7 +57,7 @@ describe('Formatters', () => {
 		{
 			const formatter = new PriceFormatter();
 			const res = formatter.format(-1.5);
-			expect(res).to.be.equal('-1.50');
+			expect(res).to.be.equal('\u22121.50');
 		}
 	});
 	it('time-formatter', () => {

--- a/tests/unittests/formatters.spec.ts
+++ b/tests/unittests/formatters.spec.ts
@@ -55,9 +55,9 @@ describe('Formatters', () => {
 			expect(res).to.be.equal('1.500');
 		}
 		{
-			const formatter = new PriceFormatter(1000);
-			const res = formatter.format(1.5, true);
-			expect(res).to.be.equal('+1.500');
+			const formatter = new PriceFormatter();
+			const res = formatter.format(-1.5);
+			expect(res).to.be.equal('-1.50');
 		}
 	});
 	it('time-formatter', () => {


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #111
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Removed params is used nowhere and can be easily removed.
