### PR TITLE
Don't extend range by 0.5 in Series (it's already done in PriceScale)

### DIFF
--- a/src/formatters/price-formatter.ts
+++ b/src/formatters/price-formatter.ts
@@ -112,9 +112,9 @@ export class PriceFormatter implements IFormatter {
 
 			fracString = formatterOptions.decimalSign + numberToStringWithLeadingZero(+fracPart.toFixed(this._fractionalLength) * this._minMove, fracLength);
 		} else {
-			// should round int part to minmov
+			// should round int part to min move
 			intPart = Math.round(intPart * base) / base;
-			// if minmov > 1, fractional part is always = 0
+			// if min move > 1, fractional part is always = 0
 			if (fracLength > 0) {
 				fracString = formatterOptions.decimalSign + numberToStringWithLeadingZero(0, fracLength);
 			}

--- a/src/model/iprice-data-source.ts
+++ b/src/model/iprice-data-source.ts
@@ -12,6 +12,6 @@ export interface IPriceDataSource extends IDataSource {
 	formatter(): IFormatter;
 	priceLineColor(lastBarColor: string): string;
 	model(): ChartModel;
-	base(): number;
+	minMove(): number;
 	priceRange(startTimePoint: TimePointIndex, endTimePoint: TimePointIndex): PriceRange | null;
 }

--- a/src/model/price-data-source.ts
+++ b/src/model/price-data-source.ts
@@ -18,7 +18,7 @@ export abstract class PriceDataSource extends DataSource implements IPriceDataSo
 		return this._model;
 	}
 
-	public base(): number {
+	public minMove(): number {
 		return 0;
 	}
 

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -857,7 +857,7 @@ export class PriceScale {
 			}
 		}
 
-		if (priceRange) {
+		if (priceRange !== null) {
 			// keep current range is new is empty
 			if (priceRange.minValue() === priceRange.maxValue()) {
 				priceRange = new PriceRange(priceRange.minValue() - 0.5, priceRange.maxValue() + 0.5);

--- a/src/model/price-tick-mark-builder.ts
+++ b/src/model/price-tick-mark-builder.ts
@@ -28,10 +28,6 @@ export class PriceTickMarkBuilder {
 		this._logicalToCoordinateFunc = logicalToCoordinateFunc;
 	}
 
-	public base(): number {
-		return this._base;
-	}
-
 	public setBase(base: number): void {
 		if (base < 0) {
 			throw new Error('base < 0');

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -395,16 +395,12 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 			barsMinMax = this.data().bars().minMaxOnRangeCached(startTimePoint, endTimePoint, [{ name: 'low', offset: 0 }, { name: 'high', offset: 0 }]);
 		}
 
-		let range =
-			barsMinMax !== null ?
-				barsMinMax.min === barsMinMax.max ?
-					new PriceRange(barsMinMax.min - 0.5, barsMinMax.max + 0.5) : // special case: range consists of the only point
-					new PriceRange(barsMinMax.min, barsMinMax.max) :
-				null;
+		let range = barsMinMax !== null ? new PriceRange(barsMinMax.min, barsMinMax.max) : null;
 
 		if (this.seriesType() === 'Histogram') {
 			const base = (this._options as HistogramStyleOptions).base;
-			range = range !== null ? range.merge(new PriceRange(base, base)) : new PriceRange(base - 0.5, base + 0.5);
+			const rangeWithBase = new PriceRange(base, base);
+			range = range !== null ? range.merge(rangeWithBase) : rangeWithBase;
 		}
 
 		return range;

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -406,8 +406,8 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 		return range;
 	}
 
-	public base(): number {
-		return Math.round(1 / this._options.priceFormat.minMove);
+	public minMove(): number {
+		return this._options.priceFormat.minMove;
 	}
 
 	public formatter(): IFormatter {

--- a/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/indexed-to-100-scale.js
+++ b/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/indexed-to-100-scale.js
@@ -1,0 +1,33 @@
+function generateData() {
+	var res = [];
+
+	var endDate = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0));
+	var time = new Date(new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0)));
+	for (var i = 0; time.getTime() < endDate.getTime(); ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: 10,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container, {
+		priceScale: {
+			mode: LightweightCharts.PriceScaleMode.IndexedTo100,
+		},
+	});
+
+	var firstSeries = chart.addLineSeries({
+		priceFormat: {
+			minMove: 10,
+		},
+	});
+
+	firstSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/normal-scale.js
+++ b/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/normal-scale.js
@@ -1,0 +1,33 @@
+function generateData() {
+	var res = [];
+
+	var endDate = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0));
+	var time = new Date(new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0)));
+	for (var i = 0; time.getTime() < endDate.getTime(); ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: 10,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container, {
+		priceScale: {
+			mode: LightweightCharts.PriceScaleMode.Normal,
+		},
+	});
+
+	var firstSeries = chart.addLineSeries({
+		priceFormat: {
+			minMove: 10,
+		},
+	});
+
+	firstSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/percentage-scale.js
+++ b/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/percentage-scale.js
@@ -1,0 +1,33 @@
+function generateData() {
+	var res = [];
+
+	var endDate = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0));
+	var time = new Date(new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0)));
+	for (var i = 0; time.getTime() < endDate.getTime(); ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: 10,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container, {
+		priceScale: {
+			mode: LightweightCharts.PriceScaleMode.Percentage,
+		},
+	});
+
+	var firstSeries = chart.addLineSeries({
+		priceFormat: {
+			minMove: 10,
+		},
+	});
+
+	firstSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/incorrect-autoscale-when-prices-are-small.js
+++ b/tests/e2e/graphics/test-cases/incorrect-autoscale-when-prices-are-small.js
@@ -1,0 +1,32 @@
+var startDate = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+var endDate = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0));
+
+function generateData() {
+	var res = [];
+
+	var time = new Date(startDate);
+	for (var i = 0; time.getTime() < endDate.getTime(); ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i / 1000 + 0.6,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var firstSeries = chart.addLineSeries();
+	var secondSeries = chart.addLineSeries();
+
+	firstSeries.setData(generateData());
+	secondSeries.setData([
+		{ time: startDate.getTime() / 1000, value: 0.5 },
+		{ time: endDate.getTime() / 1000, value: 0.5 },
+	]);
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #122
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

We don't need to extend price range by 0.5 in series because 1) it affects result price range where are other series 2) 0.5 value can be huge for current series (for example if values are about 1.0) 3) the same thing are already done in PriceScale and this is the only good place for that.