### PR TITLE
fix: fix non-passive event listener warning. #139

### DIFF
--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -371,12 +371,12 @@ export class MouseEventHandler implements IDestroyable {
 			};
 
 			doc.addEventListener('mousedown', outsideHandler);
-			doc.addEventListener('touchstart', outsideHandler);
+			doc.addEventListener('touchstart', outsideHandler, { passive: true });
 		}
 
 		this._target.addEventListener('mouseleave', this._mouseLeaveHandler.bind(this));
 
-		this._target.addEventListener('touchstart', this._mouseDownHandler.bind(this));
+		this._target.addEventListener('touchstart', this._mouseDownHandler.bind(this), { passive: true });
 		if (!mobileTouch) {
 			this._target.addEventListener('mousedown', this._mouseDownHandler.bind(this));
 		}
@@ -399,9 +399,7 @@ export class MouseEventHandler implements IDestroyable {
 			return;
 		}
 
-		this._target.addEventListener('touchstart', (event: TouchEvent) => {
-			this._checkPinchState(event.touches);
-		});
+		this._target.addEventListener('touchstart', (event: TouchEvent) => { this._checkPinchState(event.touches); }, { passive: true });
 
 		this._target.addEventListener(
 			'touchmove',

--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -399,7 +399,11 @@ export class MouseEventHandler implements IDestroyable {
 			return;
 		}
 
-		this._target.addEventListener('touchstart', (event: TouchEvent) => { this._checkPinchState(event.touches); }, { passive: true });
+		this._target.addEventListener(
+			'touchstart',
+			(event: TouchEvent) => this._checkPinchState(event.touches),
+			{ passive: true }
+		);
 
 		this._target.addEventListener(
 			'touchmove',


### PR DESCRIPTION
**Type of PR:** bugfix

Bug: #139
**Overview of change:**

In chrome, warnings started appearing on console:

```
lightweight-charts.esm.production.js:7 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
lightweight-charts.esm.production.js:7 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
lightweight-charts.esm.production.js:7 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
lightweight-charts.esm.production.js:7 [Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```

It's related to the new event listener options. More on it [here](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md) and [here](https://medium.com/@devlucky/about-passive-event-listeners-224ff620e68c)

The warning is saying the passive event listeners on the page should be passed the {passive: true} option to improve scroll performance. document.addEventListener('touchstart', handler, {passive: true});.

These warnings are only performance recommendation so it's not really something to get too worried about, although performances improvements are always good, so please accept this PR.
