### PR TITLE
OHLC charts render incorrect when `value` is provided

### DIFF
--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -294,7 +294,7 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 		return this._palette;
 	}
 
-	public seriesType(): SeriesType {
+	public seriesType(): T {
 		return this._seriesType;
 	}
 

--- a/tests/e2e/graphics/test-cases/initial-options/invalid-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/initial-options/invalid-bar-spacing.js
@@ -1,13 +1,23 @@
+function generateBar(i, target) {
+	var step = (i % 20) / 1000;
+	var base = i / 5;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
 function generateData() {
 	var res = [];
 	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
 	for (var i = 0; i < 500; ++i) {
-		res.push({
+		var item = {
 			time: time.getTime() / 1000,
-			value: i,
-		});
-
+		};
 		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateBar(i, item);
+		res.push(item);
 	}
 	return res;
 }

--- a/tests/e2e/graphics/test-cases/initial-options/time-scale.js
+++ b/tests/e2e/graphics/test-cases/initial-options/time-scale.js
@@ -1,13 +1,23 @@
+function generateBar(i, target) {
+	var step = (i % 20) / 1000;
+	var base = i / 5;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
 function generateData() {
 	var res = [];
 	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
 	for (var i = 0; i < 500; ++i) {
-		res.push({
+		var item = {
 			time: time.getTime() / 1000,
-			value: i,
-		});
-
+		};
 		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateBar(i, item);
+		res.push(item);
 	}
 	return res;
 }

--- a/tests/unittests/data-layer.spec.ts
+++ b/tests/unittests/data-layer.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { BarData, HistogramData, LineData } from '../../src/api/data-consumer';
 import { convertTime, DataLayer, SeriesUpdatePacket, stringToBusinessDay, TimedData } from '../../src/api/data-layer';
 import { ensureDefined } from '../../src/helpers/assertions';
 import { Palette } from '../../src/model/palette';
@@ -11,14 +12,19 @@ import { BusinessDay, TimePointIndex, UTCTimestamp } from '../../src/model/time-
 
 // TODO: add tests for marks spans
 
-function createSeriesMock(seriesType: SeriesType = 'Line'): Series {
+function createSeriesMock<T extends SeriesType = 'Line'>(seriesType?: T): Series<T> {
 	const data = new SeriesData();
 	// tslint:disable-next-line:no-object-literal-type-assertion
 	return {
 		data: () => data,
 		palette: () => new Palette(),
-		seriesType: () => seriesType,
-	} as Series;
+		seriesType: () => seriesType || 'Line',
+	} as Series<T>;
+}
+
+// just for tests
+function dataItemAt(time: TimedData['time']): BarData & LineData & HistogramData {
+	return { time, value: 0, open: 0, high: 0, low: 0, close: 0 };
 }
 
 describe('DataLayer', () => {
@@ -29,7 +35,7 @@ describe('DataLayer', () => {
 		const series1 = createSeriesMock();
 		const series2 = createSeriesMock();
 
-		const updateResult1 = dataLayer.setSeriesData(series1, [{ time: 1000 as UTCTimestamp }, { time: 3000 as UTCTimestamp }]);
+		const updateResult1 = dataLayer.setSeriesData(series1, [dataItemAt(1000 as UTCTimestamp), dataItemAt(3000 as UTCTimestamp)]);
 		expect(updateResult1.timeScaleUpdate.index).to.be.equal(0 as TimePointIndex);
 		expect(updateResult1.timeScaleUpdate.changes).to.have.deep.members([{ timestamp: 1000 }, { timestamp: 3000 }]);
 		expect(updateResult1.timeScaleUpdate.seriesUpdates.size).to.be.equal(1);
@@ -49,7 +55,7 @@ describe('DataLayer', () => {
 		expect(updateResult1.timeScaleUpdate.marks[1].index).to.be.equal(1 as TimePointIndex);
 		expect(updateResult1.timeScaleUpdate.marks[1].time).to.be.deep.equal({ timestamp: 3000 });
 
-		const updateResult2 = dataLayer.setSeriesData(series2, [{ time: 2000 as UTCTimestamp }, { time: 4000 as UTCTimestamp }]);
+		const updateResult2 = dataLayer.setSeriesData(series2, [dataItemAt(2000 as UTCTimestamp), dataItemAt(4000 as UTCTimestamp)]);
 		expect(updateResult2.timeScaleUpdate.index).to.be.equal(0 as TimePointIndex);
 		expect(updateResult2.timeScaleUpdate.changes).to.have.deep.members(
 			[{ timestamp: 1000 }, { timestamp: 2000 }, { timestamp: 3000 }, { timestamp: 4000 }]);
@@ -91,9 +97,9 @@ describe('DataLayer', () => {
 		const series2 = createSeriesMock();
 		const series3 = createSeriesMock();
 
-		dataLayer.setSeriesData(series1, [{ time: 2000 as UTCTimestamp }, { time: 5000 as UTCTimestamp }]);
-		dataLayer.setSeriesData(series2, [{ time: 3000 as UTCTimestamp }, { time: 7000 as UTCTimestamp }]);
-		dataLayer.setSeriesData(series3, [{ time: 4000 as UTCTimestamp }, { time: 6000 as UTCTimestamp }]);
+		dataLayer.setSeriesData(series1, [dataItemAt(2000 as UTCTimestamp), dataItemAt(5000 as UTCTimestamp)]);
+		dataLayer.setSeriesData(series2, [dataItemAt(3000 as UTCTimestamp), dataItemAt(7000 as UTCTimestamp)]);
+		dataLayer.setSeriesData(series3, [dataItemAt(4000 as UTCTimestamp), dataItemAt(6000 as UTCTimestamp)]);
 
 		const updateResult = dataLayer.removeSeries(series3);
 
@@ -138,11 +144,11 @@ describe('DataLayer', () => {
 		const series1 = createSeriesMock();
 		const series2 = createSeriesMock();
 
-		dataLayer.setSeriesData(series1, [{ time: 1000 as UTCTimestamp }, { time: 3000 as UTCTimestamp }]);
-		dataLayer.setSeriesData(series2, [{ time: 2000 as UTCTimestamp }, { time: 4000 as UTCTimestamp }]);
+		dataLayer.setSeriesData(series1, [dataItemAt(1000 as UTCTimestamp), dataItemAt(3000 as UTCTimestamp)]);
+		dataLayer.setSeriesData(series2, [dataItemAt(2000 as UTCTimestamp), dataItemAt(4000 as UTCTimestamp)]);
 
 		// add a new point
-		const updateResult1 = dataLayer.updateSeriesData(series1, { time: 5000 as UTCTimestamp });
+		const updateResult1 = dataLayer.updateSeriesData(series1, dataItemAt(5000 as UTCTimestamp));
 		expect(updateResult1.timeScaleUpdate.index).to.be.equal(4 as TimePointIndex);
 		expect(updateResult1.timeScaleUpdate.changes).to.have.deep.members([{ timestamp: 5000 }]);
 		expect(updateResult1.timeScaleUpdate.seriesUpdates.size).to.be.equal(1);
@@ -157,7 +163,7 @@ describe('DataLayer', () => {
 		expect(updateResult1.timeScaleUpdate.marks[0].time).to.be.deep.equal({ timestamp: 5000 });
 
 		// add one more point
-		const updateResult2 = dataLayer.updateSeriesData(series2, { time: 6000 as UTCTimestamp });
+		const updateResult2 = dataLayer.updateSeriesData(series2, dataItemAt(6000 as UTCTimestamp));
 		expect(updateResult2.timeScaleUpdate.index).to.be.equal(5 as TimePointIndex);
 		expect(updateResult2.timeScaleUpdate.changes).to.have.deep.members([{ timestamp: 6000 }]);
 		expect(updateResult2.timeScaleUpdate.seriesUpdates.size).to.be.equal(1);
@@ -179,11 +185,11 @@ describe('DataLayer', () => {
 		const series1 = createSeriesMock();
 		const series2 = createSeriesMock();
 
-		dataLayer.setSeriesData(series1, [{ time: 1000 as UTCTimestamp }, { time: 4000 as UTCTimestamp }]);
-		dataLayer.setSeriesData(series2, [{ time: 2000 as UTCTimestamp }, { time: 4000 as UTCTimestamp }]);
+		dataLayer.setSeriesData(series1, [dataItemAt(1000 as UTCTimestamp), dataItemAt(4000 as UTCTimestamp)]);
+		dataLayer.setSeriesData(series2, [dataItemAt(2000 as UTCTimestamp), dataItemAt(4000 as UTCTimestamp)]);
 
 		// change the last point of the first series
-		const updateResult1 = dataLayer.updateSeriesData(series1, { time: 4000 as UTCTimestamp });
+		const updateResult1 = dataLayer.updateSeriesData(series1, dataItemAt(4000 as UTCTimestamp));
 		expect(updateResult1.timeScaleUpdate.index).to.be.equal(2 as TimePointIndex);
 		expect(updateResult1.timeScaleUpdate.changes.length).to.be.equal(0);
 		expect(updateResult1.timeScaleUpdate.seriesUpdates.size).to.be.equal(1);
@@ -196,7 +202,7 @@ describe('DataLayer', () => {
 		expect(updateResult1.timeScaleUpdate.marks.length).to.be.equal(0);
 
 		// change the last point of the second series
-		const updateResult2 = dataLayer.updateSeriesData(series2, { time: 4000 as UTCTimestamp });
+		const updateResult2 = dataLayer.updateSeriesData(series2, dataItemAt(4000 as UTCTimestamp));
 		expect(updateResult2.timeScaleUpdate.index).to.be.equal(2 as TimePointIndex);
 		expect(updateResult2.timeScaleUpdate.changes.length).to.be.equal(0);
 		expect(updateResult2.timeScaleUpdate.seriesUpdates.size).to.be.equal(1);
@@ -216,11 +222,11 @@ describe('DataLayer', () => {
 		const series1 = createSeriesMock();
 		const series2 = createSeriesMock();
 
-		dataLayer.setSeriesData(series1, [{ time: 5000 as UTCTimestamp }, { time: 6000 as UTCTimestamp }]);
-		dataLayer.setSeriesData(series2, [{ time: 2000 as UTCTimestamp }, { time: 3000 as UTCTimestamp }]);
+		dataLayer.setSeriesData(series1, [dataItemAt(5000 as UTCTimestamp), dataItemAt(6000 as UTCTimestamp)]);
+		dataLayer.setSeriesData(series2, [dataItemAt(2000 as UTCTimestamp), dataItemAt(3000 as UTCTimestamp)]);
 
 		// add a new point in the end of one series but not in the end of all points
-		const updateResult = dataLayer.updateSeriesData(series2, { time: 4000 as UTCTimestamp });
+		const updateResult = dataLayer.updateSeriesData(series2, dataItemAt(4000 as UTCTimestamp));
 		expect(updateResult.timeScaleUpdate.index).to.be.equal(2 as TimePointIndex);
 		expect(updateResult.timeScaleUpdate.changes).to.have.deep.members(
 			[{ timestamp: 4000 }, { timestamp: 5000 }, { timestamp: 6000 }]);
@@ -247,7 +253,7 @@ describe('DataLayer', () => {
 		expect(updateResult.timeScaleUpdate.marks[2].time).to.be.deep.equal({ timestamp: 6000 });
 
 		// add a new point before all points
-		const updateResult2 = dataLayer.updateSeriesData(series2, { time: 1000 as UTCTimestamp });
+		const updateResult2 = dataLayer.updateSeriesData(series2, dataItemAt(1000 as UTCTimestamp));
 		expect(updateResult2.timeScaleUpdate.index).to.be.equal(0 as TimePointIndex);
 		expect(updateResult2.timeScaleUpdate.changes).to.have.deep.members(
 			[{ timestamp: 1000 }, { timestamp: 2000 }, { timestamp: 3000 }, { timestamp: 4000 }, { timestamp: 5000 }, { timestamp: 6000 }]);
@@ -295,7 +301,7 @@ describe('DataLayer', () => {
 		const series1 = createSeriesMock();
 		const date1: BusinessDay = { day: 1, month: 10, year: 2019 };
 		const date2: BusinessDay = { day: 2, month: 10, year: 2019 };
-		const updateResult1 = dataLayer.setSeriesData(series1, [{ time: date1 }, { time: date2 }]);
+		const updateResult1 = dataLayer.setSeriesData(series1, [dataItemAt(date1), dataItemAt(date2)]);
 
 		expect(updateResult1.timeScaleUpdate.index).to.be.equal(0 as TimePointIndex);
 
@@ -338,17 +344,17 @@ describe('DataLayer', () => {
 	it('all points should have same time type', () => {
 		const dataLayer = new DataLayer();
 		const series = createSeriesMock();
-		expect(() => dataLayer.setSeriesData(series, [{ time: 5000 as UTCTimestamp }, { time: { day: 1, month: 10, year: 2019 } }]))
+		expect(() => dataLayer.setSeriesData(series, [dataItemAt(5000 as UTCTimestamp), dataItemAt({ day: 1, month: 10, year: 2019 })]))
 			.to.throw();
 	});
 
 	it('all points should have same time type on updating', () => {
 		const dataLayer = new DataLayer();
 		const series = createSeriesMock();
-		const packet = dataLayer.setSeriesData(series, [{ time: { day: 1, month: 10, year: 2019 } }]);
+		const packet = dataLayer.setSeriesData(series, [dataItemAt({ day: 1, month: 10, year: 2019 })]);
 		const update = ensureDefined(packet.timeScaleUpdate.seriesUpdates.get(series));
 		series.data().bars().merge(update.update);
-		expect(() => dataLayer.updateSeriesData(series, { time: 5000 as UTCTimestamp }))
+		expect(() => dataLayer.updateSeriesData(series, dataItemAt(5000 as UTCTimestamp)))
 			.to.throw();
 	});
 
@@ -375,7 +381,7 @@ describe('DataLayer', () => {
 			const dataLayer = new DataLayer();
 			const series = createSeriesMock(seriesType);
 
-			const item = {
+			const item: BarData & LineData = {
 				time: '2017-01-01',
 				open: 10,
 				high: 15,
@@ -384,7 +390,7 @@ describe('DataLayer', () => {
 				value: 100,
 			};
 
-			const packet = dataLayer.setSeriesData(series, [item] as TimedData[]);
+			const packet = dataLayer.setSeriesData(series, [item]);
 			const update = ensureDefined(packet.timeScaleUpdate.seriesUpdates.get(series));
 
 			expect(update.update[0].value[SeriesPlotIndex.Open]).to.be.equal(item.open);


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [x] Addresses an existing issue: fixes #165 
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Getting OHLC/single value depending on series type

<!-- optional -->
