### PR TITLE
move to typecov

### DIFF
--- a/codechecks.yml
+++ b/codechecks.yml
@@ -7,7 +7,7 @@ checks:
         - path: "./dist/lightweight-charts.standalone.production.js"
           maxSize: 41.5KB
 
-  - name: type-coverage-watcher
+  - name: typecov
     options:
       atLeast: 99.9
       ignoreCatch: true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@codechecks/build-size-watcher": "~0.1.0",
     "@codechecks/client": "~0.1.5",
-    "@codechecks/type-coverage-watcher": "~0.1.3",
     "@types/chai": "~4.2.0",
     "@types/mocha": "~5.2.7",
     "chai": "~4.2.0",
@@ -60,6 +59,7 @@
     "tslint-eslint-rules": "~5.4.0",
     "tslint-microsoft-contrib": "~6.2.0",
     "ttypescript": "~1.5.7",
+    "typecov": "^0.2.1",
     "typescript": "3.5.3",
     "vrsource-tslint-rules": "6.0.0"
   },


### PR DESCRIPTION
**Type of PR:** codechecks upgrade<!-- bugfix, enhancement, fix typo, etc -->

**Overview of change:**
`type-coverage-watcher` was renamed simply to `typecov`. It has various small improvements which you might like — especially now output is more consistent.


Idea: I saw some visual regression tests in your repo. You might be interested in: https://github.com/codechecks/vis-reg I will work on adding support for storybook soon.
