### PR TITLE
224: Add an option to control double click on scales

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -304,6 +304,7 @@ You can disable any of them using `handleScroll` and `handleScale` options.
 |Name                        |Type   |Default  |Description|
 |----------------------------|-------|---------|-|
 |`axisPressedMouseMove`|`boolean`|`true`|If true, axis scaling with left mouse button pressed is allowed|
+|`axisDoubleClickReset`|`boolean`|`true`|If true, left mouse button double click axis resetting is allowed|
 |`mouseWheel`|`boolean`|`true`|If true, series scaling with a mouse wheel is enabled|
 |`pinch`|`boolean`|`true`|If true, series scaling with pinch/zoom gestures (this option is supported on touch devices) is enabled|
 

--- a/src/api/options/chart-options-defaults.ts
+++ b/src/api/options/chart-options-defaults.ts
@@ -28,6 +28,7 @@ export const chartOptionsDefaults: ChartOptions = {
 	},
 	handleScale: {
 		axisPressedMouseMove: true,
+		axisDoubleClickReset: true,
 		mouseWheel: true,
 		pinch: true,
 	},

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -345,7 +345,9 @@ export class PriceAxisWidget implements IDestroyable {
 	}
 
 	private _mouseDoubleClickEvent(e: TouchMouseEvent): void {
-		this.reset();
+		if (this._pane.chart().options().handleScale.axisDoubleClickReset) {
+			this.reset();
+		}
 	}
 
 	private _mouseEnterEvent(e: TouchMouseEvent): void {

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -167,7 +167,9 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 	}
 
 	public mouseDoubleClickEvent(): void {
-		this._chart.model().resetTimeScale();
+		if (this._chart.options().handleScale.axisDoubleClickReset) {
+			this._chart.model().resetTimeScale();
+		}
 	}
 
 	public mouseEnterEvent(e: TouchMouseEvent): void {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -36,6 +36,7 @@ export interface HandleScaleOptions {
 	mouseWheel: boolean;
 	pinch: boolean;
 	axisPressedMouseMove: boolean;
+	axisDoubleClickReset: boolean;
 }
 
 export interface HoveredObject {


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #224
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

Added an option to HandleScaleOptions to enable or disable reset scales by double click