### PR TITLE
247: Refactor candles drawing with  fillRect

### DIFF
--- a/src/helpers/canvas-helpers.ts
+++ b/src/helpers/canvas-helpers.ts
@@ -8,8 +8,13 @@
  * @param lineWidth line width. Must be less than width and height
  */
 export function strokeRectInnerWithFill(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, lineWidth: number): void {
+	// should not overlap on corners for semi-transparent colors
+	// left
 	ctx.fillRect(x, y, lineWidth, h);
-	ctx.fillRect(x, y, w, lineWidth);
-	ctx.fillRect(x, y + h - lineWidth, w, lineWidth);
+	// top
+	ctx.fillRect(x + lineWidth, y, w - lineWidth * 2, lineWidth);
+	// bottom
+	ctx.fillRect(x + lineWidth, y + h - lineWidth, w - lineWidth * 2, lineWidth);
+	// right
 	ctx.fillRect(x + w - lineWidth, y, lineWidth, h);
 }

--- a/src/helpers/canvas-helpers.ts
+++ b/src/helpers/canvas-helpers.ts
@@ -1,0 +1,15 @@
+
+/** Draw rectangle with outer border defined with parameters. FillStyle is used as color
+ * @param ctx context to draw on
+ * @param x left outer border of the target rectangle
+ * @param y top outer border of the target rectangle
+ * @param w width of the target rectangle
+ * @param h height of the target rectangle
+ * @param lineWidth line width. Must be less than width and height
+ */
+export function strokeRectInnerWithFill(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, lineWidth: number): void {
+	ctx.fillRect(x, y, lineWidth, h);
+	ctx.fillRect(x, y, w, lineWidth);
+	ctx.fillRect(x, y + h - lineWidth, w, lineWidth);
+	ctx.fillRect(x + w - lineWidth, y, lineWidth, h);
+}

--- a/src/renderers/candlesticks-renderer.ts
+++ b/src/renderers/candlesticks-renderer.ts
@@ -76,8 +76,8 @@ export class PaneRendererCandlesticks implements IPaneRenderer {
 			const top = Math.min(bar.openY, bar.closeY);
 			const bottom = Math.max(bar.openY, bar.closeY);
 
-			ctx.fillRect(bar.x, bar.highY, 1, top - bar.highY + 1);
-			ctx.fillRect(bar.x, bottom, 1, bar.lowY - bottom + 1);
+			ctx.fillRect(bar.x, bar.highY, 1, top - bar.highY);
+			ctx.fillRect(bar.x, bottom + 1, 1, bar.lowY - bottom);
 		}
 	}
 

--- a/src/renderers/candlesticks-renderer.ts
+++ b/src/renderers/candlesticks-renderer.ts
@@ -1,3 +1,5 @@
+import { strokeRectInnerWithFill } from '../helpers/canvas-helpers';
+
 import { SeriesItemsIndexesRange } from '../model/time-data';
 
 import { BarCandlestickItemBase } from './bars-renderer';
@@ -40,26 +42,27 @@ export class PaneRendererCandlesticks implements IPaneRenderer {
 		if (this._data === null || this._data.bars.length === 0 || this._data.visibleRange === null) {
 			return;
 		}
+
+		// TODO: remove this after removing of global translate
+		ctx.translate(-0.5, -0.5);
+
 		ctx.lineCap = 'square';
 
-		if (this._data.barSpacing < 1) {
-			this._drawThinCandles(ctx);
-		} else {
-			const bars = this._data.bars;
+		const bars = this._data.bars;
+		if (this._data.wickVisible) {
+			this._drawWicks(ctx, bars, this._data.visibleRange);
+		}
 
-			ctx.translate(-0.5, -0.5);
-			ctx.lineWidth = Constants.BarBorderWidth;
+		if (this._data.borderVisible) {
+			this._drawBorder(ctx, bars, this._data.visibleRange, this._data.barSpacing);
+		}
 
-			if (this._data.wickVisible) {
-				this._drawWicks(ctx, bars, this._data.visibleRange);
-			}
-
-			if (this._data.borderVisible) {
-				this._drawBorder(ctx, bars, this._data.visibleRange);
-			}
-
+		if (!this._data.borderVisible || this._data.barSpacing > 2 * Constants.BarBorderWidth) {
 			this._drawCandles(ctx, bars, this._data.visibleRange);
 		}
+
+		// TODO: remove this after removing of global translate
+		ctx.translate(0.5, 0.5);
 	}
 
 	private _drawWicks(ctx: CanvasRenderingContext2D, bars: ReadonlyArray<CandlestickItem>, visibleRange: SeriesItemsIndexesRange): void {
@@ -72,11 +75,15 @@ export class PaneRendererCandlesticks implements IPaneRenderer {
 				prevWickColor = bar.wickColor;
 			}
 
-			ctx.fillRect(bar.x, bar.highY, 1, bar.lowY - bar.highY);
+			const top = Math.min(bar.openY, bar.closeY);
+			const bottom = Math.max(bar.openY, bar.closeY);
+
+			ctx.fillRect(bar.x, bar.highY, 1, top - bar.highY + 1);
+			ctx.fillRect(bar.x, bottom, 1, bar.lowY - bottom + 1);
 		}
 	}
 
-	private _drawBorder(ctx: CanvasRenderingContext2D, bars: ReadonlyArray<CandlestickItem>, visibleRange: SeriesItemsIndexesRange): void {
+	private _drawBorder(ctx: CanvasRenderingContext2D, bars: ReadonlyArray<CandlestickItem>, visibleRange: SeriesItemsIndexesRange, barSpacing: number): void {
 		let prevBorderColor = '';
 
 		for (let i = visibleRange.from; i < visibleRange.to; i++) {
@@ -92,7 +99,11 @@ export class PaneRendererCandlesticks implements IPaneRenderer {
 			const top = Math.min(bar.openY, bar.closeY);
 			const bottom = Math.max(bar.openY, bar.closeY);
 
-			ctx.fillRect(left, top, right - left + 1, bottom - top + 1);
+			if (barSpacing > 2 * Constants.BarBorderWidth) {
+				strokeRectInnerWithFill(ctx, left, top, right - left + 1, bottom - top + 1, Constants.BarBorderWidth);
+			} else {
+				ctx.fillRect(left, top, right - left + 1, bottom - top + 1);
+			}
 		}
 	}
 
@@ -129,56 +140,6 @@ export class PaneRendererCandlesticks implements IPaneRenderer {
 			}
 
 			ctx.fillRect(left, top, right - left + 1, bottom - top + 1);
-		}
-	}
-
-	private _drawThinCandles(ctx: CanvasRenderingContext2D): void {
-		if (this._data === null || this._data.visibleRange === null) {
-			return;
-		}
-
-		ctx.lineWidth = 1;
-
-		// draw wicks, then bodies
-		if (this._data.wickVisible) {
-			ctx.strokeStyle = this._data.wickColor;
-
-			ctx.beginPath();
-
-			for (let i = this._data.visibleRange.from; i < this._data.visibleRange.to; i++) {
-				const bar = this._data.bars[i];
-				ctx.moveTo(bar.x, bar.lowY);
-				ctx.lineTo(bar.x, bar.highY);
-			}
-
-			ctx.stroke();
-		}
-
-		// bodies
-		let prevBarColor = '';
-		let needStroke = false;
-
-		ctx.beginPath();
-		for (let i = this._data.visibleRange.from; i < this._data.visibleRange.to; i++) {
-			const bar = this._data.bars[i];
-			if (prevBarColor !== bar.color) {
-				if (needStroke) {
-					ctx.stroke();
-					ctx.beginPath();
-					needStroke = false;
-				}
-
-				ctx.strokeStyle = bar.color;
-				prevBarColor = bar.color;
-			}
-
-			ctx.moveTo(bar.x, bar.openY);
-			ctx.lineTo(bar.x, bar.closeY);
-			needStroke = true;
-		}
-
-		if (needStroke) {
-			ctx.stroke();
 		}
 	}
 }

--- a/src/renderers/candlesticks-renderer.ts
+++ b/src/renderers/candlesticks-renderer.ts
@@ -15,8 +15,6 @@ export interface CandlestickItem extends BarCandlestickItemBase {
 export interface PaneRendererCandlesticksData {
 	bars: ReadonlyArray<CandlestickItem>;
 
-	wickColor: string;
-
 	barSpacing: number;
 
 	wickVisible: boolean;

--- a/src/views/pane/candlesticks-pane-view.ts
+++ b/src/views/pane/candlesticks-pane-view.ts
@@ -26,7 +26,6 @@ export class SeriesCandlesticksPaneView extends BarsPaneViewBase<'Candlestick', 
 		const data: PaneRendererCandlesticksData = {
 			bars: this._items,
 			barSpacing: this._model.timeScale().barSpacing(),
-			wickColor: candlestickStyleProps.wickColor,
 			wickVisible: candlestickStyleProps.wickVisible,
 			borderVisible: candlestickStyleProps.borderVisible,
 			visibleRange: this._itemsVisibleRange,

--- a/tests/e2e/graphics/test-cases/series/candlesticks-semitransparent.js
+++ b/tests/e2e/graphics/test-cases/series/candlesticks-semitransparent.js
@@ -1,0 +1,36 @@
+function generateCandle(i, target) {
+	var step = (i % 20) / 5000;
+	var base = i / 5;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 500; ++i) {
+		var item = {
+			time: time.getTime() / 1000,
+		};
+		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateCandle(i, item);
+		res.push(item);
+	}
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var mainSeries = chart.addCandlestickSeries({
+		borderColor: 'rgba(0, 0, 255, 0.2)',
+		upColor: 'rgba(0, 80, 0, 0.2)',
+		downColor: 'rgba(80, 0, 0, 0.2)',
+	});
+
+	mainSeries.setData(generateData());
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #247
- [x] Fixed with graphics tests
- [ ] Documentation update

**Overview of change:**
Replaced all calls of `stroke` methods with `fill`

Also this allowed to remove special branch for thin candles and allowed semi-transparent candles