### PR TITLE
Add priceLineSource option

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -59,3 +59,17 @@ It has the following values:
 - `CrosshairMode.Normal` - normal mode of the crosshair.
 
     Crosshair moves freely on the chart.
+
+## PriceLineSource
+
+`PriceLineSource` enum is used to specify the source used for value of series price line.
+
+It has the following values:
+
+- `LastBar`
+
+    Use last bar data.
+
+- `LastVisible`
+
+    Use last visible data in chart viewport.

--- a/docs/series-basics.md
+++ b/docs/series-basics.md
@@ -159,7 +159,7 @@ You can set the width, style and color of this line or disable it using the foll
 |Name|Type|Default|Description|
 |----|----|-------|-|
 |`priceLineVisible`|`boolean`|`true`|If true, a series' price line is displayed on a chart|
-|`priceLineSource`|`lastBar` &#124; `lastVisible`|`lastBar`|Source used for price line value|
+|`priceLineSource`|[PriceLineSource](./constants.md#pricelinesource)|`PriceLineSource.LastBar`|Source used for price line value|
 |`priceLineWidth`|`number`|`1`|Price line's width in pixels|
 |`priceLineColor`|`string`|`''`|Price line's color|
 |`priceLineStyle`|[LineStyle](./constants.md#linestyle)|`LineStyle.Dotted`|Price line's style|

--- a/docs/series-basics.md
+++ b/docs/series-basics.md
@@ -159,6 +159,7 @@ You can set the width, style and color of this line or disable it using the foll
 |Name|Type|Default|Description|
 |----|----|-------|-|
 |`priceLineVisible`|`boolean`|`true`|If true, a series' price line is displayed on a chart|
+|`priceLineSource`|`lastBar` &#124; `lastVisible`|`lastBar`|Source used for price line value|
 |`priceLineWidth`|`number`|`1`|Price line's width in pixels|
 |`priceLineColor`|`string`|`''`|Price line's color|
 |`priceLineStyle`|[LineStyle](./constants.md#linestyle)|`LineStyle.Dotted`|Price line's style|

--- a/src/api/create-chart.ts
+++ b/src/api/create-chart.ts
@@ -11,6 +11,7 @@ export { LineStyle, LineType, LineWidth } from '../renderers/draw-line';
 export { BarPrice } from '../model/bar';
 export { CrosshairMode } from '../model/crosshair';
 export { PriceScaleMode } from '../model/price-scale';
+export { PriceLineSource } from '../model/series-options';
 export { UTCTimestamp } from '../model/time-data';
 
 export { IChartApi, MouseEventParams } from './ichart-api';

--- a/src/api/options/series-options-defaults.ts
+++ b/src/api/options/series-options-defaults.ts
@@ -59,7 +59,7 @@ export const seriesOptionsDefaults: SeriesOptionsCommon = {
 	title: '',
 	lastValueVisible: true,
 	priceLineVisible: true,
-	priceLineSource: PriceLineSource.GlobalLast,
+	priceLineSource: PriceLineSource.LastBar,
 	priceLineWidth: 1,
 	priceLineColor: '',
 	priceLineStyle: LineStyle.Dotted,

--- a/src/api/options/series-options-defaults.ts
+++ b/src/api/options/series-options-defaults.ts
@@ -58,6 +58,7 @@ export const seriesOptionsDefaults: SeriesOptionsCommon = {
 	title: '',
 	lastValueVisible: true,
 	priceLineVisible: true,
+	priceLineSource: 'lastBar',
 	priceLineWidth: 1,
 	priceLineColor: '',
 	priceLineStyle: LineStyle.Dotted,

--- a/src/api/options/series-options-defaults.ts
+++ b/src/api/options/series-options-defaults.ts
@@ -4,6 +4,7 @@ import {
 	CandlestickStyleOptions,
 	HistogramStyleOptions,
 	LineStyleOptions,
+	PriceLineSource,
 	SeriesOptionsCommon,
 } from '../../model/series-options';
 import { LineStyle, LineType } from '../../renderers/draw-line';
@@ -58,7 +59,7 @@ export const seriesOptionsDefaults: SeriesOptionsCommon = {
 	title: '',
 	lastValueVisible: true,
 	priceLineVisible: true,
-	priceLineSource: 'lastBar',
+	priceLineSource: PriceLineSource.GlobalLast,
 	priceLineWidth: 1,
 	priceLineColor: '',
 	priceLineStyle: LineStyle.Dotted,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { LineStyle, LineType, LineWidth } from './renderers/draw-line';
 export { BarPrice } from './model/bar';
 export { CrosshairMode } from './model/crosshair';
 export { PriceScaleMode } from './model/price-scale';
+export { PriceLineSource } from './model/series-options';
 export { UTCTimestamp } from './model/time-data';
 
 export {

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -144,7 +144,13 @@ export const enum PriceAxisLastValueMode {
 }
 
 export const enum PriceLineSource {
+	/**
+	 * The last bar data
+	 */
 	LastBar,
+	/**
+	 * The last visible bar in viewport
+	 */
 	LastVisible,
 }
 

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -169,6 +169,12 @@ export interface SeriesOptionsCommon {
 
 	/** Visibility of the price line. Price line is a horizontal line indicating the last price of the series */
 	priceLineVisible: boolean;
+	/**
+	 *  Enum of possible modes of priceLine source
+	 * 'lastBar' use the last bar data
+	 * 'lastVisible' use the last visible bar in viewport
+	 */
+	priceLineSource: 'lastBar' | 'lastVisible';
 	/** Width of the price line. Ignored if priceLineVisible is false */
 	priceLineWidth: LineWidth;
 	/** Color of the price line. Ignored if priceLineVisible is false */

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -144,8 +144,8 @@ export const enum PriceAxisLastValueMode {
 }
 
 export const enum PriceLineSource {
-	GlobalLast,
-	LocalLast,
+	LastBar,
+	LastVisible,
 }
 
 export interface OverlaySeriesSpecificOptions {
@@ -176,8 +176,8 @@ export interface SeriesOptionsCommon {
 	priceLineVisible: boolean;
 	/**
 	 *  Enum of possible modes of priceLine source
-	 * 'lastBar' use the last bar data
-	 * 'lastVisible' use the last visible bar in viewport
+	 * 'LastBar' use the last bar data
+	 * 'LastVisible' use the last visible bar in viewport
 	 */
 	priceLineSource: PriceLineSource;
 	/** Width of the price line. Ignored if priceLineVisible is false */

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -143,6 +143,11 @@ export const enum PriceAxisLastValueMode {
 	LastValueAccordingToScale,
 }
 
+export const enum PriceLineSource {
+	GlobalLast,
+	LocalLast,
+}
+
 export interface OverlaySeriesSpecificOptions {
 	overlay: true;
 	scaleMargins?: PriceScaleMargins;
@@ -174,7 +179,7 @@ export interface SeriesOptionsCommon {
 	 * 'lastBar' use the last bar data
 	 * 'lastVisible' use the last visible bar in viewport
 	 */
-	priceLineSource: 'lastBar' | 'lastVisible';
+	priceLineSource: PriceLineSource;
 	/** Width of the price line. Ignored if priceLineVisible is false */
 	priceLineWidth: LineWidth;
 	/** Color of the price line. Ignored if priceLineVisible is false */

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -182,8 +182,6 @@ export interface SeriesOptionsCommon {
 	priceLineVisible: boolean;
 	/**
 	 *  Enum of possible modes of priceLine source
-	 * 'LastBar' use the last bar data
-	 * 'LastVisible' use the last visible bar in viewport
 	 */
 	priceLineSource: PriceLineSource;
 	/** Width of the price line. Ignored if priceLineVisible is false */

--- a/src/views/pane/series-price-line-pane-view.ts
+++ b/src/views/pane/series-price-line-pane-view.ts
@@ -1,4 +1,5 @@
 import { Series } from '../../model/series';
+import { PriceLineSource } from '../../model/series-options';
 
 import { SeriesHorizontalLinePaneView } from './series-horizontal-line-pane-view';
 
@@ -16,7 +17,7 @@ export class SeriesPriceLinePaneView extends SeriesHorizontalLinePaneView {
 			return;
 		}
 
-		const lastValueData = this._series.lastValueData(undefined, seriesOptions.priceLineSource === 'lastVisible');
+		const lastValueData = this._series.lastValueData(undefined, seriesOptions.priceLineSource === PriceLineSource.GlobalLast);
 		if (lastValueData.noData) {
 			return;
 		}

--- a/src/views/pane/series-price-line-pane-view.ts
+++ b/src/views/pane/series-price-line-pane-view.ts
@@ -16,7 +16,7 @@ export class SeriesPriceLinePaneView extends SeriesHorizontalLinePaneView {
 			return;
 		}
 
-		const lastValueData = this._series.lastValueData(undefined, true);
+		const lastValueData = this._series.lastValueData(undefined, seriesOptions.priceLineSource === 'lastVisible');
 		if (lastValueData.noData) {
 			return;
 		}

--- a/src/views/pane/series-price-line-pane-view.ts
+++ b/src/views/pane/series-price-line-pane-view.ts
@@ -17,7 +17,7 @@ export class SeriesPriceLinePaneView extends SeriesHorizontalLinePaneView {
 			return;
 		}
 
-		const lastValueData = this._series.lastValueData(undefined, seriesOptions.priceLineSource === PriceLineSource.GlobalLast);
+		const lastValueData = this._series.lastValueData(undefined, seriesOptions.priceLineSource === PriceLineSource.LastBar);
 		if (lastValueData.noData) {
 			return;
 		}

--- a/tests/e2e/graphics/test-cases/initial-options/price-line-source-default.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-line-source-default.js
@@ -20,5 +20,5 @@ function runTestCase(container) {
 
 	series.setData(generateData());
 
-	chart.timeScale().scrollToPosition(-100);
+	chart.timeScale().scrollToPosition(-10);
 }

--- a/tests/e2e/graphics/test-cases/initial-options/price-line-source-default.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-line-source-default.js
@@ -1,0 +1,24 @@
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var series = chart.addLineSeries();
+
+	series.setData(generateData());
+
+	chart.timeScale().scrollToPosition(-100);
+}

--- a/tests/e2e/graphics/test-cases/initial-options/price-line-source-last-visible.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-line-source-last-visible.js
@@ -1,0 +1,26 @@
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var series = chart.addLineSeries({
+		priceLineSource: LightweightCharts.PriceLineSource.LastVisible,
+	});
+
+	series.setData(generateData());
+
+	chart.timeScale().scrollToPosition(-10);
+}


### PR DESCRIPTION
**Type of PR:** Enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #203
- [x] Includes tests
- [x] Documentation update

**Overview of change:**
Add `priceLineSource` option. I might add more option later in future like `firstBar`, `firstVisible`.

Example usage:

```js
series.applyOptions({
    priceLineSource: LightweightCharts.PriceLineSource.LastVisible,
});
```
