### PR TITLE
Timescale fixes

### DIFF
--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -18,7 +18,7 @@ import { TimePoints } from './time-points';
 
 const enum Constants {
 	DefaultAnimationDuration = 400,
-	MaxBarSpacing = 50,
+	MaxBarSpacing = 100,
 	MinBarSpacing = 0.5,
 	MinVisibleBarsCount = 5,
 }

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -506,7 +506,8 @@ export class TimeScale {
 		if (first === null || last === null) {
 			return;
 		}
-		this.setVisibleRange(new BarsRange(first - 1 as TimePointIndex, last + 1 + this._options.rightOffset as TimePointIndex));
+
+		this.setVisibleRange(new BarsRange(first, last + this._options.rightOffset as TimePointIndex));
 	}
 
 	public setTimePointsRange(range: TimePointsRange): void {

--- a/tests/e2e/graphics/test-cases/fit-content-with-few-data.js
+++ b/tests/e2e/graphics/test-cases/fit-content-with-few-data.js
@@ -1,0 +1,25 @@
+function generateData(valueOffset, count) {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < count; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i + valueOffset,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var series = chart.addLineSeries();
+
+	series.setData(generateData(0, 10));
+
+	chart.timeScale().fitContent();
+}

--- a/tests/e2e/graphics/test-cases/initial-options/invalid-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/initial-options/invalid-bar-spacing.js
@@ -26,7 +26,7 @@ function generateData() {
 function runTestCase(container) {
 	var chart = LightweightCharts.createChart(container, {
 		timeScale: {
-			barSpacing: 100,
+			barSpacing: 1000,
 		},
 	});
 


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: partially addressed to #229, but not at all
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

1. Increased max available bar spacing from 50 to 100
2. Removed +-1 from visible range in `fitContent`
