### PR TITLE
TimeScale enhancement

### DIFF
--- a/codechecks.yml
+++ b/codechecks.yml
@@ -5,7 +5,7 @@ checks:
         - path: "./dist/lightweight-charts.esm.production.js"
           maxSize: 43.1KB
         - path: "./dist/lightweight-charts.standalone.production.js"
-          maxSize: 43.5KB
+          maxSize: 43.7KB
 
   - name: typecov
     options:

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -625,11 +625,11 @@ export class TimeScale {
 			return this._leftEdgeIndex - baseIndex + barsEstimation - 1;
 		}
 
-		return firstIndex - baseIndex - 1 + Constants.MinVisibleBarsCount;
+		return firstIndex - baseIndex - 1 + Math.min(Constants.MinVisibleBarsCount, this._points.size());
 	}
 
 	private _maxRightOffset(): number {
-		return (this._width / this._barSpacing) - Constants.MinVisibleBarsCount;
+		return (this._width / this._barSpacing) - Math.min(Constants.MinVisibleBarsCount, this._points.size());
 	}
 
 	private _saveCommonTransitionsStartState(): void {

--- a/tests/e2e/graphics/test-cases/applying-options/update-chart-width.js
+++ b/tests/e2e/graphics/test-cases/applying-options/update-chart-width.js
@@ -1,0 +1,47 @@
+function generateCandle(i, target) {
+	var step = (i % 20) / 5000;
+	var base = i / 5;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 500; ++i) {
+		var item = {
+			time: time.getTime() / 1000,
+		};
+		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateCandle(i, item);
+		res.push(item);
+	}
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var box = container.getBoundingClientRect();
+	var chart = LightweightCharts.createChart(container, {
+		width: 2000,
+		height: box.height,
+		timeScale: {
+			barSpacing: 1000000,
+			rightOffset: 100000,
+		},
+	});
+
+	var mainSeries = chart.addCandlestickSeries();
+
+	mainSeries.setData(generateData());
+
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			chart.applyOptions({ width: box.width });
+			resolve();
+		}, 300);
+	});
+}

--- a/tests/e2e/graphics/test-cases/initial-options/min-visible-bars.js
+++ b/tests/e2e/graphics/test-cases/initial-options/min-visible-bars.js
@@ -1,0 +1,37 @@
+function generateCandle(i, target) {
+	var step = (i % 20) / 5000;
+	var base = i / 5;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 500; ++i) {
+		var item = {
+			time: time.getTime() / 1000,
+		};
+		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateCandle(i, item);
+		res.push(item);
+	}
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container, {
+		timeScale: {
+			barSpacing: 1000000,
+			rightOffset: 100000,
+		},
+	});
+
+	var mainSeries = chart.addCandlestickSeries();
+
+	mainSeries.setData(generateData());
+}


### PR DESCRIPTION
**Type of PR:** enhancement & bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #352
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

1. Max bar spacing now is 0.5 of chart's width
2. Min visible bars count now is 2 instead of 5
3. Fixed order of applying bar spacing and right offset
4. Invaliding model while setting bar spacing