### PR TITLE
Improved tick marks generation algorithm for the first point

### DIFF
--- a/tests/e2e/graphics/test-cases/months-chart.js
+++ b/tests/e2e/graphics/test-cases/months-chart.js
@@ -1,0 +1,23 @@
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 12; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCMonth(time.getUTCMonth() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	var chart = LightweightCharts.createChart(container);
+
+	var firstSeries = chart.addLineSeries();
+	firstSeries.setData(generateData());
+	chart.timeScale().fitContent();
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue:
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Span (weight) for the first tick mark previously was always 20, but now it's "smarty" and calculated as spanByTime of the first time point and average time point's diff back.