### PR TITLE
Separate handling of missing/zero width/height in chart-widget constr…

### DIFF
--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -75,19 +75,20 @@ export class ChartWidget implements IDestroyable {
 		let width = this._options.width;
 		let height = this._options.height;
 
-		if (width === 0 && height === 0) {
+		if (width === 0 || height === 0) {
 			const containerRect = container.getBoundingClientRect();
 			// TODO: Fix it better
 			// on Hi-DPI CSS size * Device Pixel Ratio should be integer to avoid smoothing
 			// For chart widget we decreases because we must be inside container.
 			// For time axis this is not important, since it just affects space for pane widgets
-			width = Math.floor(containerRect.width);
-			if (width % 2) {
-				width -= 1;
+			if (width === 0) {
+				width = Math.floor(containerRect.width);
+				width -= width % 2;
 			}
-			height = Math.floor(containerRect.height);
-			if (height % 2) {
-				height -= 1;
+
+			if (height === 0) {
+				height = Math.floor(containerRect.height);
+				height -= height % 2;
 			}
 		}
 

--- a/tests/e2e/graphics/test-cases/initial-options/chart-width-and-height.js
+++ b/tests/e2e/graphics/test-cases/initial-options/chart-width-and-height.js
@@ -1,0 +1,36 @@
+function generateData() {
+	var res = [];
+	var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (var i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+// eslint-disable-next-line no-unused-vars
+function runTestCase(container) {
+	const configs = [{}, { width: 500 }, { height: 100 }, { width: 500, height: 100 }];
+
+	configs.forEach((config, i) => {
+		const box = document.createElement('div');
+
+		box.style.position = 'absolute';
+		box.style.top = `${i * 25}%`;
+		box.style.left = 0;
+		box.style.right = 0;
+		box.style.height = '25%';
+
+		container.appendChild(box);
+
+		const chart = LightweightCharts.createChart(box, config);
+		const mainSeries = chart.addAreaSeries();
+
+		mainSeries.setData(generateData());
+	});
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #353 
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

I noticed this issue when browsing the `3.0` milestone and saw it had the `help-wanted` tag.

Width/height were only adjusted to the container size if both are 0 or missing, but not if only one of them is missing. This fixes it.

**Is there anything you'd like reviewers to focus on?**

I think it would make sense to move the highDPI-fix to the unconditional path or mention it in the docs that width/height should be chosen so that `(width-or-height * devicePixelRatio) % 2 === 0`, or that could be a gotcha for people specifying their own width/height.

If the intention of not doing so is to ensure the resulting DOM element has exactly the requested width/height, we could add the potentially lost pixel as padding on the right or bottom (where the price scale and time scale are), so that the enclosing element still has exactly the same width/height as specified (that might be important to people doing absolute positioning to build an interface, as an example, so they don't get missing single pixel lines that they can't explain).