### PR TITLE
Removed non-exported const enum's JS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rollup-plugin-terser": "~5.3.0",
     "ts-node": "~8.8.2",
     "ts-transformer-minify-privates": "~0.3.0",
+    "ts-transformer-strip-const-enums": "~1.0.1",
     "tslib": "1.11.1",
     "tslint": "6.1.1",
     "tslint-eslint-rules": "~5.4.0",

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -227,6 +227,7 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 	}
 
 	public update(): void {
+		// this call has side-effect - it regenerates marks on the time scale
 		this._chart.model().timeScale().marks();
 	}
 

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -10,7 +10,7 @@ import { InvalidationLevel } from '../model/invalidate-mask';
 import { LayoutOptions } from '../model/layout-options';
 import { PriceAxisPosition } from '../model/price-scale';
 import { TextWidthCache } from '../model/text-width-cache';
-import { MarkSpanBorder, TimeMark } from '../model/time-scale';
+import { TimeMark } from '../model/time-scale';
 import { TimeAxisViewRendererOptions } from '../renderers/itime-axis-view-renderer';
 import { TimeAxisView } from '../views/time-axis/time-axis-view';
 
@@ -44,7 +44,6 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 	private readonly _canvasBinding: CanvasCoordinateSpaceBinding;
 	private readonly _topCanvasBinding: CanvasCoordinateSpaceBinding;
 	private _stub: PriceAxisStub | null = null;
-	private _minVisibleSpan: number = MarkSpanBorder.Year;
 	private readonly _mouseEventHandler: MouseEventHandler;
 	private _rendererOptions: TimeAxisViewRendererOptions | null = null;
 	private _mouseDown: boolean = false;
@@ -228,17 +227,7 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 	}
 
 	public update(): void {
-		const tickMarks = this._chart.model().timeScale().marks();
-
-		if (!tickMarks) {
-			return;
-		}
-
-		this._minVisibleSpan = MarkSpanBorder.Year;
-
-		tickMarks.forEach((tickMark: TimeMark) => {
-			this._minVisibleSpan = Math.min(tickMark.span, this._minVisibleSpan);
-		});
+		this._chart.model().timeScale().marks();
 	}
 
 	public getImage(): HTMLCanvasElement {

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -23,7 +23,7 @@ const enum Constants {
 	MinVisibleBarsCount = 2,
 }
 
-export const enum MarkSpanBorder {
+const enum MarkSpanBorder {
 	Minute = 20,
 	Hour = 30,
 	Day = 40,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,9 +20,8 @@
 		"noUnusedLocals": true,
 		"outDir": "lib",
 		"plugins": [
-			{
-				"transform": "ts-transformer-minify-privates"
-			}
+			{ "transform": "ts-transformer-minify-privates" },
+			{ "transform": "ts-transformer-strip-const-enums" }
 		],
 		"preserveConstEnums": true,
 		"resolveJsonModule": true,


### PR DESCRIPTION
**Type of PR:** enhancement

After we enabled `preserveConstEnums` TS has started to generate a code for `const enum`s, even they aren't exported from source file. This PR fixes that and removes code for const enums from JS code if `const enum` isn't exported.

`ts-transformer-strip-const-enums` itself support to strip `const enum` if it isn't exported from some entry point only (so it might remove some additional `const enum`s which are "shared" between modules internally, but aren't exported from the library), but let's do it in another PR after introducing https://github.com/timocov/ts-transformer-properties-rename.

The code of the transformer: https://github.com/timocov/ts-transformer-strip-const-enums