### PR TITLE
Fixed bug with updating the same x coordinate several times so text is going away

### DIFF
--- a/src/renderers/series-markers-renderer.ts
+++ b/src/renderers/series-markers-renderer.ts
@@ -15,7 +15,6 @@ import { drawText, hitTestText } from './series-markers-text';
 
 export interface SeriesMarkerText {
 	content: string;
-	x: Coordinate;
 	y: Coordinate;
 	width: number;
 	height: number;
@@ -87,7 +86,6 @@ export class SeriesMarkersRenderer extends ScaledRenderer {
 			if (item.text !== undefined) {
 				item.text.width = this._textWidthCache.measureText(ctx, item.text.content);
 				item.text.height = this._fontSize;
-				item.text.x = item.text.x - item.text.width / 2 as Coordinate;
 			}
 			drawItem(item, ctx);
 		}
@@ -98,7 +96,7 @@ function drawItem(item: SeriesMarkerRendererDataItem, ctx: CanvasRenderingContex
 	ctx.fillStyle = item.color;
 
 	if (item.text !== undefined) {
-		drawText(ctx, item.text.content, item.text.x, item.text.y);
+		drawText(ctx, item.text.content, item.x - item.text.width / 2, item.text.y);
 	}
 
 	drawShape(item, ctx);
@@ -128,7 +126,7 @@ function drawShape(item: SeriesMarkerRendererDataItem, ctx: CanvasRenderingConte
 }
 
 function hitTestItem(item: SeriesMarkerRendererDataItem, x: Coordinate, y: Coordinate): boolean {
-	if (item.text !== undefined && hitTestText(item.text.x, item.text.y, item.text.width, item.text.height, x, y)) {
+	if (item.text !== undefined && hitTestText(item.x, item.text.y, item.text.width, item.text.height, x, y)) {
 		return true;
 	}
 

--- a/src/views/pane/series-markers-pane-view.ts
+++ b/src/views/pane/series-markers-pane-view.ts
@@ -200,7 +200,6 @@ export class SeriesMarkersPaneView implements IUpdatablePaneView {
 			if (marker.text !== undefined && marker.text.length > 0) {
 				rendererItem.text = {
 					content: marker.text,
-					x: rendererItem.x,
 					y: 0 as Coordinate,
 					width: 0,
 					height: 0,


### PR DESCRIPTION
**Type of PR:** bugfix

**Overview of change:**

1. Open test case series-markers-with-text in debug.html
1. Disable autoscale on price axis by dragging it
1. Move crosshair over chart and see what's going on with the text

=>

![clw](https://user-images.githubusercontent.com/3112183/82911080-1e347b00-9f74-11ea-8569-3353aba1833d.gif)