### PR TITLE
TextWidthCache refactoring & tests

### DIFF
--- a/src/model/text-width-cache.ts
+++ b/src/model/text-width-cache.ts
@@ -1,15 +1,9 @@
+export type CanvasCtxLike = Pick<CanvasRenderingContext2D, 'measureText'>;
+
 const defaultReplacementRe = /[2-9]/g;
 
-export interface TextMetricsLike {
-	width: number;
-}
-
-export interface CanvasCtxLike {
-	measureText(text: string): TextMetricsLike;
-}
-
 export class TextWidthCache {
-	private _cache: Map<string | undefined, number> = new Map();
+	private _cache: Map<string, number> = new Map();
 	/** A "cyclic buffer" of cache keys */
 	private _keys: (string | undefined)[];
 	/** Current index in the "cyclic buffer" */

--- a/src/model/text-width-cache.ts
+++ b/src/model/text-width-cache.ts
@@ -2,7 +2,7 @@ const defaultReplacementRe = /[2-9]/g;
 
 export class TextWidthCache {
 	private readonly _maxSize: number;
-	private _cache: Record<string, number> = Object.create(null);
+	private _cache: Map<string, number> = new Map();
 	/** A "cyclic buffer" of cache keys */
 	private _keys: string[] = [];
 	/** Current index in the "cyclic buffer" */
@@ -13,7 +13,7 @@ export class TextWidthCache {
 	}
 
 	public reset(): void {
-		this._cache = Object.create(null);
+		this._cache = new Map();
 		this._keys = [];
 		this._keysIndex = 0;
 	}
@@ -22,25 +22,58 @@ export class TextWidthCache {
 		const re = optimizationReplacementRe || defaultReplacementRe;
 		const cacheString = String(text).replace(re, '0');
 
-		if (cacheString in this._cache) {
-			return this._cache[cacheString];
+		let width = this._cache.get(cacheString);
+
+		if (width === undefined) {
+			width = ctx.measureText(cacheString).width;
+
+			if (width === 0 && text.length !== 0) {
+				// measureText can return 0 in FF depending on a canvas size, don't cache it
+				return 0;
+			}
+
+			// A cyclic buffer like structure is used to keep track of all the cache keys
+			// and remove them when their time has come.
+			// This contents of an array cannot be pre-allocated with out-of-band empty values
+			// because this would deoptimize the array internal stucture.
+			// We will grow this array as we're writing values.
+
+			// The _keysIndex always points to an oldest value.
+			// The array is inititalized in "growing" phase when this index equals array length.
+			//                .length = N ↓      ↓ maxSize
+			// ├──────┬──────┬     ┬──────┐      ┊
+			// │ foo  │ bar  │ ... │ baz  │      ┊
+			// ├──────┴──────┴     ┴──────┘      ┊
+			//                  index = N ↑
+
+			// Eventually the array length reaches _maxSize and the index rolls over to the start.
+			//                                   ↓ length = maxSize
+			// ├──────┬──────┬     ┬──────┬──────┤
+			// │ foo  │ bar  │ ... │ baz  │ quux │
+			// ├──────┴──────┴     ┴──────┴──────┤
+			// ↑ index = 0
+
+			// From on now we're in the "cyclic" phase when a newest key overwrites the oldest one.
+			//                                   ↓ length = maxSize
+			// ├──────┬──────┬     ┬──────┬──────┤
+			// │ WOOT │ bar  │ ... │ baz  │ quux │
+			// ├──────┴──────┴     ┴──────┴──────┤
+			//        ↑ index = 1
+
+			// Are we in the "cyclic" phase?
+			if (this._keysIndex < this._keys.length) {
+				// Cleanup the oldest value
+				this._cache.delete(this._keys[this._keysIndex]);
+			}
+
+			// Overwrite or create the array element
+			this._keys[this._keysIndex] = cacheString;
+			// Advance the index so it always points the oldest value
+			this._keysIndex = (this._keysIndex + 1) % this._maxSize;
+
+			this._cache.set(cacheString, width);
 		}
 
-		const width = ctx.measureText(cacheString).width;
-
-		if (width === 0 && text.length !== 0) {
-			// measureText can return 0 in FF depending on a canvas size, don't cache it
-			return 0;
-		}
-
-		if (this._keysIndex < this._keys.length) {
-			// Cleanup the oldest value
-			delete this._cache[this._keys[this._keysIndex]];
-		}
-
-		this._keys[this._keysIndex] = cacheString;
-		// Advance the index so it always points the oldest value
-		this._keysIndex = (this._keysIndex + 1) % this._maxSize;
-		return this._cache[cacheString] = width;
+		return width;
 	}
 }

--- a/tests/unittests/text-width-cache.spec.ts
+++ b/tests/unittests/text-width-cache.spec.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { TextWidthCache } from '../../src/model/text-width-cache';
+
+function fakeMeasureText(str: string): { width: number } {
+	let fakeWidth = 0;
+	for (let i = 0; i < str.length; i++) {
+		fakeWidth += (1 + str.charCodeAt(i) % 64 / 64) * 10;
+	}
+	return { width: fakeWidth };
+}
+
+describe('TextWidthCache', () => {
+	it('should return the same measureText would return', () => {
+		const textWidthCache = new TextWidthCache();
+		const fakeCtx = { measureText: fakeMeasureText } as unknown as CanvasRenderingContext2D;
+		expect(
+			textWidthCache.measureText(fakeCtx, 'test')
+		).to.be.equal(
+			fakeMeasureText('test').width
+		);
+	});
+
+	it('should cache and purge values', () => {
+		const invocations: Record<string, number> = Object.create(null);
+		const fakeCtx = {
+			measureText(str: string): { width: number } {
+				invocations[str] = (invocations[str] || 0) + 1;
+				return { width: 42 };
+			},
+		} as unknown as CanvasRenderingContext2D;
+
+		const textWidthCache = new TextWidthCache(3);
+		textWidthCache.measureText(fakeCtx, 'foo');
+		textWidthCache.measureText(fakeCtx, 'bar');
+		textWidthCache.measureText(fakeCtx, 'baz');
+
+		expect(invocations).to.deep.equal({
+			foo: 1,
+			bar: 1,
+			baz: 1,
+		});
+
+		textWidthCache.measureText(fakeCtx, 'baz');
+		textWidthCache.measureText(fakeCtx, 'bar');
+		textWidthCache.measureText(fakeCtx, 'foo');
+
+		expect(invocations).to.deep.equal({
+			foo: 1,
+			bar: 1,
+			baz: 1,
+		});
+
+		// The oldest, foo, should be removed
+		textWidthCache.measureText(fakeCtx, 'quux');
+
+		expect(invocations).to.deep.equal({
+			foo: 1,
+			bar: 1,
+			baz: 1,
+			quux: 1,
+		});
+
+		textWidthCache.measureText(fakeCtx, 'baz');
+		textWidthCache.measureText(fakeCtx, 'bar');
+		textWidthCache.measureText(fakeCtx, 'foo');
+
+		expect(invocations).to.deep.equal({
+			foo: 2,
+			bar: 1,
+			baz: 1,
+			quux: 1,
+		});
+	});
+
+	it('should not cache zero width of nonempty string', () => {
+		const invocations: Record<string, number> = Object.create(null);
+		const fakeCtx = {
+			measureText(str: string): { width: number } {
+				invocations[str] = (invocations[str] || 0) + 1;
+				return { width: 0 };
+			},
+		} as unknown as CanvasRenderingContext2D;
+
+		const textWidthCache = new TextWidthCache(3);
+
+		textWidthCache.measureText(fakeCtx, '');
+		textWidthCache.measureText(fakeCtx, 'not empty');
+		textWidthCache.measureText(fakeCtx, '');
+		textWidthCache.measureText(fakeCtx, 'not empty');
+		textWidthCache.measureText(fakeCtx, '');
+		textWidthCache.measureText(fakeCtx, 'not empty');
+
+		expect(invocations).to.deep.equal({
+			// cache
+			'': 1,
+			// no cache
+			'not empty': 3,
+		});
+	});
+
+	it('should not treat prototype values as keys', () => {
+		const invocations: Record<string, number> = Object.create(null);
+		const fakeCtx = {
+			measureText(str: string): { width: number } {
+				invocations[str] = (invocations[str] || 0) + 1;
+				return { width: 42 };
+			},
+		} as unknown as CanvasRenderingContext2D;
+
+		const textWidthCache = new TextWidthCache(3);
+
+		textWidthCache.measureText(fakeCtx, '__proto__');
+		textWidthCache.measureText(fakeCtx, 'prototype');
+		textWidthCache.measureText(fakeCtx, 'hasOwnProperty');
+
+		expect(invocations.__proto__).to.deep.equal(1);
+		expect(invocations.prototype).to.deep.equal(1);
+		expect(invocations.hasOwnProperty).to.deep.equal(1);
+
+		// Just checking if it still works
+
+		textWidthCache.measureText(fakeCtx, '__proto__');
+		textWidthCache.measureText(fakeCtx, 'prototype');
+		textWidthCache.measureText(fakeCtx, 'hasOwnProperty');
+
+		expect(invocations.__proto__).to.deep.equal(1);
+		expect(invocations.prototype).to.deep.equal(1);
+		expect(invocations.hasOwnProperty).to.deep.equal(1);
+	});
+
+	it('should apply default optimization regex', () => {
+		const textWidthCache = new TextWidthCache();
+		const fakeCtx = { measureText: fakeMeasureText } as unknown as CanvasRenderingContext2D;
+		expect(
+			textWidthCache.measureText(fakeCtx, 'test2345')
+		).to.be.equal(
+			textWidthCache.measureText(fakeCtx, 'test6789')
+		);
+	});
+
+	it('should apply custom optimization regex', () => {
+		const textWidthCache = new TextWidthCache();
+		const fakeCtx = { measureText: fakeMeasureText } as unknown as CanvasRenderingContext2D;
+		const re = /[1-9]/g;
+		expect(
+			textWidthCache.measureText(fakeCtx, 'test01234', re)
+		).to.be.equal(
+			textWidthCache.measureText(fakeCtx, 'test56789', re)
+		);
+	});
+});


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [x] Includes tests
- [x] Documentation update (not required)

**Overview of change:**

No signature changes.

Added some tests.

Changed the cache from `Record<string, { tick: number, width: number}>` to just `Record<string, number>`

Fixed `__proto__` and `prototype` were read from cache object proto

Changed a ticks2indices record with even growing indices into a cyclic array structure,

-10 bytes .min.gz :grin: 

**Is there anything you'd like reviewers to focus on?**

<!-- optional -->

The `private _cache` can be a `Map<string, number>` as well. It's an easy change and I can apply it if you wish.