### PR TITLE
Explicitly label unix timestamp as a number

### DIFF
--- a/docs/time.md
+++ b/docs/time.md
@@ -13,6 +13,7 @@ Example:
 ```js
 const timestamp = 1529884800; // June 25, 2018
 ```
+- `timestamp` (`number`) - UTC
 
 ## Business day object
 


### PR DESCRIPTION
I missed "prevent errors, you should cast the numeric type of the time to UTCTimestamp" when reading this initally. This extra comment may help future library users avoid accidentally cast timestamp as a string and open new issues.

**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**



**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
