### PR TITLE
Fixed getting price scale api if price scale id is empty string

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -307,9 +307,9 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 	public priceScale(priceScaleId?: string): IPriceScaleApi {
 		if (priceScaleId === undefined) {
 			warn('Using ChartApi.priceScale() method without arguments has been deprecated, pass valid price scale id instead');
+			priceScaleId = this._chartWidget.model().defaultVisiblePriceScaleId();
 		}
 
-		priceScaleId = priceScaleId || this._chartWidget.model().defaultVisiblePriceScaleId();
 		return new PriceScaleApi(this._chartWidget, priceScaleId);
 	}
 

--- a/tests/e2e/graphics/test-cases/applying-options/scale-margins-for-overlay-series.js
+++ b/tests/e2e/graphics/test-cases/applying-options/scale-margins-for-overlay-series.js
@@ -32,14 +32,14 @@ function runTestCase(container) {
 	});
 
 	const thirdSeries = chart.addLineSeries({
-		priceScaleId: 'second-overlay',
+		priceScaleId: '',
 	});
 
 	thirdSeries.applyOptions({
 		color: 'red',
 	});
 
-	chart.priceScale('second-overlay').applyOptions({
+	chart.priceScale('').applyOptions({
 		scaleMargins: {
 			top: 0,
 			bottom: 0.5,


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #537
- [x] Includes tests
- [ ] Documentation update
