### PR TITLE
adds fixRightEdge option

### DIFF
--- a/src/api/options/time-scale-options-defaults.ts
+++ b/src/api/options/time-scale-options-defaults.ts
@@ -4,6 +4,7 @@ export const timeScaleOptionsDefaults: TimeScaleOptions = {
 	rightOffset: 0,
 	barSpacing: 6,
 	fixLeftEdge: false,
+	fixRightEdge: false,
 	lockVisibleTimeRangeOnResize: false,
 	rightBarStaysOnScroll: false,
 	borderVisible: true,


### PR DESCRIPTION
**Type of PR:** enhancement

Fixes #218

**Overview of change:**

Adds `fixRightEdge` option to the timescale as requested in #268 and #218.

I'm using it in conjuction with the `fixLeftEdge` option to prevent zooming the chart out and scrolling the chart into the future.
