### PR TITLE
Added an option `shiftVisibleRangeOnNewBar` to not shift visible time range when data is added

### DIFF
--- a/docs/time-scale.md
+++ b/docs/time-scale.md
@@ -16,6 +16,7 @@ Time scale (or time axis) is a horizontal scale at the bottom of the chart that 
 |`visible`|`boolean`|`true`|If true, the time scale is shown on a chart|
 |`timeVisible`|`boolean`|`false`|If true, the time is shown on the time scale and in the vertical crosshair label|
 |`secondsVisible`|`boolean`|`true`|If true, seconds are shown on the label of the crosshair vertical line in `hh:mm:ss` format on intraday intervals|
+|`shiftVisibleRangeOnNewBar`|`boolean`|`true`|If true, the visible range is shifted by the number of new bars when new bars are added (note that this only applies when the last bar is visible)|
 |`tickMarkFormatter`|`(TimePoint, TickMarkType, locale) => string` &#124; `undefined`|`undefined`|Allows to override the tick marks formatter (see below)|
 
 ### Tick marks formatter

--- a/src/api/options/time-scale-options-defaults.ts
+++ b/src/api/options/time-scale-options-defaults.ts
@@ -11,4 +11,5 @@ export const timeScaleOptionsDefaults: TimeScaleOptions = {
 	visible: true,
 	timeVisible: false,
 	secondsVisible: true,
+	shiftVisibleRangeOnNewBar: true,
 };

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -469,7 +469,8 @@ export class ChartModel implements IDestroyable {
 			const isSeriesPointsAdded = newBaseIndex > currentBaseIndex;
 			const isSeriesPointsAddedToRight = isSeriesPointsAdded && !isLeftBarShiftToLeft;
 
-			if (isSeriesPointsAddedToRight && !isLastSeriesBarVisible) {
+			const needShiftVisibleRangeOnNewBar = isLastSeriesBarVisible && this._timeScale.options().shiftVisibleRangeOnNewBar;
+			if (isSeriesPointsAddedToRight && !needShiftVisibleRangeOnNewBar) {
 				const compensationShift = newBaseIndex - currentBaseIndex;
 				this._timeScale.setRightOffset(this._timeScale.rightOffset() - compensationShift);
 			}

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -76,6 +76,7 @@ export interface TimeScaleOptions {
 	visible: boolean;
 	timeVisible: boolean;
 	secondsVisible: boolean;
+	shiftVisibleRangeOnNewBar: boolean;
 	tickMarkFormatter?: TickMarkFormatter;
 }
 

--- a/tests/e2e/graphics/test-cases/time-scale/do-not-shift-on-new-data-from-right.js
+++ b/tests/e2e/graphics/test-cases/time-scale/do-not-shift-on-new-data-from-right.js
@@ -1,0 +1,35 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container, {
+		timeScale: {
+			rightOffset: 10,
+			shiftVisibleRangeOnNewBar: false,
+		},
+	});
+
+	const mainSeries = chart.addLineSeries();
+
+	const data = generateData();
+
+	mainSeries.setData(data.slice(0, -20));
+
+	return new Promise(resolve => {
+		setTimeout(() => {
+			mainSeries.setData(data);
+			resolve();
+		}, 100);
+	});
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #584
- [x] Includes tests
- [x] Documentation update

**Overview of change:**



**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
