### PR TITLE
Fix #752 Series data still in memory after using setdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ debug.html
 
 # graphics tests out data
 /tests/e2e/graphics/.gendata/
+
+# OS X .DS_Store files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ debug.html
 
 # graphics tests out data
 /tests/e2e/graphics/.gendata/
-
-# OS X .DS_Store files
-.DS_Store

--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -160,6 +160,8 @@ export class DataLayer {
 	// this is kind of "dest" values (in opposite to "source" ones) - we don't need to modify it manually, the only by calling _syncIndexesAndApplyChanges method
 	private _sortedTimePoints: readonly TimeScalePoint[] = [];
 
+	private _previousBaseIndexValue: TimePointIndex = 0 as TimePointIndex;
+
 	public destroy(): void {
 		this._pointDataByTimePoint.clear();
 		this._seriesRowsBySeries.clear();
@@ -384,12 +386,19 @@ export class DataLayer {
 	private _getBaseIndex(): TimePointIndex {
 		let baseIndex = 0 as TimePointIndex;
 
-		this._seriesRowsBySeries.forEach((data: SeriesPlotRow[]) => {
-			if (data.length !== 0) {
-				baseIndex = Math.max(baseIndex, data[data.length - 1].index) as TimePointIndex;
-			}
-		});
+		if (this._seriesRowsBySeries.size === 0) {
+			// all series have been removed so use the previous base index value
+			baseIndex = this._previousBaseIndexValue;
+		} else {
+			// calculate a new base index value from series data
+			this._seriesRowsBySeries.forEach((data: SeriesPlotRow[]) => {
+				if (data.length !== 0) {
+					baseIndex = Math.max(baseIndex, data[data.length - 1].index) as TimePointIndex;
+				}
+			});
+		}
 
+		this._previousBaseIndexValue = baseIndex;
 		return baseIndex;
 	}
 

--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -335,8 +335,6 @@ export class DataLayer {
 	private _updateTimeScalePoints(newTimePoints: TimeScalePoint[]): number {
 		let firstChangedPointIndex = -1;
 
-		// if the new time points array is empty we have removed all data...?
-
 		// search the first different point and "syncing" time weight by the way
 		for (let index = 0; index < this._sortedTimePoints.length && index < newTimePoints.length; ++index) {
 			const oldPoint = this._sortedTimePoints[index];

--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -335,6 +335,8 @@ export class DataLayer {
 	private _updateTimeScalePoints(newTimePoints: TimeScalePoint[]): number {
 		let firstChangedPointIndex = -1;
 
+		// if the new time points array is empty we have removed all data...?
+
 		// search the first different point and "syncing" time weight by the way
 		for (let index = 0; index < this._sortedTimePoints.length && index < newTimePoints.length; ++index) {
 			const oldPoint = this._sortedTimePoints[index];
@@ -419,6 +421,10 @@ export class DataLayer {
 			this._seriesRowsBySeries.forEach((data: SeriesPlotRow[], s: Series) => {
 				dataUpdateResponse.series.set(s, { data, fullUpdate: true });
 			});
+
+			if (!this._seriesRowsBySeries.has(series)) {
+				dataUpdateResponse.series.set(series, { data: [], fullUpdate: true });
+			}
 
 			dataUpdateResponse.timeScale.points = this._sortedTimePoints;
 		} else {

--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -420,6 +420,9 @@ export class DataLayer {
 				dataUpdateResponse.series.set(s, { data, fullUpdate: true });
 			});
 
+			// if the seires data was set to [] it will have already been removed from _seriesRowBySeries
+			// meaning the forEach above won't add the series to the data update response
+			// so we handle that case here
 			if (!this._seriesRowsBySeries.has(series)) {
 				dataUpdateResponse.series.set(series, { data: [], fullUpdate: true });
 			}

--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -160,8 +160,6 @@ export class DataLayer {
 	// this is kind of "dest" values (in opposite to "source" ones) - we don't need to modify it manually, the only by calling _syncIndexesAndApplyChanges method
 	private _sortedTimePoints: readonly TimeScalePoint[] = [];
 
-	private _previousBaseIndexValue: TimePointIndex = 0 as TimePointIndex;
-
 	public destroy(): void {
 		this._pointDataByTimePoint.clear();
 		this._seriesRowsBySeries.clear();
@@ -386,19 +384,12 @@ export class DataLayer {
 	private _getBaseIndex(): TimePointIndex {
 		let baseIndex = 0 as TimePointIndex;
 
-		if (this._seriesRowsBySeries.size === 0) {
-			// all series have been removed so use the previous base index value
-			baseIndex = this._previousBaseIndexValue;
-		} else {
-			// calculate a new base index value from series data
-			this._seriesRowsBySeries.forEach((data: SeriesPlotRow[]) => {
-				if (data.length !== 0) {
-					baseIndex = Math.max(baseIndex, data[data.length - 1].index) as TimePointIndex;
-				}
-			});
-		}
+		this._seriesRowsBySeries.forEach((data: SeriesPlotRow[]) => {
+			if (data.length !== 0) {
+				baseIndex = Math.max(baseIndex, data[data.length - 1].index) as TimePointIndex;
+			}
+		});
 
-		this._previousBaseIndexValue = baseIndex;
 		return baseIndex;
 	}
 

--- a/tests/e2e/graphics/test-cases/series/update-removed-series-data.js
+++ b/tests/e2e/graphics/test-cases/series/update-removed-series-data.js
@@ -1,54 +1,54 @@
 function generateData() {
-  var res = [];
-  var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
-  for (var i = 0; i < 3; ++i) {
-    res.push({
-      time: time.getTime() / 1000,
-      value: i * Math.random(),
-    });
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 3; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i * Math.random(),
+		});
 
-    time.setUTCDate(time.getUTCDate() + 1);
-  }
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
 
-  return res;
+	return res;
 }
 
 function runTestCase(container) {
-  const chart = LightweightCharts.createChart(container, {
-    width: 600,
-    height: 300,
-    timeScale: {
-      barSpacing: 40,
-      timeVisible: true,
-    }
-  });
+	const chart = LightweightCharts.createChart(container, {
+		width: 600,
+		height: 300,
+		timeScale: {
+			barSpacing: 40,
+			timeVisible: true,
+		},
+	});
 
-  const data1 = generateData()
-  const data2 = generateData()
-  const series1 = chart.addLineSeries({ title: 'Series 1' })
-  const series2 = chart.addLineSeries({ title: 'Series 2' })
+	const data1 = generateData();
+	const data2 = generateData();
+	const series1 = chart.addLineSeries({ title: 'Series 1' });
+	const series2 = chart.addLineSeries({ title: 'Series 2' });
 
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      series1.setData(data1);
+	return new Promise(resolve => {
+		setTimeout(() => {
+			series1.setData(data1);
 
-      setTimeout(() => {
-        series2.setData(data2);
+			setTimeout(() => {
+				series2.setData(data2);
 
-        setTimeout(() => {
-          series1.setData([]);
+				setTimeout(() => {
+					series1.setData([]);
 
-          setTimeout(() => {
-            series2.setData([]);
+					setTimeout(() => {
+						series2.setData([]);
 
-            setTimeout(() => {
-              series1.setData(data1);
+						setTimeout(() => {
+							series1.setData(data1);
 
-              resolve()
-            }, 50)
-          }, 50)
-        }, 50)
-      }, 50)
-    }, 50)
-  })
+							resolve();
+						}, 50);
+					}, 50);
+				}, 50);
+			}, 50);
+		}, 50);
+	});
 }

--- a/tests/e2e/graphics/test-cases/series/update-removed-series-data.js
+++ b/tests/e2e/graphics/test-cases/series/update-removed-series-data.js
@@ -1,0 +1,54 @@
+function generateData() {
+  var res = [];
+  var time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+  for (var i = 0; i < 3; ++i) {
+    res.push({
+      time: time.getTime() / 1000,
+      value: i * Math.random(),
+    });
+
+    time.setUTCDate(time.getUTCDate() + 1);
+  }
+
+  return res;
+}
+
+function runTestCase(container) {
+  const chart = LightweightCharts.createChart(container, {
+    width: 600,
+    height: 300,
+    timeScale: {
+      barSpacing: 40,
+      timeVisible: true,
+    }
+  });
+
+  const data1 = generateData()
+  const data2 = generateData()
+  const series1 = chart.addLineSeries({ title: 'Series 1' })
+  const series2 = chart.addLineSeries({ title: 'Series 2' })
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      series1.setData(data1);
+
+      setTimeout(() => {
+        series2.setData(data2);
+
+        setTimeout(() => {
+          series1.setData([]);
+
+          setTimeout(() => {
+            series2.setData([]);
+
+            setTimeout(() => {
+              series1.setData(data1);
+
+              resolve()
+            }, 50)
+          }, 50)
+        }, 50)
+      }, 50)
+    }, 50)
+  })
+}

--- a/tests/unittests/data-layer.spec.ts
+++ b/tests/unittests/data-layer.spec.ts
@@ -423,10 +423,9 @@ describe('DataLayer', () => {
 			const res = [];
 			const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
 
-			for (let i = 0; i < 3; ++i) {
+			for (let i = 0; i < 10; ++i) {
 				const timestamp = time.getTime() / 1000;
 				res.push(dataItemAt(timestamp as UTCTimestamp));
-				time.setUTCDate(time.getUTCDate() + 1);
 			}
 
 			return res;
@@ -442,24 +441,31 @@ describe('DataLayer', () => {
 
 		const updateResult1 = dataLayer.setSeriesData(series1, []);
 
-		expect(updateResult1.timeScale.baseIndex).to.be.equal(2, 'expected base index to be 2');
+		expect(updateResult1.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
 		expect(updateResult1.timeScale.points).to.be.equal(undefined, 'expected updated time scale points to be undefined');
 		expect(updateResult1.series.has(series1)).to.be.equal(true, 'expected to contain series1');
 		expect(updateResult1.series.get(series1)?.data.length).to.be.equal(0, 'expected series1 data to be empty');
 
 		const updateResult2 = dataLayer.setSeriesData(series2, []);
 
-		expect(updateResult2.timeScale.baseIndex).to.be.equal(2, 'expected base index to be 2');
+		expect(updateResult2.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
 		expect(updateResult2.timeScale.points?.length).to.be.equal(0, 'expected updated time scale points length to equal 0');
 		expect(updateResult2.series.has(series2)).to.be.equal(true, 'expected to contain series2');
 		expect(updateResult2.series.get(series2)?.data.length).to.be.equal(0, 'expected series2 data to be empty');
 
 		const updateResult3 = dataLayer.setSeriesData(series1, data1);
 
-		expect(updateResult3.timeScale.baseIndex).to.be.equal(2, 'expected base index to be 2');
-		expect(updateResult3.timeScale.points?.length).to.be.equal(3, 'expected updated time scale points length to equal 3');
+		expect(updateResult3.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
+		expect(updateResult3.timeScale.points?.length).to.be.equal(1, 'expected updated time scale points length to equal 1');
 		expect(updateResult3.series.has(series1)).to.be.equal(true, 'expected to contain series1');
 		expect(updateResult3.series.get(series1)?.data.length).to.be.equal(data1.length, 'expected series1 data to be non-empty');
+
+		const updateResult4 = dataLayer.setSeriesData(series2, data2);
+
+		expect(updateResult4.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
+		expect(updateResult4.timeScale.points).to.be.equal(undefined, 'expected updated time scale points to be undefined');
+		expect(updateResult4.series.has(series2)).to.be.equal(true, 'expected to contain series2');
+		expect(updateResult4.series.get(series2)?.data.length).to.be.equal(data2.length, 'expected series1 data to be non-empty');
 	});
 
 	describe('should be able to remove series and generate full update to other series if time scale is changed gh#355', () => {

--- a/tests/unittests/data-layer.spec.ts
+++ b/tests/unittests/data-layer.spec.ts
@@ -423,9 +423,10 @@ describe('DataLayer', () => {
 			const res = [];
 			const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
 
-			for (let i = 0; i < 10; ++i) {
+			for (let i = 0; i < 3; ++i) {
 				const timestamp = time.getTime() / 1000;
 				res.push(dataItemAt(timestamp as UTCTimestamp));
+				time.setUTCDate(time.getUTCDate() + 1);
 			}
 
 			return res;
@@ -441,31 +442,24 @@ describe('DataLayer', () => {
 
 		const updateResult1 = dataLayer.setSeriesData(series1, []);
 
-		expect(updateResult1.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
+		expect(updateResult1.timeScale.baseIndex).to.be.equal(2, 'expected base index to be 2');
 		expect(updateResult1.timeScale.points).to.be.equal(undefined, 'expected updated time scale points to be undefined');
 		expect(updateResult1.series.has(series1)).to.be.equal(true, 'expected to contain series1');
 		expect(updateResult1.series.get(series1)?.data.length).to.be.equal(0, 'expected series1 data to be empty');
 
 		const updateResult2 = dataLayer.setSeriesData(series2, []);
 
-		expect(updateResult2.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
+		expect(updateResult2.timeScale.baseIndex).to.be.equal(2, 'expected base index to be 2');
 		expect(updateResult2.timeScale.points?.length).to.be.equal(0, 'expected updated time scale points length to equal 0');
 		expect(updateResult2.series.has(series2)).to.be.equal(true, 'expected to contain series2');
 		expect(updateResult2.series.get(series2)?.data.length).to.be.equal(0, 'expected series2 data to be empty');
 
 		const updateResult3 = dataLayer.setSeriesData(series1, data1);
 
-		expect(updateResult3.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
-		expect(updateResult3.timeScale.points?.length).to.be.equal(1, 'expected updated time scale points length to equal 1');
+		expect(updateResult3.timeScale.baseIndex).to.be.equal(2, 'expected base index to be 2');
+		expect(updateResult3.timeScale.points?.length).to.be.equal(3, 'expected updated time scale points length to equal 3');
 		expect(updateResult3.series.has(series1)).to.be.equal(true, 'expected to contain series1');
 		expect(updateResult3.series.get(series1)?.data.length).to.be.equal(data1.length, 'expected series1 data to be non-empty');
-
-		const updateResult4 = dataLayer.setSeriesData(series2, data2);
-
-		expect(updateResult4.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
-		expect(updateResult4.timeScale.points).to.be.equal(undefined, 'expected updated time scale points to be undefined');
-		expect(updateResult4.series.has(series2)).to.be.equal(true, 'expected to contain series2');
-		expect(updateResult4.series.get(series2)?.data.length).to.be.equal(data2.length, 'expected series1 data to be non-empty');
 	});
 
 	describe('should be able to remove series and generate full update to other series if time scale is changed gh#355', () => {

--- a/tests/unittests/data-layer.spec.ts
+++ b/tests/unittests/data-layer.spec.ts
@@ -426,6 +426,7 @@ describe('DataLayer', () => {
 			for (let i = 0; i < 10; ++i) {
 				const timestamp = time.getTime() / 1000;
 				res.push(dataItemAt(timestamp as UTCTimestamp));
+				time.setUTCDate(time.getUTCDate() + 1);
 			}
 
 			return res;
@@ -441,7 +442,7 @@ describe('DataLayer', () => {
 
 		const updateResult1 = dataLayer.setSeriesData(series1, []);
 
-		expect(updateResult1.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
+		expect(updateResult1.timeScale.baseIndex).to.be.equal(9, 'expected base index to be 9');
 		expect(updateResult1.timeScale.points).to.be.equal(undefined, 'expected updated time scale points to be undefined');
 		expect(updateResult1.series.has(series1)).to.be.equal(true, 'expected to contain series1');
 		expect(updateResult1.series.get(series1)?.data.length).to.be.equal(0, 'expected series1 data to be empty');
@@ -455,14 +456,14 @@ describe('DataLayer', () => {
 
 		const updateResult3 = dataLayer.setSeriesData(series1, data1);
 
-		expect(updateResult3.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
-		expect(updateResult3.timeScale.points?.length).to.be.equal(1, 'expected updated time scale points length to equal 1');
+		expect(updateResult3.timeScale.baseIndex).to.be.equal(9, 'expected base index to be 9');
+		expect(updateResult3.timeScale.points?.length).to.be.equal(10, 'expected updated time scale points length to equal 10');
 		expect(updateResult3.series.has(series1)).to.be.equal(true, 'expected to contain series1');
 		expect(updateResult3.series.get(series1)?.data.length).to.be.equal(data1.length, 'expected series1 data to be non-empty');
 
 		const updateResult4 = dataLayer.setSeriesData(series2, data2);
 
-		expect(updateResult4.timeScale.baseIndex).to.be.equal(0, 'expected base index to be 0');
+		expect(updateResult4.timeScale.baseIndex).to.be.equal(9, 'expected base index to be 9');
 		expect(updateResult4.timeScale.points).to.be.equal(undefined, 'expected updated time scale points to be undefined');
 		expect(updateResult4.series.has(series2)).to.be.equal(true, 'expected to contain series2');
 		expect(updateResult4.series.get(series2)?.data.length).to.be.equal(data2.length, 'expected series1 data to be non-empty');


### PR DESCRIPTION
**Type of PR:** Bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #752 
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Currently when a series is remove (i.e. it is updated with empty data `[]`) the library does not properly handle removing that data.

Internally this is because `DataLayer._syncIndexesAndApplyChanges` doesn't include the removed series in the returned `DataUpdateResponse`.

This PR fixes the logic so that removed series are included in the update response. 
