### PR TITLE
Area chart with baseLine feature

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,11 +4,11 @@ module.exports = [
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.esm.production.js',
-		limit: '40.5 KB',
+		limit: '41 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '41 KB',
+		limit: '42 KB',
 	},
 ];

--- a/docs/area-series.md
+++ b/docs/area-series.md
@@ -46,11 +46,15 @@ An area series interface can be customized using the following set of options:
 
 |Name|Type|Default|Description|
 |-|----|-------|-|
-|`topColor`|`string`|`rgba(46, 220, 135, 0.4)`|Area top color|
-|`bottomColor`|`string`|`rgba(40, 221, 100, 0)`|Area bottom color|
-|`lineColor`|`string`|`#33D778`|Line color|
+|`topFillColor1`|`string`|`rgba(46, 220, 135, 0.4)`|Area top fill color 1|
+|`topFillColor2`|`string`|`rgba(40, 221, 100, 0)`|Area top color 2|
+|`bottomFillColor1`|`string`|`rgba(255, 18, 18, 0)`|Area bottom color 1|
+|`bottomFillColor2`|`string`|`rgba(255, 18, 18, 0.4)`|Area bottom color 2|
+|`topLineColor`|`string`|`#33D778`|Top Line color|
+|`bottomLineColor`|`string`|`#FF1212`|Bottom Line color|
 |`lineStyle`|[LineStyle](./constants.md#linestyle)|`LineStyle.Solid`|Line style|
 |`lineWidth`|`number`|`3`|Line width in pixels|
+|`baselinePrice`|`number`|`0`|Price as base line|
 |`crosshairMarkerVisible`|`boolean`|`true`|If true, the crosshair marker is shown|
 |`crosshairMarkerRadius`|`number`|`4`|The radius of the crosshair marker in pixels|
 |`crosshairMarkerBorderColor`|`string`|`''`|The crosshair border color (an empty string fallbacks the color to series' color under the crosshair)|
@@ -62,9 +66,9 @@ An area series interface can be customized using the following set of options:
 
     ```js
     const areaSeries = chart.addAreaSeries({
-        topColor: 'rgba(21, 146, 230, 0.4)',
-        bottomColor: 'rgba(21, 146, 230, 0)',
-        lineColor: 'rgba(21, 146, 230, 1)',
+        topFillColor1: 'rgba(21, 146, 230, 0.4)',
+        topFillColor2: 'rgba(21, 146, 230, 0)',
+        topLineColor: 'rgba(21, 146, 230, 1)',
         lineStyle: 0,
         lineWidth: 3,
         crosshairMarkerVisible: false,
@@ -79,7 +83,7 @@ An area series interface can be customized using the following set of options:
     ```js
     // for example, let's override line width and color only
     areaSeries.applyOptions({
-        lineColor: 'rgba(255, 44, 128, 1)',
+        topLineColor: 'rgba(255, 44, 128, 1)',
         lineWidth: 1,
     });
     ```

--- a/src/api/options/series-options-defaults.ts
+++ b/src/api/options/series-options-defaults.ts
@@ -41,9 +41,13 @@ export const lineStyleDefaults: LineStyleOptions = {
 };
 
 export const areaStyleDefaults: AreaStyleOptions = {
-	topColor: 'rgba( 46, 220, 135, 0.4)',
-	bottomColor: 'rgba( 40, 221, 100, 0)',
-	lineColor: '#33D778',
+	topFillColor1: 'rgba( 46, 220, 135, 0.4)',
+	topFillColor2: 'rgba( 40, 221, 100, 0)',
+	bottomFillColor1: 'rgba(255, 18, 18, 0)',
+	bottomFillColor2: 'rgba(255, 18, 18, 0.4)',
+	topLineColor: '#33D778',
+	bottomLineColor: '#FF1212',
+	baselinePrice: 0,
 	lineStyle: LineStyle.Solid,
 	lineWidth: 3,
 	lineType: LineType.Simple,

--- a/src/model/series-bar-colorer.ts
+++ b/src/model/series-bar-colorer.ts
@@ -102,7 +102,7 @@ export class SeriesBarColorer {
 
 	private _areaStyle(areaStyle: AreaStyleOptions, barIndex: TimePointIndex, precomputedBars?: PrecomputedBars): BarColorerStyle {
 		const currentBar = ensureNotNull(this._findBar(barIndex, precomputedBars)) as SeriesPlotRow<'Area'>;
-		const isAboveBaseLine = currentBar.value[0] > areaStyle.baselinePrice;
+		const isAboveBaseLine = currentBar.value[0] >= areaStyle.baselinePrice;
 		return {
 			...emptyResult,
 			barColor: isAboveBaseLine ? areaStyle.topLineColor : areaStyle.bottomLineColor,

--- a/src/model/series-bar-colorer.ts
+++ b/src/model/series-bar-colorer.ts
@@ -47,7 +47,7 @@ export class SeriesBarColorer {
 				return this._lineStyle(seriesOptions as LineStyleOptions);
 
 			case 'Area':
-				return this._areaStyle(seriesOptions as AreaStyleOptions);
+				return this._areaStyle(seriesOptions as AreaStyleOptions, barIndex, precomputedBars);
 
 			case 'Bar':
 				return this._barStyle(seriesOptions as BarStyleOptions, barIndex, precomputedBars);
@@ -100,10 +100,12 @@ export class SeriesBarColorer {
 		return result;
 	}
 
-	private _areaStyle(areaStyle: AreaStyleOptions): BarColorerStyle {
+	private _areaStyle(areaStyle: AreaStyleOptions, barIndex: TimePointIndex, precomputedBars?: PrecomputedBars): BarColorerStyle {
+		const currentBar = ensureNotNull(this._findBar(barIndex, precomputedBars)) as SeriesPlotRow<'Area'>;
+		const isAboveBaseLine = currentBar.value[0] > areaStyle.baselinePrice;
 		return {
 			...emptyResult,
-			barColor: areaStyle.lineColor,
+			barColor: isAboveBaseLine ? areaStyle.topLineColor : areaStyle.bottomLineColor,
 		};
 	}
 

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -67,9 +67,13 @@ export interface LineStyleOptions {
 }
 
 export interface AreaStyleOptions {
-	topColor: string;
-	bottomColor: string;
-	lineColor: string;
+	topFillColor1: string;
+	topFillColor2: string;
+	bottomFillColor1: string;
+	bottomFillColor2: string;
+	topLineColor: string;
+	bottomLineColor: string;
+	baselinePrice: number;
 	lineStyle: LineStyle;
 	lineWidth: LineWidth;
 	lineType: LineType;

--- a/src/renderers/area-renderer.ts
+++ b/src/renderers/area-renderer.ts
@@ -9,13 +9,18 @@ import { walkLine } from './walk-line';
 export interface PaneRendererAreaData {
 	items: LineItem[];
 	lineType: LineType;
-	lineColor: string;
 	lineWidth: LineWidth;
 	lineStyle: LineStyle;
 
-	topColor: string;
-	bottomColor: string;
+	topLineColor: string;
+	bottomLineColor: string;
+	topFillColor1: string;
+	topFillColor2: string;
+	bottomFillColor1: string;
+	bottomFillColor2: string;
+
 	bottom: Coordinate;
+	baseLine: Coordinate;
 
 	barWidth: number;
 
@@ -24,19 +29,32 @@ export interface PaneRendererAreaData {
 
 export class PaneRendererArea extends ScaledRenderer {
 	protected _data: PaneRendererAreaData | null = null;
+	protected _baseLine: number | null = null;
 
 	public setData(data: PaneRendererAreaData): void {
 		this._data = data;
+		this._baseLine = Math.min(this._data.bottom, this._data.baseLine);
 	}
 
 	protected _drawImpl(ctx: CanvasRenderingContext2D): void {
-		if (this._data === null || this._data.items.length === 0 || this._data.visibleRange === null) {
+		this._drawArea(ctx);
+		this._drawLine(ctx);
+	}
+
+	private _drawArea(ctx: CanvasRenderingContext2D): void {
+		if (this._data === null || this._data.items.length === 0 || this._data.visibleRange === null || this._baseLine === null) {
 			return;
 		}
+		const gradient = ctx.createLinearGradient(0, 0, 0, this._data.bottom);
+		const baseLinePercent = this._baseLine / this._data.bottom;
+		gradient.addColorStop(0, this._data.topFillColor1);
+		gradient.addColorStop(baseLinePercent, this._data.topFillColor2);
+		gradient.addColorStop(baseLinePercent, this._data.bottomFillColor1); // Add small size?
+		gradient.addColorStop(1, this._data.bottomFillColor2);
 
 		ctx.lineCap = 'butt';
 		ctx.lineJoin = 'round';
-		ctx.strokeStyle = this._data.lineColor;
+		ctx.strokeStyle = gradient;
 		ctx.lineWidth = this._data.lineWidth;
 		setLineStyle(ctx, this._data.lineStyle);
 
@@ -48,28 +66,54 @@ export class PaneRendererArea extends ScaledRenderer {
 		if (this._data.items.length === 1) {
 			const point = this._data.items[0];
 			const halfBarWidth = this._data.barWidth / 2;
-			ctx.moveTo(point.x - halfBarWidth, this._data.bottom);
+			ctx.moveTo(point.x - halfBarWidth, this._baseLine);
 			ctx.lineTo(point.x - halfBarWidth, point.y);
 			ctx.lineTo(point.x + halfBarWidth, point.y);
-			ctx.lineTo(point.x + halfBarWidth, this._data.bottom);
+			ctx.lineTo(point.x + halfBarWidth, this._baseLine);
 		} else {
-			ctx.moveTo(this._data.items[this._data.visibleRange.from].x, this._data.bottom);
+			ctx.moveTo(this._data.items[this._data.visibleRange.from].x, this._baseLine);
 			ctx.lineTo(this._data.items[this._data.visibleRange.from].x, this._data.items[this._data.visibleRange.from].y);
 
 			walkLine(ctx, this._data.items, this._data.lineType, this._data.visibleRange);
 
 			if (this._data.visibleRange.to > this._data.visibleRange.from) {
-				ctx.lineTo(this._data.items[this._data.visibleRange.to - 1].x, this._data.bottom);
-				ctx.lineTo(this._data.items[this._data.visibleRange.from].x, this._data.bottom);
+				ctx.lineTo(this._data.items[this._data.visibleRange.to - 1].x, this._baseLine);
+				ctx.lineTo(this._data.items[this._data.visibleRange.from].x, this._baseLine);
 			}
 		}
 		ctx.closePath();
 
-		const gradient = ctx.createLinearGradient(0, 0, 0, this._data.bottom);
-		gradient.addColorStop(0, this._data.topColor);
-		gradient.addColorStop(1, this._data.bottomColor);
-
 		ctx.fillStyle = gradient;
 		ctx.fill();
+	}
+
+	private _drawLine(ctx: CanvasRenderingContext2D): void {
+		if (this._data === null || this._data.items.length === 0 || this._data.visibleRange === null || this._baseLine === null) {
+			return;
+		}
+		ctx.lineCap = 'butt';
+		ctx.lineWidth = this._data.lineWidth;
+
+		const gradient = ctx.createLinearGradient(0, 0, 0, this._data.bottom);
+		const baseLinePercent = this._baseLine / this._data.bottom;
+		gradient.addColorStop(0, this._data.topLineColor);
+		gradient.addColorStop(baseLinePercent, this._data.topLineColor);
+		gradient.addColorStop(baseLinePercent, this._data.bottomLineColor); // Add small size?
+		gradient.addColorStop(1, this._data.bottomLineColor);
+		setLineStyle(ctx, this._data.lineStyle);
+
+		ctx.strokeStyle = gradient;
+		ctx.lineJoin = 'round';
+
+		ctx.beginPath();
+		if (this._data.items.length === 1) {
+			const point = this._data.items[0];
+			ctx.moveTo(point.x - this._data.barWidth / 2, point.y);
+			ctx.lineTo(point.x + this._data.barWidth / 2, point.y);
+		} else {
+			walkLine(ctx, this._data.items, this._data.lineType, this._data.visibleRange);
+		}
+
+		ctx.stroke();
 	}
 }

--- a/src/renderers/area-renderer.ts
+++ b/src/renderers/area-renderer.ts
@@ -49,7 +49,7 @@ export class PaneRendererArea extends ScaledRenderer {
 		const baseLinePercent = this._baseLine / this._data.bottom;
 		gradient.addColorStop(0, this._data.topFillColor1);
 		gradient.addColorStop(baseLinePercent, this._data.topFillColor2);
-		gradient.addColorStop(baseLinePercent, this._data.bottomFillColor1); // Add small size?
+		gradient.addColorStop(baseLinePercent + 0.01, this._data.bottomFillColor1); // Add small size
 		gradient.addColorStop(1, this._data.bottomFillColor2);
 
 		ctx.lineCap = 'butt';
@@ -98,7 +98,7 @@ export class PaneRendererArea extends ScaledRenderer {
 		const baseLinePercent = this._baseLine / this._data.bottom;
 		gradient.addColorStop(0, this._data.topLineColor);
 		gradient.addColorStop(baseLinePercent, this._data.topLineColor);
-		gradient.addColorStop(baseLinePercent, this._data.bottomLineColor); // Add small size?
+		gradient.addColorStop(baseLinePercent + 0.01, this._data.bottomLineColor); // Add small size
 		gradient.addColorStop(1, this._data.bottomLineColor);
 		setLineStyle(ctx, this._data.lineStyle);
 

--- a/src/views/pane/area-pane-view.ts
+++ b/src/views/pane/area-pane-view.ts
@@ -6,18 +6,17 @@ import { TimePointIndex } from '../../model/time-data';
 import { PaneRendererArea, PaneRendererAreaData } from '../../renderers/area-renderer';
 import { CompositeRenderer } from '../../renderers/composite-renderer';
 import { IPaneRenderer } from '../../renderers/ipane-renderer';
-import { LineItem, PaneRendererLine } from '../../renderers/line-renderer';
+import { LineItem } from '../../renderers/line-renderer';
 
 import { LinePaneViewBase } from './line-pane-view-base';
 
 export class SeriesAreaPaneView extends LinePaneViewBase<'Area', LineItem> {
 	private readonly _renderer: CompositeRenderer = new CompositeRenderer();
 	private readonly _areaRenderer: PaneRendererArea = new PaneRendererArea();
-	private readonly _lineRenderer: PaneRendererLine = new PaneRendererLine();
 
 	public constructor(series: Series<'Area'>, model: ChartModel) {
 		super(series, model);
-		this._renderer.setRenderers([this._areaRenderer, this._lineRenderer]);
+		this._renderer.setRenderers([this._areaRenderer]);
 	}
 
 	public renderer(height: number, width: number): IPaneRenderer | null {
@@ -26,23 +25,25 @@ export class SeriesAreaPaneView extends LinePaneViewBase<'Area', LineItem> {
 		}
 
 		const areaStyleProperties = this._series.options();
-
 		this._makeValid();
 		const data: PaneRendererAreaData = {
 			lineType: areaStyleProperties.lineType,
 			items: this._items,
-			lineColor: areaStyleProperties.lineColor,
+			topLineColor: areaStyleProperties.topLineColor,
+			bottomLineColor: areaStyleProperties.bottomLineColor,
 			lineStyle: areaStyleProperties.lineStyle,
 			lineWidth: areaStyleProperties.lineWidth,
-			topColor: areaStyleProperties.topColor,
-			bottomColor: areaStyleProperties.bottomColor,
+			topFillColor1: areaStyleProperties.topFillColor1,
+			topFillColor2: areaStyleProperties.topFillColor2,
+			bottomFillColor1: areaStyleProperties.bottomFillColor1,
+			bottomFillColor2: areaStyleProperties.bottomFillColor2,
 			bottom: height as Coordinate,
+			baseLine: this._series.priceScale().priceToCoordinate(areaStyleProperties.baselinePrice, 0),
 			visibleRange: this._itemsVisibleRange,
 			barWidth: this._model.timeScale().barSpacing(),
 		};
 
 		this._areaRenderer.setData(data);
-		this._lineRenderer.setData(data);
 
 		return this._renderer;
 	}

--- a/tests/e2e/graphics/test-cases/series/area-with-base-line.js
+++ b/tests/e2e/graphics/test-cases/series/area-with-base-line.js
@@ -1,0 +1,55 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 50; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	for (let i = 0; i < 50; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: 50 - i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	for (let i = 0; i < 50; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	for (let i = 0; i < 50; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: 50 - i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addAreaSeries({
+		lineWidth: 1,
+		baselinePrice: 25,
+	});
+
+	mainSeries.createPriceLine({
+		price: 25,
+	});
+
+	mainSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/time-scale/add-data-to-left-two-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/add-data-to-left-two-series.js
@@ -48,7 +48,7 @@ function createFirstSeries() {
 
 function createSecondSeries() {
 	areaSeries2 = chart.addAreaSeries({
-		lineColor: 'red',
+		topLineColor: 'red',
 	});
 	data2 = [...generateData(20, Date.UTC(2022, 0, 1, 0, 0, 0, 0), true), ...generateData(61, Date.UTC(2022, 1, 1, 0, 0, 0, 0))];
 	areaSeries2.setData(data2);

--- a/tests/e2e/graphics/test-cases/time-scale/add-data-to-right-two-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/add-data-to-right-two-series.js
@@ -48,7 +48,7 @@ function createFirstSeries() {
 
 function createSecondSeries() {
 	areaSeries2 = chart.addAreaSeries({
-		lineColor: 'red',
+		topLineColor: 'red',
 	});
 	data2 = [...generateData(20, Date.UTC(2022, 0, 1, 0, 0, 0, 0), true), ...generateData(61, Date.UTC(2022, 1, 1, 0, 0, 0, 0))];
 	areaSeries2.setData(data2);


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #195  and #151
- [x] Includes tests
- [x] Documentation update

**Overview of change:**
```js
export interface AreaStyleOptions {
	topFillColor1: string; // new
	topFillColor2: string; // new
	bottomFillColor1: string; // new
	bottomFillColor2: string; // new
	topLineColor: string; // new
	bottomLineColor: string; // new
	baselinePrice: number; // new
	lineStyle: LineStyle;
	lineWidth: LineWidth;
	lineType: LineType;
	crosshairMarkerVisible: boolean;
	crosshairMarkerRadius: number;
	crosshairMarkerBorderColor: string;
	crosshairMarkerBackgroundColor: string;
}
```

This change is **not backward compatible** since changing some area chart option

**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
