### PR TITLE
Rename and chage logic of entireTextOnly property #754

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -133,7 +133,6 @@ The following set of options can be used to adjust the price axis interface:
 |`borderVisible`|`boolean`|`true`|If true, price scale border is visible|
 |`borderColor`|`string`|`#2b2b43`|Pricescale border color|
 |`scaleMargins`|`{ bottom, top }`|`{ bottom: 0.1, top: 0.2 }`|Sets the series margins from the top and bottom chart borders (percent)|
-|`entireTextOnly`|`boolean`|`false`|If false, top and bottom corner labels are shown even if they are partially not visible |
 |`drawTicks`|`boolean`|`true`|If true, a small horizontal line is drawn on price axis labels|
 
 ### An example of a price scale customization
@@ -286,6 +285,7 @@ The following options can be used to customize chart design:
 |`textColor`|`string`|`#191919`|Scale value text color|
 |`fontSize`|`number`|`11`|Scales values' font size|
 |`fontFamily`|`string`|`'Trebuchet MS', Roboto, Ubuntu, sans-serif`|Font family to be used on scales|
+|`croppedTickMarks`|`boolean`|`true`|If disabled, partially visible price labels on price axis will be hidden |
 
 ### An example of layout customization
 

--- a/src/api/options/layout-options-defaults.ts
+++ b/src/api/options/layout-options-defaults.ts
@@ -7,4 +7,5 @@ export const layoutOptionsDefaults: LayoutOptions = {
 	textColor: '#191919',
 	fontSize: 11,
 	fontFamily: defaultFontFamily,
+	croppedTickMarks: true,
 };

--- a/src/api/options/price-scale-options-defaults.ts
+++ b/src/api/options/price-scale-options-defaults.ts
@@ -7,7 +7,6 @@ export const priceScaleOptionsDefaults: PriceScaleOptions = {
 	alignLabels: true,
 	borderVisible: true,
 	borderColor: '#2B2B43',
-	entireTextOnly: false,
 	visible: false,
 	drawTicks: true,
 	scaleMargins: {

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -11,7 +11,7 @@ import { InvalidationLevel } from '../model/invalidate-mask';
 import { IPriceDataSource } from '../model/iprice-data-source';
 import { LayoutOptions } from '../model/layout-options';
 import { PriceScalePosition } from '../model/pane';
-import { PriceScale } from '../model/price-scale';
+import { PriceMark, PriceScale } from '../model/price-scale';
 import { TextWidthCache } from '../model/text-width-cache';
 import { PriceAxisViewRendererOptions } from '../renderers/iprice-axis-view-renderer';
 import { PriceAxisRendererOptionsProvider } from '../renderers/price-axis-renderer-options-provider';
@@ -406,7 +406,8 @@ export class PriceAxisWidget implements IDestroyable {
 	}
 
 	private _drawTickMarks(ctx: CanvasRenderingContext2D, pixelRatio: number): void {
-		if (this._size === null || this._priceScale === null) {
+		const size = this._size;
+		if (size === null || this._priceScale === null) {
 			return;
 		}
 
@@ -422,7 +423,7 @@ export class PriceAxisWidget implements IDestroyable {
 		const drawTicks = this._priceScale.options().borderVisible && this._priceScale.options().drawTicks;
 
 		const tickMarkLeftX = this._isLeft ?
-			Math.floor((this._size.w - rendererOptions.tickLength) * pixelRatio - rendererOptions.borderSize * pixelRatio) :
+			Math.floor((size.w - rendererOptions.tickLength) * pixelRatio - rendererOptions.borderSize * pixelRatio) :
 			Math.floor(rendererOptions.borderSize * pixelRatio);
 
 		const textLeftX = this._isLeft ?
@@ -433,19 +434,38 @@ export class PriceAxisWidget implements IDestroyable {
 		const tickHeight = Math.max(1, Math.floor(pixelRatio));
 		const tickOffset = Math.floor(pixelRatio * 0.5);
 
+		const labelHeight = this.fontSize();
+		const tickMarksVisibility = tickMarks.map((tickMark: PriceMark) => {
+			if (this._options.croppedTickMarks) {
+				return true;
+			}
+
+			const labelTop = tickMark.coord - (labelHeight / 2);
+			const labelBottom = tickMark.coord + (labelHeight / 2);
+			return labelTop >= 0 && labelBottom <= size.h;
+		});
+
 		if (drawTicks) {
 			const tickLength = Math.round(rendererOptions.tickLength * pixelRatio);
 			ctx.beginPath();
-			for (const tickMark of tickMarks) {
-				ctx.rect(tickMarkLeftX, Math.round(tickMark.coord * pixelRatio) - tickOffset, tickLength, tickHeight);
+			for (let i = 0; i < tickMarks.length; i++) {
+				if (!tickMarksVisibility[i]) {
+					continue;
+				}
+
+				ctx.rect(tickMarkLeftX, Math.round(tickMarks[i].coord * pixelRatio) - tickOffset, tickLength, tickHeight);
 			}
 
 			ctx.fill();
 		}
 
 		ctx.fillStyle = this.textColor();
-		for (const tickMark of tickMarks) {
-			this._tickMarksCache.paintTo(ctx, tickMark.label, textLeftX, Math.round(tickMark.coord * pixelRatio), textAlign);
+		for (let i = 0; i < tickMarks.length; i++) {
+			if (!tickMarksVisibility[i]) {
+				continue;
+			}
+
+			this._tickMarksCache.paintTo(ctx, tickMarks[i].label, textLeftX, Math.round(tickMarks[i].coord * pixelRatio), textAlign);
 		}
 
 		ctx.restore();

--- a/src/model/layout-options.ts
+++ b/src/model/layout-options.ts
@@ -8,4 +8,6 @@ export interface LayoutOptions {
 	fontSize: number;
 	/** Font family of a text on the scales */
 	fontFamily: string;
+	/** If disabled, partially visible price labels on price axis will be hidden */
+	croppedTickMarks: boolean;
 }

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -92,8 +92,6 @@ export interface PriceScaleOptions {
 	borderVisible: boolean;
 	/** Defines a color of the border between the price scale and the chart area. It is ignored if borderVisible is false */
 	borderColor: string;
-	/** Indicates whether the price scale displays only full lines of text or partial lines. */
-	entireTextOnly: boolean;
 	/** Indicates if this price scale visible. Could not be applied to overlay price scale */
 	visible: boolean;
 	/** True value add a small horizontal ticks on price axis labels */

--- a/src/model/price-tick-mark-builder.ts
+++ b/src/model/price-tick-mark-builder.ts
@@ -68,10 +68,6 @@ export class PriceTickMarkBuilder {
 		const bottom = this._coordinateToLogicalFunc(scaleHeight - 1, firstValue);
 		const top = this._coordinateToLogicalFunc(0, firstValue);
 
-		const extraTopBottomMargin = this._priceScale.options().entireTextOnly ? this._fontHeight() / 2 : 0;
-		const minCoord = extraTopBottomMargin;
-		const maxCoord = scaleHeight - 1 - extraTopBottomMargin;
-
 		const high = Math.max(bottom, top);
 		const low = Math.min(bottom, top);
 		if (high === low) {
@@ -94,11 +90,6 @@ export class PriceTickMarkBuilder {
 			// check if there is place for it
 			// this is required for log scale
 			if (prevCoord !== null && Math.abs(coord - prevCoord) < this._tickMarkHeight()) {
-				continue;
-			}
-
-			// check if a tick mark is partially visible and skip it if entireTextOnly is true
-			if (coord < minCoord || coord > maxCoord) {
 				continue;
 			}
 

--- a/tests/e2e/graphics/test-cases/initial-options/layout-cropped-tick-marks.js
+++ b/tests/e2e/graphics/test-cases/initial-options/layout-cropped-tick-marks.js
@@ -2,12 +2,12 @@ function runTestCase(container) {
 	const chart = LightweightCharts.createChart(container, {
 		width: 600,
 		height: 300,
-		rightPriceScale: {
-			entireTextOnly: true,
-		},
 		timeScale: {
 			timeVisible: true,
 			secondsVisible: true,
+		},
+		layout: {
+			croppedTickMarks: false,
 		},
 	});
 


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [*] Addresses an existing issue: fixes #754 
- [*] Includes tests
- [*] Documentation update

**Overview of change:**
The entireTextOnly property has been removed. The croppedTickMarks has been added instead. The new property is applied to all price scales, unlike the previous one and also affects only the drawing of the label and the line in front of it (the previous setting also affected the grid lines).


**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
