### PR TITLE
WIP: fix multi-pane feature

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,11 +4,11 @@ module.exports = [
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.esm.production.js',
-		limit: '43 KB',
+		limit: '45 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '43.5 KB',
+		limit: '45.5 KB',
 	},
 ];

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -1,4 +1,9 @@
-import { ChartWidget, MouseEventParamsImpl, MouseEventParamsImplSupplier } from '../gui/chart-widget';
+import {
+	ChartWidget,
+	MouseEventParamsImpl,
+	MouseEventParamsImplSupplier, PaneEventParamsImpl,
+	PaneEventParamsImplSupplier,
+} from '../gui/chart-widget';
 
 import { ensureDefined } from '../helpers/assertions';
 import { Delegate } from '../helpers/delegate';
@@ -30,7 +35,7 @@ import {
 import { CandlestickSeriesApi } from './candlestick-series-api';
 import { DataUpdatesConsumer, SeriesDataItemTypeMap } from './data-consumer';
 import { DataLayer, DataUpdateResponse, SeriesChanges } from './data-layer';
-import { IChartApi, MouseEventHandler, MouseEventParams } from './ichart-api';
+import { IChartApi, MouseEventHandler, MouseEventParams, PaneEventHandler, PaneEventParams } from './ichart-api';
 import { IPriceScaleApi } from './iprice-scale-api';
 import { ISeriesApi } from './iseries-api';
 import { ITimeScaleApi } from './itime-scale-api';
@@ -156,6 +161,7 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 
 	private readonly _clickedDelegate: Delegate<MouseEventParams> = new Delegate();
 	private readonly _crosshairMovedDelegate: Delegate<MouseEventParams> = new Delegate();
+	private readonly _paneResizeDelegate: Delegate<PaneEventParams> = new Delegate();
 
 	private readonly _timeScaleApi: TimeScaleApi;
 
@@ -178,6 +184,15 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 			(paramSupplier: MouseEventParamsImplSupplier) => {
 				if (this._crosshairMovedDelegate.hasListeners()) {
 					this._crosshairMovedDelegate.fire(this._convertMouseParams(paramSupplier()));
+				}
+			},
+			this
+		);
+
+		this._chartWidget.paneResized().subscribe(
+			(paramSupplier: PaneEventParamsImplSupplier) => {
+				if (this._paneResizeDelegate.hasListeners()) {
+					this._paneResizeDelegate.fire(this._convertPaneResizeParams(paramSupplier()));
 				}
 			},
 			this
@@ -339,6 +354,14 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 		return this._chartWidget.takeScreenshot();
 	}
 
+	public subscribePaneResize(handler: PaneEventHandler): void {
+		this._paneResizeDelegate.subscribe(handler);
+	}
+
+	public unsubscribePaneResize(handler: PaneEventHandler): void {
+		this._paneResizeDelegate.unsubscribe(handler);
+	}
+
 	private _sendUpdateToChart(update: DataUpdateResponse): void {
 		const model = this._chartWidget.model();
 
@@ -366,6 +389,20 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 			hoveredSeries,
 			hoveredMarkerId: param.hoveredObject,
 			seriesPrices,
+		};
+	}
+
+	// noinspection JSMethodCanBeStatic
+	private _convertPaneResizeParams(param: PaneEventParamsImpl): PaneEventParams {
+		return {
+			top: {
+				index: param.top.index,
+				height: param.top.height,
+			},
+			bottom: {
+				index: param.bottom.index,
+				height: param.bottom.height,
+			},
 		};
 	}
 }

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -1,9 +1,4 @@
-import {
-	ChartWidget,
-	MouseEventParamsImpl,
-	MouseEventParamsImplSupplier, PaneEventParamsImpl,
-	PaneEventParamsImplSupplier,
-} from '../gui/chart-widget';
+import { ChartWidget, MouseEventParamsImpl, MouseEventParamsImplSupplier } from '../gui/chart-widget';
 
 import { ensureDefined } from '../helpers/assertions';
 import { Delegate } from '../helpers/delegate';
@@ -35,7 +30,7 @@ import {
 import { CandlestickSeriesApi } from './candlestick-series-api';
 import { DataUpdatesConsumer, SeriesDataItemTypeMap } from './data-consumer';
 import { DataLayer, DataUpdateResponse, SeriesChanges } from './data-layer';
-import { IChartApi, MouseEventHandler, MouseEventParams, PaneEventHandler, PaneEventParams } from './ichart-api';
+import { IChartApi, MouseEventHandler, MouseEventParams } from './ichart-api';
 import { IPriceScaleApi } from './iprice-scale-api';
 import { ISeriesApi } from './iseries-api';
 import { ITimeScaleApi } from './itime-scale-api';
@@ -161,7 +156,6 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 
 	private readonly _clickedDelegate: Delegate<MouseEventParams> = new Delegate();
 	private readonly _crosshairMovedDelegate: Delegate<MouseEventParams> = new Delegate();
-	private readonly _paneResizeDelegate: Delegate<PaneEventParams> = new Delegate();
 
 	private readonly _timeScaleApi: TimeScaleApi;
 
@@ -184,15 +178,6 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 			(paramSupplier: MouseEventParamsImplSupplier) => {
 				if (this._crosshairMovedDelegate.hasListeners()) {
 					this._crosshairMovedDelegate.fire(this._convertMouseParams(paramSupplier()));
-				}
-			},
-			this
-		);
-
-		this._chartWidget.paneResized().subscribe(
-			(paramSupplier: PaneEventParamsImplSupplier) => {
-				if (this._paneResizeDelegate.hasListeners()) {
-					this._paneResizeDelegate.fire(this._convertPaneResizeParams(paramSupplier()));
 				}
 			},
 			this
@@ -354,14 +339,6 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 		return this._chartWidget.takeScreenshot();
 	}
 
-	public subscribePaneResize(handler: PaneEventHandler): void {
-		this._paneResizeDelegate.subscribe(handler);
-	}
-
-	public unsubscribePaneResize(handler: PaneEventHandler): void {
-		this._paneResizeDelegate.unsubscribe(handler);
-	}
-
 	public removePane(index: number): void {
 		this._chartWidget.model().removePane(index);
 	}
@@ -397,20 +374,6 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 			hoveredSeries,
 			hoveredMarkerId: param.hoveredObject,
 			seriesPrices,
-		};
-	}
-
-	// noinspection JSMethodCanBeStatic
-	private _convertPaneResizeParams(param: PaneEventParamsImpl): PaneEventParams {
-		return {
-			top: {
-				index: param.top.index,
-				height: param.top.height,
-			},
-			bottom: {
-				index: param.bottom.index,
-				height: param.bottom.height,
-			},
 		};
 	}
 }

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -362,6 +362,14 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 		this._paneResizeDelegate.unsubscribe(handler);
 	}
 
+	public removePane(index: number): void {
+		this._chartWidget.model().removePane(index);
+	}
+
+	public swapPane(first: number, second: number): void {
+		this._chartWidget.model().swapPane(first, second);
+	}
+
 	private _sendUpdateToChart(update: DataUpdateResponse): void {
 		const model = this._chartWidget.model();
 

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -376,6 +376,7 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 		return {
 			time: param.time && (param.time.businessDay || param.time.timestamp),
 			point: param.point,
+			paneIndex: param.paneIndex,
 			hoveredSeries,
 			hoveredMarkerId: param.hoveredObject,
 			seriesPrices,

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -1,4 +1,5 @@
 import { ChartWidget, MouseEventParamsImpl, MouseEventParamsImplSupplier } from '../gui/chart-widget';
+import { PaneWidget } from '../gui/pane-widget';
 
 import { ensureDefined } from '../helpers/assertions';
 import { Delegate } from '../helpers/delegate';
@@ -345,6 +346,10 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 
 	public swapPane(first: number, second: number): void {
 		this._chartWidget.model().swapPane(first, second);
+	}
+
+	public getPaneElements(): HTMLElement[] {
+		return this._chartWidget.paneWidgets().map((paneWidget: PaneWidget) => paneWidget.getPaneCell());
 	}
 
 	private _sendUpdateToChart(update: DataUpdateResponse): void {

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -29,18 +29,6 @@ export interface MouseEventParams {
 
 export type MouseEventHandler = (param: MouseEventParams) => void;
 
-export interface PaneEventParams {
-	top: {
-		index: number;
-		height: number;
-	};
-	bottom: {
-		index: number;
-		height: number;
-	};
-}
-
-export type PaneEventHandler = (param: PaneEventParams) => void;
 /*
  * The main interface of a single chart
  */
@@ -167,20 +155,6 @@ export interface IChartApi {
 	 * @returns a canvas with the chart drawn on
 	 */
 	takeScreenshot(): HTMLCanvasElement;
-
-	/**
-	 * Adds a subscription to pane resize event
-	 *
-	 * @param handler - handler (function) to be called on pane resize
-	 */
-	subscribePaneResize(handler: PaneEventHandler): void;
-
-	/**
-	 * Removes pane resize subscription
-	 *
-	 * @param handler - previously subscribed handler
-	 */
-	unsubscribePaneResize(handler: PaneEventHandler): void;
 
 	/**
 	 * Removes a pane with index

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -22,6 +22,7 @@ import { ITimeScaleApi } from './itime-scale-api';
 export interface MouseEventParams {
 	time?: UTCTimestamp | BusinessDay;
 	point?: Point;
+	paneIndex?: number;
 	seriesPrices: Map<ISeriesApi<SeriesType>, BarPrice | BarPrices>;
 	hoveredSeries?: ISeriesApi<SeriesType>;
 	hoveredMarkerId?: SeriesMarker<Time>['id'];

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -29,6 +29,18 @@ export interface MouseEventParams {
 
 export type MouseEventHandler = (param: MouseEventParams) => void;
 
+export interface PaneEventParams {
+	top: {
+		index: number;
+		height: number;
+	};
+	bottom: {
+		index: number;
+		height: number;
+	};
+}
+
+export type PaneEventHandler = (param: PaneEventParams) => void;
 /*
  * The main interface of a single chart
  */
@@ -92,8 +104,9 @@ export interface IChartApi {
 	 */
 	removeSeries(seriesApi: ISeriesApi<SeriesType>): void;
 
-	/*
+	/**
 	 * Adds a subscription to mouse click event
+	 *
 	 * @param handler - handler (function) to be called on mouse click
 	 */
 	subscribeClick(handler: MouseEventHandler): void;
@@ -154,4 +167,18 @@ export interface IChartApi {
 	 * @returns a canvas with the chart drawn on
 	 */
 	takeScreenshot(): HTMLCanvasElement;
+
+	/**
+	 * Adds a subscription to pane resize event
+	 *
+	 * @param handler - handler (function) to be called on pane resize
+	 */
+	subscribePaneResize(handler: PaneEventHandler): void;
+
+	/**
+	 * Removes pane resize subscription
+	 *
+	 * @param handler - previously subscribed handler
+	 */
+	unsubscribePaneResize(handler: PaneEventHandler): void;
 }

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -171,4 +171,5 @@ export interface IChartApi {
 	 */
 	swapPane(first: number, second: number): void;
 
+	getPaneElements(): HTMLElement[];
 }

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -181,4 +181,20 @@ export interface IChartApi {
 	 * @param handler - previously subscribed handler
 	 */
 	unsubscribePaneResize(handler: PaneEventHandler): void;
+
+	/**
+	 * Removes a pane with index
+	 *
+	 * @param index the pane to be removed
+	 */
+	removePane(index: number): void;
+
+	/**
+	 * swap the position of two panes.
+	 *
+	 * @param first the first index
+	 * @param second the second index
+	 */
+	swapPane(first: number, second: number): void;
+
 }

--- a/src/api/options/chart-options-defaults.ts
+++ b/src/api/options/chart-options-defaults.ts
@@ -26,6 +26,10 @@ export const chartOptionsDefaults: ChartOptionsInternal = {
 		...priceScaleOptionsDefaults,
 		visible: true,
 	},
+	nonPrimaryPriceScale: {
+		...priceScaleOptionsDefaults,
+		visible: true,
+	},
 	timeScale: timeScaleOptionsDefaults,
 	watermark: watermarkOptionsDefaults,
 	localization: {

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -34,6 +34,19 @@ export interface MouseEventParamsImpl {
 
 export type MouseEventParamsImplSupplier = () => MouseEventParamsImpl;
 
+export interface PaneEventParamsImpl {
+	readonly top: {
+		index: number;
+		height: number;
+	};
+	bottom: {
+		index: number;
+		height: number;
+	};
+}
+
+export type PaneEventParamsImplSupplier = () => PaneEventParamsImpl;
+
 export class ChartWidget implements IDestroyable {
 	private readonly _options: ChartOptionsInternal;
 	private _paneWidgets: PaneWidget[] = [];
@@ -51,6 +64,7 @@ export class ChartWidget implements IDestroyable {
 	private _drawPlanned: boolean = false;
 	private _clicked: Delegate<MouseEventParamsImplSupplier> = new Delegate();
 	private _crosshairMoved: Delegate<MouseEventParamsImplSupplier> = new Delegate();
+	private _paneResized: Delegate<PaneEventParamsImplSupplier> = new Delegate();
 	private _onWheelBound: (event: WheelEvent) => void;
 
 	public constructor(container: HTMLElement, options: ChartOptionsInternal) {
@@ -208,6 +222,10 @@ export class ChartWidget implements IDestroyable {
 
 	public crosshairMoved(): ISubscription<MouseEventParamsImplSupplier> {
 		return this._crosshairMoved;
+	}
+
+	public paneResized(): ISubscription<PaneEventParamsImplSupplier> {
+		return this._paneResized;
 	}
 
 	public takeScreenshot(): HTMLCanvasElement {
@@ -557,7 +575,7 @@ export class ChartWidget implements IDestroyable {
 
 			// create and insert separator
 			if (i > 0) {
-				const paneSeparator = new PaneSeparator(this, i - 1, i, false);
+				const paneSeparator = new PaneSeparator(this, i - 1, i, false, this._paneResized);
 				this._paneSeparators.push(paneSeparator);
 				this._tableElement.insertBefore(paneSeparator.getElement(), this._timeAxisWidget.getElement());
 			}

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -34,19 +34,6 @@ export interface MouseEventParamsImpl {
 
 export type MouseEventParamsImplSupplier = () => MouseEventParamsImpl;
 
-export interface PaneEventParamsImpl {
-	readonly top: {
-		index: number;
-		height: number;
-	};
-	bottom: {
-		index: number;
-		height: number;
-	};
-}
-
-export type PaneEventParamsImplSupplier = () => PaneEventParamsImpl;
-
 export class ChartWidget implements IDestroyable {
 	private readonly _options: ChartOptionsInternal;
 	private _paneWidgets: PaneWidget[] = [];
@@ -64,7 +51,6 @@ export class ChartWidget implements IDestroyable {
 	private _drawPlanned: boolean = false;
 	private _clicked: Delegate<MouseEventParamsImplSupplier> = new Delegate();
 	private _crosshairMoved: Delegate<MouseEventParamsImplSupplier> = new Delegate();
-	private _paneResized: Delegate<PaneEventParamsImplSupplier> = new Delegate();
 	private _onWheelBound: (event: WheelEvent) => void;
 
 	public constructor(container: HTMLElement, options: ChartOptionsInternal) {
@@ -222,10 +208,6 @@ export class ChartWidget implements IDestroyable {
 
 	public crosshairMoved(): ISubscription<MouseEventParamsImplSupplier> {
 		return this._crosshairMoved;
-	}
-
-	public paneResized(): ISubscription<PaneEventParamsImplSupplier> {
-		return this._paneResized;
 	}
 
 	public takeScreenshot(): HTMLCanvasElement {
@@ -575,7 +557,7 @@ export class ChartWidget implements IDestroyable {
 
 			// create and insert separator
 			if (i > 0) {
-				const paneSeparator = new PaneSeparator(this, i - 1, i, false, this._paneResized);
+				const paneSeparator = new PaneSeparator(this, i - 1, i, false);
 				this._paneSeparators.push(paneSeparator);
 				this._tableElement.insertBefore(paneSeparator.getElement(), this._timeAxisWidget.getElement());
 			}

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -20,7 +20,7 @@ import { Series } from '../model/series';
 import { TimePoint, TimePointIndex } from '../model/time-data';
 
 import { createPreconfiguredCanvas, getCanvasDevicePixelRatio, getContext2D, Size } from './canvas-utils';
-// import { PaneSeparator, SEPARATOR_HEIGHT } from './pane-separator';
+import { PaneSeparator, SEPARATOR_HEIGHT } from './pane-separator';
 import { PaneWidget } from './pane-widget';
 import { TimeAxisWidget } from './time-axis-widget';
 
@@ -37,7 +37,7 @@ export type MouseEventParamsImplSupplier = () => MouseEventParamsImpl;
 export class ChartWidget implements IDestroyable {
 	private readonly _options: ChartOptionsInternal;
 	private _paneWidgets: PaneWidget[] = [];
-	// private _paneSeparators: PaneSeparator[] = [];
+	private _paneSeparators: PaneSeparator[] = [];
 	private readonly _model: ChartModel;
 	private _drawRafId: number = 0;
 	private _height: number = 0;
@@ -141,10 +141,10 @@ export class ChartWidget implements IDestroyable {
 		}
 		this._paneWidgets = [];
 
-		// for (const paneSeparator of this._paneSeparators) {
-		// 	this._destroySeparator(paneSeparator);
-		// }
-		// this._paneSeparators = [];
+		for (const paneSeparator of this._paneSeparators) {
+			this._destroySeparator(paneSeparator);
+		}
+		this._paneSeparators = [];
 
 		ensureNotNull(this._timeAxisWidget).destroy();
 
@@ -232,13 +232,13 @@ export class ChartWidget implements IDestroyable {
 					const image = priceAxisWidget.getImage();
 					ctx.drawImage(image, targetX, targetY, priceAxisWidget.getWidth(), paneWidgetHeight);
 					targetY += paneWidgetHeight;
-					// if (paneIndex < this._paneWidgets.length - 1) {
-					// 	const separator = this._paneSeparators[paneIndex];
-					// 	const separatorSize = separator.getSize();
-					// 	const separatorImage = separator.getImage();
-					// 	ctx.drawImage(separatorImage, targetX, targetY, separatorSize.w, separatorSize.h);
-					// 	targetY += separatorSize.h;
-					// }
+					if (paneIndex < this._paneWidgets.length - 1) {
+						const separator = this._paneSeparators[paneIndex];
+						const separatorSize = separator.getSize();
+						const separatorImage = separator.getImage();
+						ctx.drawImage(separatorImage, targetX, targetY, separatorSize.w, separatorSize.h);
+						targetY += separatorSize.h;
+					}
 				}
 			};
 			// draw left price scale if exists
@@ -253,13 +253,13 @@ export class ChartWidget implements IDestroyable {
 				const image = paneWidget.getImage();
 				ctx.drawImage(image, targetX, targetY, paneWidgetSize.w, paneWidgetSize.h);
 				targetY += paneWidgetSize.h;
-				// if (paneIndex < this._paneWidgets.length - 1) {
-				// 	const separator = this._paneSeparators[paneIndex];
-				// 	const separatorSize = separator.getSize();
-				// 	const separatorImage = separator.getImage();
-				// 	ctx.drawImage(separatorImage, targetX, targetY, separatorSize.w, separatorSize.h);
-				// 	targetY += separatorSize.h;
-				// }
+				if (paneIndex < this._paneWidgets.length - 1) {
+					const separator = this._paneSeparators[paneIndex];
+					const separatorSize = separator.getSize();
+					const separatorImage = separator.getImage();
+					ctx.drawImage(separatorImage, targetX, targetY, separatorSize.w, separatorSize.h);
+					targetY += separatorSize.h;
+				}
 			}
 			targetX += firstPane.getSize().w;
 			if (this._isRightAxisVisible()) {
@@ -318,6 +318,9 @@ export class ChartWidget implements IDestroyable {
 		return ensureNotNull(priceAxisWidget).getWidth();
 	}
 
+	public adjustSize(): void {
+		this._adjustSizeImpl();
+	}
 	// eslint-disable-next-line complexity
 	private _adjustSizeImpl(): void {
 		let totalStretch = 0;
@@ -340,9 +343,9 @@ export class ChartWidget implements IDestroyable {
 
 		const paneWidth = Math.max(width - leftPriceAxisWidth - rightPriceAxisWidth, 0);
 
-		// const separatorCount = this._paneSeparators.length;
-		// const separatorHeight = SEPARATOR_HEIGHT;
-		const separatorsHeight = 0; // separatorHeight * separatorCount;
+		const separatorCount = this._paneSeparators.length;
+		const separatorHeight = SEPARATOR_HEIGHT;
+		const separatorsHeight = separatorHeight * separatorCount;
 		let timeAxisHeight = this._options.timeScale.visible ? this._timeAxisWidget.optimalHeight() : 0;
 		// TODO: Fix it better
 		// on Hi-DPI CSS size * Device Pixel Ratio should be integer to avoid smoothing
@@ -354,6 +357,9 @@ export class ChartWidget implements IDestroyable {
 		const stretchPixels = totalPaneHeight / totalStretch;
 
 		let accumulatedHeight = 0;
+
+		const pixelRatio = document.body.ownerDocument.defaultView?.devicePixelRatio || 1;
+
 		for (let paneIndex = 0; paneIndex < this._paneWidgets.length; ++paneIndex) {
 			const paneWidget = this._paneWidgets[paneIndex];
 			paneWidget.setState(this._model.panes()[paneIndex]);
@@ -362,9 +368,9 @@ export class ChartWidget implements IDestroyable {
 			let calculatePaneHeight = 0;
 
 			if (paneIndex === this._paneWidgets.length - 1) {
-				calculatePaneHeight = totalPaneHeight - accumulatedHeight;
+				calculatePaneHeight = Math.ceil((totalPaneHeight - accumulatedHeight) * pixelRatio) / pixelRatio;
 			} else {
-				calculatePaneHeight = Math.round(paneWidget.stretchFactor() * stretchPixels);
+				calculatePaneHeight = Math.round(paneWidget.stretchFactor() * stretchPixels * pixelRatio) / pixelRatio;
 			}
 
 			paneHeight = Math.max(calculatePaneHeight, 2);
@@ -519,10 +525,10 @@ export class ChartWidget implements IDestroyable {
 		this._syncGuiWithModel();
 	}
 
-	// private _destroySeparator(separator: PaneSeparator): void {
-	// 	this._tableElement.removeChild(separator.getElement());
-	// 	separator.destroy();
-	// }
+	private _destroySeparator(separator: PaneSeparator): void {
+		this._tableElement.removeChild(separator.getElement());
+		separator.destroy();
+	}
 
 	private _syncGuiWithModel(): void {
 		const panes = this._model.panes();
@@ -536,10 +542,10 @@ export class ChartWidget implements IDestroyable {
 			paneWidget.clicked().unsubscribeAll(this);
 			paneWidget.destroy();
 
-			// const paneSeparator = this._paneSeparators.pop();
-			// if (paneSeparator !== undefined) {
-			// 	this._destroySeparator(paneSeparator);
-			// }
+			const paneSeparator = this._paneSeparators.pop();
+			if (paneSeparator !== undefined) {
+				this._destroySeparator(paneSeparator);
+			}
 		}
 
 		// Create (if needed) new pane widgets and separators
@@ -550,11 +556,11 @@ export class ChartWidget implements IDestroyable {
 			this._paneWidgets.push(paneWidget);
 
 			// create and insert separator
-			// if (i > 1) {
-			// 	const paneSeparator = new PaneSeparator(this, i - 1, i, true);
-			// 	this._paneSeparators.push(paneSeparator);
-			// 	this._tableElement.insertBefore(paneSeparator.getElement(), this._timeAxisWidget.getElement());
-			// }
+			if (i > 0) {
+				const paneSeparator = new PaneSeparator(this, i - 1, i, false);
+				this._paneSeparators.push(paneSeparator);
+				this._tableElement.insertBefore(paneSeparator.getElement(), this._timeAxisWidget.getElement());
+			}
 
 			// insert paneWidget
 			this._tableElement.insertBefore(paneWidget.getElement(), this._timeAxisWidget.getElement());

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -14,6 +14,7 @@ import {
 	TimeScaleInvalidation,
 	TimeScaleInvalidationType,
 } from '../model/invalidate-mask';
+import { PaneInfo } from '../model/pane';
 import { Point } from '../model/point';
 import { PriceAxisPosition } from '../model/price-scale';
 import { Series } from '../model/series';
@@ -24,9 +25,10 @@ import { PaneSeparator, SEPARATOR_HEIGHT } from './pane-separator';
 import { PaneWidget } from './pane-widget';
 import { TimeAxisWidget } from './time-axis-widget';
 
-export interface MouseEventParamsImpl {
+export interface MouseEventParamsImpl extends PaneInfo {
 	time?: TimePoint;
 	point?: Point;
+	paneIndex?: number;
 	seriesPrices: Map<Series, BarPrice | BarPrices>;
 	hoveredSeries?: Series;
 	hoveredObject?: string;
@@ -580,7 +582,7 @@ export class ChartWidget implements IDestroyable {
 		this._adjustSizeImpl();
 	}
 
-	private _getMouseEventParamsImpl(index: TimePointIndex | null, point: Point | null): MouseEventParamsImpl {
+	private _getMouseEventParamsImpl(index: TimePointIndex | null, details: Point & PaneInfo | null): MouseEventParamsImpl {
 		const seriesPrices = new Map<Series, BarPrice | BarPrices>();
 		if (index !== null) {
 			const serieses = this._model.serieses();
@@ -612,19 +614,20 @@ export class ChartWidget implements IDestroyable {
 
 		return {
 			time: clientTime,
-			point: point || undefined,
+			point: details && { x: details.x, y: details.y } || undefined,
+			paneIndex: details?.paneIndex,
 			hoveredSeries,
 			seriesPrices,
 			hoveredObject,
 		};
 	}
 
-	private _onPaneWidgetClicked(time: TimePointIndex | null, point: Point): void {
-		this._clicked.fire(() => this._getMouseEventParamsImpl(time, point));
+	private _onPaneWidgetClicked(time: TimePointIndex | null, details: Point & PaneInfo): void {
+		this._clicked.fire(() => this._getMouseEventParamsImpl(time, details));
 	}
 
-	private _onPaneWidgetCrosshairMoved(time: TimePointIndex | null, point: Point | null): void {
-		this._crosshairMoved.fire(() => this._getMouseEventParamsImpl(time, point));
+	private _onPaneWidgetCrosshairMoved(time: TimePointIndex | null, details: Point & PaneInfo | null): void {
+		this._crosshairMoved.fire(() => this._getMouseEventParamsImpl(time, details));
 	}
 
 	private _updateTimeAxisVisibility(): void {

--- a/src/gui/pane-separator.ts
+++ b/src/gui/pane-separator.ts
@@ -1,9 +1,8 @@
-import { Delegate } from '../helpers/delegate';
 import { IDestroyable } from '../helpers/idestroyable';
 import { clamp } from '../helpers/mathex';
 
 import { createPreconfiguredCanvas, getContext2D, Size } from './canvas-utils';
-import { ChartWidget, PaneEventParamsImplSupplier } from './chart-widget';
+import { ChartWidget } from './chart-widget';
 import { MouseEventHandler, MouseEventHandlers, TouchMouseEvent } from './mouse-event-handler';
 import { PaneWidget } from './pane-widget';
 
@@ -18,11 +17,6 @@ export class PaneSeparator implements IDestroyable {
 	private readonly _paneA: PaneWidget;
 	private readonly _paneB: PaneWidget;
 
-	private readonly _topPaneIndex: number;
-	private readonly _bottomPaneIndex: number;
-
-	private readonly _resizeDelegate: Delegate<PaneEventParamsImplSupplier>;
-
 	private _startY: number = 0;
 	private _deltaY: number = 0;
 	private _totalHeight: number = 0;
@@ -32,16 +26,14 @@ export class PaneSeparator implements IDestroyable {
 	private _pixelStretchFactor: number = 0;
 	private _mouseActive: boolean = false;
 
-	public constructor(chartWidget: ChartWidget, topPaneIndex: number, bottomPaneIndex: number, disableResize: boolean, resizeDelegate: Delegate<PaneEventParamsImplSupplier>) {
+	public constructor(chartWidget: ChartWidget, topPaneIndex: number, bottomPaneIndex: number, disableResize: boolean) {
 		this._chartWidget = chartWidget;
 		this._paneA = chartWidget.paneWidgets()[topPaneIndex];
 		this._paneB = chartWidget.paneWidgets()[bottomPaneIndex];
 
 		this._rowElement = document.createElement('tr');
 		this._rowElement.style.height = SEPARATOR_HEIGHT + 'px';
-		this._topPaneIndex = topPaneIndex;
-		this._bottomPaneIndex = bottomPaneIndex;
-		this._resizeDelegate = resizeDelegate;
+
 		this._cell = document.createElement('td');
 		this._cell.style.position = 'relative';
 		this._cell.style.padding = '0';
@@ -124,7 +116,6 @@ export class PaneSeparator implements IDestroyable {
 			this._handle.style.backgroundColor = '';
 		}
 	}
-
 	private _mouseDownEvent(event: TouchMouseEvent): void {
 		this._startY = event.pageY;
 		this._deltaY = 0;
@@ -150,16 +141,6 @@ export class PaneSeparator implements IDestroyable {
 			this._startY = event.pageY;
 		}
 		this._chartWidget.model().fullUpdate();
-		this._resizeDelegate.fire(() => ({
-			top: {
-				index: this._topPaneIndex,
-				height: this._paneA.getSize().h,
-			},
-			bottom: {
-				index: this._bottomPaneIndex,
-				height: this._paneB.getSize().h,
-			},
-		}));
 	}
 
 	private _mouseUpEvent(event: TouchMouseEvent): void {

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -611,7 +611,7 @@ export class PaneWidget implements IDestroyable {
 	private _drawGrid(ctx: CanvasRenderingContext2D, pixelRatio: number): void {
 		const state = ensureNotNull(this._state);
 		const paneView = state.grid().paneView();
-		const renderer = paneView.renderer(state.height(), state.width());
+		const renderer = paneView.renderer(state.height(), state.width(), state);
 
 		if (renderer !== null) {
 			ctx.save();
@@ -661,7 +661,7 @@ export class PaneWidget implements IDestroyable {
 			: undefined;
 
 		for (const paneView of paneViews) {
-			const renderer = paneView.renderer(height, width);
+			const renderer = paneView.renderer(height, width, state);
 			if (renderer !== null) {
 				ctx.save();
 				drawFn(renderer, ctx, pixelRatio, isHovered, objecId);
@@ -671,8 +671,9 @@ export class PaneWidget implements IDestroyable {
 	}
 
 	private _hitTestPaneView(paneViews: readonly IPaneView[], x: Coordinate, y: Coordinate): HitTestPaneViewResult | null {
+		const state = ensureNotNull(this._state);
 		for (const paneView of paneViews) {
-			const renderer = paneView.renderer(this._size.h, this._size.w);
+			const renderer = paneView.renderer(this._size.h, this._size.w, state);
 			if (renderer !== null && renderer.hitTest) {
 				const result = renderer.hitTest(x, y);
 				if (result !== null) {

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -582,6 +582,10 @@ export class PaneWidget implements IDestroyable {
 		return this._leftPriceAxisWidget;
 	}
 
+	public getPaneCell(): HTMLElement {
+		return this._paneCell;
+	}
+
 	public rightPriceAxisWidget(): PriceAxisWidget | null {
 		return this._rightPriceAxisWidget;
 	}

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -11,7 +11,7 @@ import { Coordinate } from '../model/coordinate';
 import { IDataSource } from '../model/idata-source';
 import { InvalidationLevel } from '../model/invalidate-mask';
 import { IPriceDataSource } from '../model/iprice-data-source';
-import { Pane } from '../model/pane';
+import { Pane, PaneInfo } from '../model/pane';
 import { Point } from '../model/point';
 import { TimePointIndex } from '../model/time-data';
 import { IPaneRenderer } from '../renderers/ipane-renderer';
@@ -89,7 +89,7 @@ export class PaneWidget implements IDestroyable {
 	private readonly _mouseEventHandler: MouseEventHandler;
 	private _startScrollingPos: StartScrollPosition | null = null;
 	private _isScrolling: boolean = false;
-	private _clicked: Delegate<TimePointIndex | null, Point> = new Delegate();
+	private _clicked: Delegate<TimePointIndex | null, Point & PaneInfo> = new Delegate();
 	private _prevPinchScale: number = 0;
 	private _longTap: boolean = false;
 	private _startTrackPoint: Point | null = null;
@@ -320,7 +320,8 @@ export class PaneWidget implements IDestroyable {
 
 		if (this._clicked.hasListeners()) {
 			const currentTime = this._model().crosshairSource().appliedIndex();
-			this._clicked.fire(currentTime, { x, y });
+			const paneIndex = this._model().getPaneIndex(ensureNotNull(this._state));
+			this._clicked.fire(currentTime, { x, y, paneIndex });
 		}
 
 		this._tryExitTrackingMode();

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -19,7 +19,7 @@ import { IPriceDataSource } from './iprice-data-source';
 import { ColorType, LayoutOptions, LayoutOptionsInternal } from './layout-options';
 import { LocalizationOptions } from './localization-options';
 import { Magnet } from './magnet';
-import { DEFAULT_STRETCH_FACTOR, Pane } from './pane';
+import { DEFAULT_STRETCH_FACTOR, Pane, PaneInfo } from './pane';
 import { Point } from './point';
 import { PriceScale, PriceScaleOptions } from './price-scale';
 import { Series, SeriesOptionsInternal } from './series';
@@ -151,6 +151,7 @@ export class ChartModel implements IDestroyable {
 
 	private readonly _timeScale: TimeScale;
 	private readonly _panes: Pane[] = [];
+	private readonly _panesToIndex: Map<Pane, number> = new Map<Pane, number>();
 	private readonly _crosshair: Crosshair;
 	private readonly _magnet: Magnet;
 	private readonly _watermark: Watermark;
@@ -161,7 +162,7 @@ export class ChartModel implements IDestroyable {
 	private _initialTimeScrollPos: number | null = null;
 	private _hoveredSource: HoveredSource | null = null;
 	private readonly _priceScalesOptionsChanged: Delegate = new Delegate();
-	private _crosshairMoved: Delegate<TimePointIndex | null, Point | null> = new Delegate();
+	private _crosshairMoved: Delegate<TimePointIndex | null, Point & PaneInfo | null> = new Delegate();
 
 	private _suppressSeriesMoving: boolean = false;
 
@@ -290,7 +291,7 @@ export class ChartModel implements IDestroyable {
 		return this._crosshair;
 	}
 
-	public crosshairMoved(): ISubscription<TimePointIndex | null, Point | null> {
+	public crosshairMoved(): ISubscription<TimePointIndex | null, (Point & PaneInfo) | null> {
 		return this._crosshairMoved;
 	}
 
@@ -328,6 +329,7 @@ export class ChartModel implements IDestroyable {
 
 		const actualIndex = (index === undefined) ? this._panes.length - 1 : index;
 
+		this._buildPaneIndexMapping();
 		// we always do autoscaling on the creation
 		// if autoscale option is true, it is ok, just recalculate by invalidation mask
 		// if autoscale option is false, autoscale anyway on the first draw
@@ -338,7 +340,6 @@ export class ChartModel implements IDestroyable {
 			autoScale: true,
 		});
 		this._invalidate(mask);
-
 		return pane;
 	}
 
@@ -370,7 +371,7 @@ export class ChartModel implements IDestroyable {
 
 		this._panes.splice(index, 1);
 		this._suppressSeriesMoving = false;
-
+		this._buildPaneIndexMapping();
 		const mask = new InvalidateMask(InvalidationLevel.Full);
 		this._invalidate(mask);
 	}
@@ -395,6 +396,7 @@ export class ChartModel implements IDestroyable {
 		this._panes[second] = firstPane;
 
 		this._suppressSeriesMoving = false;
+		this._buildPaneIndexMapping();
 		this._invalidate(new InvalidateMask(InvalidationLevel.Full));
 	}
 
@@ -530,7 +532,8 @@ export class ChartModel implements IDestroyable {
 		this._crosshair.setPosition(index, price, pane);
 
 		this.cursorUpdate();
-		this._crosshairMoved.fire(this._crosshair.appliedIndex(), { x, y });
+		const paneIndex = this.getPaneIndex(pane);
+		this._crosshairMoved.fire(this._crosshair.appliedIndex(), { x, y, paneIndex });
 	}
 
 	public clearCurrentPosition(): void {
@@ -762,6 +765,10 @@ export class ChartModel implements IDestroyable {
 		return result;
 	}
 
+	public getPaneIndex(pane: Pane): number {
+		return this._panesToIndex.get(pane) ?? 0;
+	}
+
 	private _paneInvalidationMask(pane: Pane | null, level: InvalidationLevel): InvalidateMask {
 		const inv = new InvalidateMask(level);
 		if (pane !== null) {
@@ -817,5 +824,12 @@ export class ChartModel implements IDestroyable {
 		}
 
 		return layoutOptions.background.color;
+	}
+
+	private _buildPaneIndexMapping(): void {
+		this._panesToIndex.clear();
+		for (let i = 0; i < this._panes.length; i++) {
+			this._panesToIndex.set(this._panes[i], i);
+		}
 	}
 }

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -83,6 +83,7 @@ type InvalidateHandler = (mask: InvalidateMask) => void;
 
 export type VisiblePriceScaleOptions = PriceScaleOptions;
 export type OverlayPriceScaleOptions = Omit<PriceScaleOptions, 'visible' | 'autoScale'>;
+
 /**
  * Structure describing options of the chart. Series options are to be set separately
  */
@@ -161,6 +162,8 @@ export class ChartModel implements IDestroyable {
 	private _hoveredSource: HoveredSource | null = null;
 	private readonly _priceScalesOptionsChanged: Delegate = new Delegate();
 	private _crosshairMoved: Delegate<TimePointIndex | null, Point | null> = new Delegate();
+
+	private _suppressSeriesMoving: boolean = false;
 
 	private _backgroundTopColor: string;
 	private _backgroundBottomColor: string;
@@ -304,6 +307,16 @@ export class ChartModel implements IDestroyable {
 	}
 
 	public createPane(index?: number): Pane {
+		if (index !== undefined) {
+			if (index > this._panes.length) {
+				for (let i = this._panes.length; i < index; i++) {
+					this.createPane(i);
+				}
+			} else if (index < this._panes.length) {
+				return this._panes[index];
+			}
+		}
+
 		const pane = new Pane(this._timeScale, this);
 
 		if (index !== undefined) {
@@ -327,6 +340,62 @@ export class ChartModel implements IDestroyable {
 		this._invalidate(mask);
 
 		return pane;
+	}
+
+	public removePane(index: number): void {
+		if (index === 0) {
+			// we don't support removing the first pane.
+			return;
+		}
+
+		const paneToRemove = this._panes[index];
+		paneToRemove.orderedSources().forEach((source: IPriceDataSource) => {
+			if (source instanceof Series) {
+				this.removeSeries(source);
+			}
+		});
+
+		this._suppressSeriesMoving = true;
+		if (index !== this._panes.length - 1) {
+			// this is not the last pane
+			for (let i = index + 1; i < this._panes.length; i++) {
+				const pane = this._panes[i];
+				pane.orderedSources().forEach((source: IPriceDataSource) => {
+					if (source instanceof Series) {
+						(source as Series).applyOptions({ pane: i - 1 });
+					}
+				});
+			}
+		}
+
+		this._panes.splice(index, 1);
+		this._suppressSeriesMoving = false;
+
+		const mask = new InvalidateMask(InvalidationLevel.Full);
+		this._invalidate(mask);
+	}
+
+	public swapPane(first: number, second: number): void {
+		const firstPane = this._panes[first];
+		const secondPane = this._panes[second];
+
+		this._suppressSeriesMoving = true;
+		firstPane.orderedSources().forEach((source: IPriceDataSource) => {
+			if (source instanceof Series) {
+				(source as Series).applyOptions({ pane: second });
+			}
+		});
+		secondPane.orderedSources().forEach((source: IPriceDataSource) => {
+			if (source instanceof Series) {
+				(source as Series).applyOptions({ pane: first });
+			}
+		});
+
+		this._panes[first] = secondPane;
+		this._panes[second] = firstPane;
+
+		this._suppressSeriesMoving = false;
+		this._invalidate(new InvalidateMask(InvalidationLevel.Full));
 	}
 
 	public startScalePrice(pane: Pane, priceScale: PriceScale, x: number): void {
@@ -554,7 +623,7 @@ export class ChartModel implements IDestroyable {
 
 	public createSeries<T extends SeriesType>(seriesType: T, options: SeriesOptionsMap[T]): Series<T> {
 		const paneIndex = options.pane || 0;
-		if (this._panes.length - 1 < paneIndex) {
+		if (this._panes.length - 1 <= paneIndex) {
 			this.createPane(paneIndex);
 		}
 		const pane = this._panes[paneIndex];
@@ -636,6 +705,22 @@ export class ChartModel implements IDestroyable {
 		return this._options.rightPriceScale.visible ? DefaultPriceScaleId.Right : DefaultPriceScaleId.Left;
 	}
 
+	public moveSeriesToPane(series: Series, fromPaneIndex: number, newPaneIndex: number): void {
+		if (newPaneIndex === fromPaneIndex || this._suppressSeriesMoving) {
+			// no change
+			return;
+		}
+
+		if (series.options().pane !== newPaneIndex) {
+			series.applyOptions({ pane: newPaneIndex });
+		}
+
+		const previousPane = this.paneForSource(series);
+		previousPane?.removeDataSource(series);
+		const newPane = this.createPane(newPaneIndex);
+		this._addSeriesToPane(series, newPane);
+	}
+
 	public backgroundBottomColor(): string {
 		return this._backgroundBottomColor;
 	}
@@ -706,16 +791,20 @@ export class ChartModel implements IDestroyable {
 
 	private _createSeries<T extends SeriesType>(options: SeriesOptionsInternal<T>, seriesType: T, pane: Pane): Series<T> {
 		const series = new Series<T>(this, options, seriesType);
+		this._addSeriesToPane(series, pane);
 
-		const targetScaleId = options.priceScaleId !== undefined ? options.priceScaleId : this.defaultVisiblePriceScaleId();
+		return series;
+	}
+
+	private _addSeriesToPane(series: Series, pane: Pane): void {
+		const priceScaleId = series.options().priceScaleId;
+		const targetScaleId: string = priceScaleId !== undefined ? priceScaleId : this.defaultVisiblePriceScaleId();
 		pane.addDataSource(series, targetScaleId);
 
 		if (!isDefaultPriceScale(targetScaleId)) {
 			// let's apply that options again to apply margins
-			series.applyOptions(options);
+			series.applyOptions(series.options());
 		}
-
-		return series;
 	}
 
 	private _getBackgroundColor(side: BackgroundColorSide): string {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -553,7 +553,11 @@ export class ChartModel implements IDestroyable {
 	}
 
 	public createSeries<T extends SeriesType>(seriesType: T, options: SeriesOptionsMap[T]): Series<T> {
-		const pane = this._panes[0];
+		const paneIndex = options.pane || 0;
+		if (this._panes.length - 1 < paneIndex) {
+			this.createPane(paneIndex);
+		}
+		const pane = this._panes[paneIndex];
 		const series = this._createSeries(options, seriesType, pane);
 		this._serieses.push(series);
 

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -109,7 +109,8 @@ export interface ChartOptions {
 	rightPriceScale: VisiblePriceScaleOptions;
 	/** Structure describing default price scale options for overlays */
 	overlayPriceScales: OverlayPriceScaleOptions;
-
+	/** Structure describing price scale options for non-primary pane */
+	nonPrimaryPriceScale: VisiblePriceScaleOptions;
 	/** Structure with time scale options */
 	timeScale: TimeScaleOptions;
 	/** Structure with crosshair options */
@@ -318,7 +319,9 @@ export class ChartModel implements IDestroyable {
 			}
 		}
 
-		const pane = new Pane(this._timeScale, this);
+		const actualIndex = (index === undefined) ? (this._panes.length - 1) + 1 : index;
+
+		const pane = new Pane(this._timeScale, this, actualIndex);
 
 		if (index !== undefined) {
 			this._panes.splice(index, 0, pane);
@@ -326,8 +329,6 @@ export class ChartModel implements IDestroyable {
 			// adding to the end - common case
 			this._panes.push(pane);
 		}
-
-		const actualIndex = (index === undefined) ? this._panes.length - 1 : index;
 
 		this._buildPaneIndexMapping();
 		// we always do autoscaling on the creation

--- a/src/model/default-price-scale.ts
+++ b/src/model/default-price-scale.ts
@@ -1,6 +1,7 @@
 export const enum DefaultPriceScaleId {
 	Left = 'left',
 	Right = 'right',
+	NonPrimary = 'non-primary',
 }
 
 export function isDefaultPriceScale(priceScaleId: string): boolean {

--- a/src/model/pane.ts
+++ b/src/model/pane.ts
@@ -45,7 +45,7 @@ export class Pane implements IDestroyable {
 	private _leftPriceScale: PriceScale;
 	private _rightPriceScale: PriceScale;
 
-	public constructor(timeScale: TimeScale, model: ChartModel) {
+	public constructor(timeScale: TimeScale, model: ChartModel, initialPaneIndex: number = 0) {
 		this._timeScale = timeScale;
 		this._model = model;
 		this._grid = new Grid(this);
@@ -53,10 +53,14 @@ export class Pane implements IDestroyable {
 		const options = model.options();
 
 		this._leftPriceScale = this._createPriceScale(DefaultPriceScaleId.Left, options.leftPriceScale);
-		this._rightPriceScale = this._createPriceScale(DefaultPriceScaleId.Right, options.rightPriceScale);
+		if (initialPaneIndex === 0) {
+			this._rightPriceScale = this._createPriceScale(DefaultPriceScaleId.Right, options.rightPriceScale);
+		} else {
+			this._rightPriceScale = this._createPriceScale(DefaultPriceScaleId.NonPrimary, options.nonPrimaryPriceScale);
+		}
 
 		this._leftPriceScale.modeChanged().subscribe(this._onPriceScaleModeChanged.bind(this, this._leftPriceScale), this);
-		this._rightPriceScale.modeChanged().subscribe(this._onPriceScaleModeChanged.bind(this, this._leftPriceScale), this);
+		this._rightPriceScale.modeChanged().subscribe(this._onPriceScaleModeChanged.bind(this, this._rightPriceScale), this);
 
 		this.applyScaleOptions(options);
 	}
@@ -65,9 +69,15 @@ export class Pane implements IDestroyable {
 		if (options.leftPriceScale) {
 			this._leftPriceScale.applyOptions(options.leftPriceScale);
 		}
-		if (options.rightPriceScale) {
+
+		if (this._rightPriceScale.id() === DefaultPriceScaleId.Right && options.rightPriceScale) {
 			this._rightPriceScale.applyOptions(options.rightPriceScale);
 		}
+
+		if (this._rightPriceScale.id() === DefaultPriceScaleId.NonPrimary && options.nonPrimaryPriceScale) {
+			this._rightPriceScale.applyOptions(options.nonPrimaryPriceScale);
+		}
+
 		if (options.localization) {
 			this._leftPriceScale.updateFormatter();
 			this._rightPriceScale.updateFormatter();

--- a/src/model/pane.ts
+++ b/src/model/pane.ts
@@ -23,6 +23,10 @@ interface MinMaxOrderInfo {
 	maxZOrder: number;
 }
 
+export interface PaneInfo {
+	paneIndex?: number;
+}
+
 export class Pane implements IDestroyable {
 	private readonly _timeScale: TimeScale;
 	private readonly _model: ChartModel;

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -230,6 +230,8 @@ export interface SeriesOptionsCommon {
 	overlay?: boolean;
 	/** @deprecated Use priceScale method of the series to apply options instead */
 	scaleMargins?: PriceScaleMargins;
+	/** Panel this series to be added */
+	pane?: number;
 }
 
 export type SeriesOptions<T> = T & SeriesOptionsCommon;

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -5,7 +5,7 @@ import { VolumeFormatter } from '../formatters/volume-formatter';
 
 import { ensureNotNull } from '../helpers/assertions';
 import { IDestroyable } from '../helpers/idestroyable';
-import { isInteger, merge } from '../helpers/strict-type-checks';
+import { DeepPartial, isInteger, merge } from '../helpers/strict-type-checks';
 
 import { SeriesAreaPaneView } from '../views/pane/area-pane-view';
 import { SeriesBarsPaneView } from '../views/pane/bars-pane-view';
@@ -43,6 +43,7 @@ import {
 	AreaStyleOptions,
 	HistogramStyleOptions,
 	LineStyleOptions,
+	SeriesOptionsCommon,
 	SeriesOptionsMap,
 	SeriesPartialOptionsMap,
 	SeriesType,
@@ -226,12 +227,13 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 		return this._options as SeriesOptionsMap[T];
 	}
 
-	public applyOptions(options: SeriesPartialOptionsInternal<T>): void {
+	public applyOptions(options: SeriesPartialOptionsInternal<T> | DeepPartial<SeriesOptionsCommon>): void {
 		const targetPriceScaleId = options.priceScaleId;
 		if (targetPriceScaleId !== undefined && targetPriceScaleId !== this._options.priceScaleId) {
 			// series cannot do it itself, ask model
 			this.model().moveSeriesToScale(this, targetPriceScaleId);
 		}
+		const previousPaneIndex = this._options.pane ?? 0;
 		merge(this._options, options);
 
 		// eslint-disable-next-line deprecation/deprecation
@@ -244,6 +246,10 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 
 		if (options.priceFormat !== undefined) {
 			this._recreateFormatter();
+		}
+
+		if (options.pane && previousPaneIndex !== options.pane) {
+			this.model().moveSeriesToPane(this, previousPaneIndex, options.pane);
 		}
 
 		this.model().updateSource(this);

--- a/src/views/pane/crosshair-marks-pane-view.ts
+++ b/src/views/pane/crosshair-marks-pane-view.ts
@@ -4,6 +4,8 @@ import { BarPrice } from '../../model/bar';
 import { ChartModel } from '../../model/chart-model';
 import { Coordinate } from '../../model/coordinate';
 import { Crosshair } from '../../model/crosshair';
+import { IPriceDataSource } from '../../model/iprice-data-source';
+import { Pane } from '../../model/pane';
 import { Series } from '../../model/series';
 import { SeriesItemsIndexesRange, TimePointIndex } from '../../model/time-data';
 import { CompositeRenderer } from '../../renderers/composite-renderer';
@@ -35,7 +37,7 @@ export class CrosshairMarksPaneView implements IUpdatablePaneView {
 	private readonly _compositeRenderer: CompositeRenderer = new CompositeRenderer();
 	private _markersRenderers: PaneRendererMarks[] = [];
 	private _markersData: MarksRendererData[] = [];
-	private _invalidated: boolean = true;
+	private _validated: Map<Pane, PaneRendererMarks[]> = new Map();
 
 	public constructor(chartModel: ChartModel, crosshair: Crosshair) {
 		this._chartModel = chartModel;
@@ -55,41 +57,51 @@ export class CrosshairMarksPaneView implements IUpdatablePaneView {
 			this._compositeRenderer.setRenderers(this._markersRenderers);
 		}
 
-		this._invalidated = true;
+		this._validated.clear();
 	}
 
-	public renderer(height: number, width: number, addAnchors?: boolean): IPaneRenderer | null {
-		if (this._invalidated) {
-			this._updateImpl(height);
-			this._invalidated = false;
+	public renderer(height: number, width: number, pane: Pane, addAnchors?: boolean): IPaneRenderer | null {
+		let renderers = this._validated.get(pane);
+		if (!renderers) {
+			renderers = this._updateImpl(pane, height);
+			this._validated.set(pane, renderers);
+			const compositeRenderer = new CompositeRenderer();
+			compositeRenderer.setRenderers(renderers);
+			return compositeRenderer;
 		}
 
-		return this._compositeRenderer;
+		const compositeRenderer = new CompositeRenderer();
+		compositeRenderer.setRenderers(renderers);
+		return compositeRenderer;
+		// return this._compositeRenderer;
 	}
 
-	private _updateImpl(height: number): void {
-		const serieses = this._chartModel.serieses();
+	private _updateImpl(pane: Pane, height: number): PaneRendererMarks[] {
+		const serieses = this._chartModel.serieses()
+			.map((datasource: IPriceDataSource, index: number): [Series, number] => [datasource as Series, index])
+			.filter((entry: [IPriceDataSource, number]) => pane.dataSources().includes(entry[0]));
+
 		const timePointIndex = this._crosshair.appliedIndex();
 		const timeScale = this._chartModel.timeScale();
 
-		serieses.forEach((s: Series, index: number) => {
+		return serieses.map(([s, index]: [Series, number]) => {
 			const data = this._markersData[index];
 			const seriesData = s.markerDataAtIndex(timePointIndex);
 
 			if (seriesData === null || !s.visible()) {
 				data.visibleRange = null;
-				return;
+			} else {
+				const firstValue = ensureNotNull(s.firstValue());
+				data.lineColor = seriesData.backgroundColor;
+				data.backColor = seriesData.borderColor ?? this._chartModel.backgroundColorAtYPercentFromTop(data.items[0].y / height);
+				data.radius = seriesData.radius;
+				data.items[0].price = seriesData.price;
+				data.items[0].y = s.priceScale().priceToCoordinate(seriesData.price, firstValue.value);data.backColor = seriesData.borderColor ?? this._chartModel.backgroundColorAtYPercentFromTop(data.items[0].y / height);
+				data.items[0].time = timePointIndex;
+				data.items[0].x = timeScale.indexToCoordinate(timePointIndex);
+				data.visibleRange = rangeForSinglePoint;
 			}
-
-			const firstValue = ensureNotNull(s.firstValue());
-			data.lineColor = seriesData.backgroundColor;
-			data.radius = seriesData.radius;
-			data.items[0].price = seriesData.price;
-			data.items[0].y = s.priceScale().priceToCoordinate(seriesData.price, firstValue.value);
-			data.backColor = seriesData.borderColor ?? this._chartModel.backgroundColorAtYPercentFromTop(data.items[0].y / height);
-			data.items[0].time = timePointIndex;
-			data.items[0].x = timeScale.indexToCoordinate(timePointIndex);
-			data.visibleRange = rangeForSinglePoint;
+			return this._markersRenderers[index];
 		});
 	}
 }

--- a/src/views/pane/crosshair-marks-pane-view.ts
+++ b/src/views/pane/crosshair-marks-pane-view.ts
@@ -93,10 +93,10 @@ export class CrosshairMarksPaneView implements IUpdatablePaneView {
 			} else {
 				const firstValue = ensureNotNull(s.firstValue());
 				data.lineColor = seriesData.backgroundColor;
-				data.backColor = seriesData.borderColor ?? this._chartModel.backgroundColorAtYPercentFromTop(data.items[0].y / height);
 				data.radius = seriesData.radius;
 				data.items[0].price = seriesData.price;
-				data.items[0].y = s.priceScale().priceToCoordinate(seriesData.price, firstValue.value);data.backColor = seriesData.borderColor ?? this._chartModel.backgroundColorAtYPercentFromTop(data.items[0].y / height);
+				data.items[0].y = s.priceScale().priceToCoordinate(seriesData.price, firstValue.value);
+				data.backColor = seriesData.borderColor ?? this._chartModel.backgroundColorAtYPercentFromTop(data.items[0].y / height);
 				data.items[0].time = timePointIndex;
 				data.items[0].x = timeScale.indexToCoordinate(timePointIndex);
 				data.visibleRange = rangeForSinglePoint;

--- a/src/views/pane/ipane-view.ts
+++ b/src/views/pane/ipane-view.ts
@@ -1,8 +1,9 @@
 import { Coordinate } from '../../model/coordinate';
+import { Pane } from '../../model/pane';
 import { IPaneRenderer } from '../../renderers/ipane-renderer';
 
 export interface IPaneView {
-	renderer(height: number, width: number, addAnchors?: boolean): IPaneRenderer | null;
+	renderer(height: number, width: number, pane: Pane, addAnchors?: boolean): IPaneRenderer | null;
 	clickHandler?(x: Coordinate, y: Coordinate): void;
 	moveHandler?(x: Coordinate, y: Coordinate): void;
 }

--- a/src/views/pane/series-markers-pane-view.ts
+++ b/src/views/pane/series-markers-pane-view.ts
@@ -5,6 +5,7 @@ import { AutoScaleMargins } from '../../model/autoscale-info-impl';
 import { BarPrice, BarPrices } from '../../model/bar';
 import { ChartModel } from '../../model/chart-model';
 import { Coordinate } from '../../model/coordinate';
+import { Pane } from '../../model/pane';
 import { PriceScale } from '../../model/price-scale';
 import { Series } from '../../model/series';
 import { InternalSeriesMarker, SeriesMarker } from '../../model/series-markers';
@@ -113,7 +114,7 @@ export class SeriesMarkersPaneView implements IUpdatablePaneView {
 		}
 	}
 
-	public renderer(height: number, width: number, addAnchors?: boolean): IPaneRenderer | null {
+	public renderer(height: number, width: number, pane: Pane, addAnchors?: boolean): IPaneRenderer | null {
 		if (!this._series.visible()) {
 			return null;
 		}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue: fixes #50 
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**
This is base on the pane widget and pane separator feature previously implemented in 22c6b03897c926cb9a0295d9b0bbc4fe2b5d83a5.

**Is there anything you'd like reviewers to focus on?**
API design. New API added so far (To be finalized) 

Things I have implemented so far:

- series option to configure which pane a series should be rendered ( pane: number to SeriesOptionsCommon )
- `ChartApi#removePane(index: number)` so that you can remove a pane (and series on it) programmatically.
- `ChartApi#swapPane(first: number, second: number)` for swapping the positions of the two pane.
- code to handle series.applyOptions( { pane: newIndex } );
- `ChartApi#getPaneElements()` for getting container elements to each pane. (I need the container to draw legends to each pane)

Things I am also implementing but not going to be included in this PR:

- React binding with pane and legend supports

Demo here (It maybe outdated): https://jsfiddle.net/adrianntf/6qea5ytv/2/

You can use below command to install my version to your project locally:

`yarn add git+https://github.com/ntf/lightweight-charts.git`
or `npm install git+https://github.com/ntf/lightweight-charts.git`

You should not use this directly in your production environment. However, you may review my code and merge into your own folk of the project.
