### PR TITLE
Set visible range with percent right margin

### DIFF
--- a/docs/time-scale.md
+++ b/docs/time-scale.md
@@ -102,13 +102,24 @@ chart.timeScale().getVisibleRange();
 
 ### setVisibleRange()
 
-Sets visible time range of the chart. The argument is an object with the first and last time points of a desired time range.
+Sets visible time range of the chart. It has the following arguments:
+
+`range` - an object with the first and last time points of a desired time range.
+
+`options` - an optional object that for now has only one field:
+
+* `percentRightMargin`: indicates whether the library should apply the percent right margin to the right border if it points on the last bar.
 
 ```js
-chart.timeScale().setVisibleRange({
-    from: (new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0))).getTime() / 1000,
-    to: (new Date(Date.UTC(2018, 1, 1, 0, 0, 0, 0))).getTime() / 1000,
-});
+chart.timeScale().setVisibleRange(
+    {
+        from: (new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0))).getTime() / 1000,
+        to: (new Date(Date.UTC(2018, 1, 1, 0, 0, 0, 0))).getTime() / 1000,
+    },
+    {
+        percentRightMargin: 10,
+    }
+);
 ```
 
 ### getVisibleLogicalRange
@@ -121,14 +132,24 @@ chart.timeScale().getVisibleLogicalRange();
 
 ### setVisibleLogicalRange
 
-Sets visible [logical range](#logical-range) of the chart.
-The argument is an object with the first and last time points of a desired logical range.
+Sets visible [logical range](#logical-range) of the chart. It has the following arguments:
+
+`range` - an object with the first and last time points of a desired logical range.
+
+`options` - an optional object that for now has only one field:
+
+* `percentRightMargin`: indicates whether the library should apply the percent right margin to the right border if it points on the last bar.
 
 ```js
-chart.timeScale().setVisibleLogicalRange({
-    from: 0,
-    to: 10,
-});
+chart.timeScale().setVisibleLogicalRange(
+    {
+        from: 0,
+        to: 10,
+    },
+    {
+        percentRightMargin: 10,
+    }
+);
 ```
 
 ### resetTimeScale()
@@ -217,8 +238,8 @@ The argument is a handler function, which will be called with the new visible ti
 
 The argument passed to your handler is the new visible time range, which might be either:
 
-- an object with properties `from` and `to` of type [Time](./time.md), that are the first and last visible time points, respectively
-- `null` if nothing is visible or the chart has no data at all
+* an object with properties `from` and `to` of type [Time](./time.md), that are the first and last visible time points, respectively
+* `null` if nothing is visible or the chart has no data at all
 
 ```js
 function onVisibleTimeRangeChanged(newVisibleTimeRange) {
@@ -244,8 +265,8 @@ The argument is a handler function, which will be called with the new visible lo
 
 The argument passed to your handler is the new visible logical range, which might be either:
 
-- an object with numerical properties `from` and `to` of type number (see [Logical range](#logical-range) section), that are the first and last visible logical indexes, respectively
-- `null` if the chart has no data at all
+* an object with numerical properties `from` and `to` of type number (see [Logical range](#logical-range) section), that are the first and last visible logical indexes, respectively
+*`null` if the chart has no data at all
 
 ```js
 function onVisibleLogicalRangeChanged(newVisibleLogicalRange) {

--- a/src/api/itime-scale-api.ts
+++ b/src/api/itime-scale-api.ts
@@ -8,6 +8,10 @@ import { Time } from './data-consumer';
 
 export type TimeRange = Range<Time>;
 
+export interface SetVisibleRangeOptions {
+	percentRightMargin: number;
+}
+
 export type TimeRangeChangeEventHandler = (timeRange: TimeRange | null) => void;
 export type LogicalRangeChangeEventHandler = (logicalRange: LogicalRange | null) => void;
 
@@ -44,8 +48,9 @@ export interface ITimeScaleApi {
 	 * Sets visible range of data
 	 *
 	 * @param range - target visible range of data
+	 * @param options
 	 */
-	setVisibleRange(range: TimeRange): void;
+	setVisibleRange(range: TimeRange, options?: Partial<SetVisibleRangeOptions>): void;
 
 	/**
 	 * Returns the currently visible logical range of data.
@@ -58,8 +63,9 @@ export interface ITimeScaleApi {
 	 * Sets visible logical range of data.
 	 *
 	 * @param range - target visible logical range of data.
+	 * @param options
 	 */
-	setVisibleLogicalRange(range: Range<number>): void;
+	setVisibleLogicalRange(range: Range<number>, options?: Partial<SetVisibleRangeOptions>): void;
 
 	/**
 	 * Restores default zooming and scroll position of the time scale

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -225,8 +225,8 @@ export class TimeScale {
 		const from = Math.round(range.from);
 		const to = Math.round(range.to);
 
-		const firstIndex = ensureNotNull(this._firstIndex());
-		const lastIndex = ensureNotNull(this._lastIndex());
+		const firstIndex = ensureNotNull(this.firstIndex());
+		const lastIndex = ensureNotNull(this.lastIndex());
 
 		return {
 			from: ensureNotNull(this.indexToTime(Math.max(firstIndex, from) as TimePointIndex) as TimePoint),
@@ -580,8 +580,8 @@ export class TimeScale {
 	}
 
 	public fitContent(): void {
-		const first = this._firstIndex();
-		const last = this._lastIndex();
+		const first = this.firstIndex();
+		const last = this.lastIndex();
 		if (first === null || last === null) {
 			return;
 		}
@@ -605,11 +605,11 @@ export class TimeScale {
 		return this._dateTimeFormatter.format(new Date(time.timestamp * 1000));
 	}
 
-	private _firstIndex(): TimePointIndex | null {
+	public firstIndex(): TimePointIndex | null {
 		return this._points.length === 0 ? null : 0 as TimePointIndex;
 	}
 
-	private _lastIndex(): TimePointIndex | null {
+	public lastIndex(): TimePointIndex | null {
 		return this._points.length === 0 ? null : (this._points.length - 1) as TimePointIndex;
 	}
 
@@ -706,7 +706,7 @@ export class TimeScale {
 	}
 
 	private _minRightOffset(): number | null {
-		const firstIndex = this._firstIndex();
+		const firstIndex = this.firstIndex();
 		const baseIndex = this._baseIndexOrNull;
 		if (firstIndex === null || baseIndex === null) {
 			return null;
@@ -826,7 +826,7 @@ export class TimeScale {
 			return;
 		}
 
-		const firstIndex = this._firstIndex();
+		const firstIndex = this.firstIndex();
 		if (firstIndex === null) {
 			return;
 		}

--- a/tests/e2e/graphics/test-cases/time-scale/set-visible-range-with-percent-right-margin.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-visible-range-with-percent-right-margin.js
@@ -1,0 +1,23 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 1000; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addLineSeries();
+
+	const data = generateData();
+	mainSeries.setData(data);
+	chart.timeScale().setVisibleRange({ from: data[0].time, to: data[data.length - 1].time }, { percentRightMargin: 10 });
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [x] Includes tests
- [x] Documentation update

**Overview of change:**

```js
chart.timeScale().setVisibleRange({ from, to }, { percentRightMargin: 10 });
```
