### PR TITLE
Fixed incorrect min bar spacing when there is no data on the time scale yet

### DIFF
--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -702,7 +702,7 @@ export class TimeScale {
 	private _minBarSpacing(): number {
 		// if both options are enabled then limit bar spacing so that zooming-out is not possible
 		// if it would cause either the first or last points to move too far from an edge
-		if (this._options.fixLeftEdge && this._options.fixRightEdge) {
+		if (this._options.fixLeftEdge && this._options.fixRightEdge && this._points.length !== 0) {
 			return this._width / this._points.length;
 		}
 

--- a/tests/e2e/graphics/test-cases/applying-options/fix-both-edges.js
+++ b/tests/e2e/graphics/test-cases/applying-options/fix-both-edges.js
@@ -1,0 +1,36 @@
+function generateBar(i, target) {
+	const step = (i % 20) / 1000;
+	const base = i;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		const item = {
+			time: time.getTime() / 1000,
+		};
+		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateBar(i, item);
+		res.push(item);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container, {
+		timeScale: {
+			fixLeftEdge: true,
+			fixRightEdge: true,
+		},
+	});
+
+	const mainSeries = chart.addCandlestickSeries();
+
+	mainSeries.setData(generateData());
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #823
- [x] Includes tests
- [ ] Documentation update
