### PR TITLE
Remove color customisation from settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,21 +4,5 @@
         "lib/**": true,
         "tests/e2e/graphics/.gendata/**": true
     },
-    "typescript.tsdk": "node_modules\\typescript\\lib",
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#1976d225",
-        "activityBar.background": "#131722",
-        "activityBar.dropBackground": "#262B3E",
-        "activityBar.foreground": "#1976D2",
-        "activityBar.inactiveForeground": "#1976D255",
-        "activityBarBadge.background": "#1E88E5",
-        "activityBarBadge.foreground": "#131722",
-        "statusBar.background": "#131722",
-        "statusBar.foreground": "#E1ECF2",
-        "statusBarItem.hoverBackground": "#2A2E39",
-        "titleBar.activeBackground": "#131722",
-        "titleBar.activeForeground": "#E1ECF2",
-        "titleBar.inactiveBackground": "#2A2E39",
-        "titleBar.inactiveForeground": "#787B86"
-    }
+    "typescript.tsdk": "node_modules\\typescript\\lib"
 }


### PR DESCRIPTION

**Type of PR:** enhancement

**Overview of change:**


1) The colors here are hard to see in certain lighting.
2) I don't think lightweight-charts should have an opinion about the theme of my VS Code workspace.

Every time I checkout the repo I end up removing these lines locally, and the accidentally committing them anyway. 😬 🎨

