### PR TITLE
Add GIT_USER to config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,8 @@ jobs:
     executor: node14-executor
     environment:
       USE_SSH: "true"
+      # We should be able to remove GIT_USER when we have upgraded to a Docusaurus version > 2.0.0-beta.9
+      GIT_USER: "tvrobot"
     steps:
       - checkout-with-deps
       - attach_workspace:


### PR DESCRIPTION
**Type of PR:** fix build

**PR checklist:**

- [x] Addresses an existing issue: fixes broken build https://app.circleci.com/pipelines/github/tradingview/lightweight-charts/1218/workflows/bb152e7b-0149-4659-9291-894f9c784824/jobs/14642
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

This variable shouldn't be required as we are using SSH to deploy, but it is a limitation of the current Docusaurus version.

We should be able to remove GIT_USER when we have upgraded to a Docusaurus version > 2.0.0-beta.9

