### PR TITLE
Fixed last price animation on setting new data

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,11 +4,11 @@ module.exports = [
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.esm.production.js',
-		limit: '43.3 KB',
+		limit: '43.4 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '43.9 KB',
+		limit: '44.0 KB',
 	},
 ];

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -360,7 +360,7 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 		const model = this._chartWidget.model();
 
 		model.updateTimeScale(update.timeScale.baseIndex, update.timeScale.points, update.timeScale.firstChangedPointIndex);
-		update.series.forEach((value: SeriesChanges, series: Series) => series.setData(value.data));
+		update.series.forEach((value: SeriesChanges, series: Series) => series.setData(value.data, value.info));
 
 		model.recalculateAllPanes();
 	}

--- a/src/api/data-layer.ts
+++ b/src/api/data-layer.ts
@@ -4,7 +4,7 @@ import { lowerbound } from '../helpers/algorithms';
 import { ensureNotNull } from '../helpers/assertions';
 import { isString } from '../helpers/strict-type-checks';
 
-import { Series } from '../model/series';
+import { Series, SeriesUpdateInfo } from '../model/series';
 import { SeriesPlotRow } from '../model/series-data';
 import { SeriesType } from '../model/series-options';
 import { BusinessDay, TimePoint, TimePointIndex, TimeScalePoint, UTCTimestamp } from '../model/time-data';
@@ -124,6 +124,10 @@ export interface SeriesChanges {
 	 * Data to be merged into series' plot list
 	 */
 	data: readonly SeriesPlotRow[];
+	/**
+	 * Additional info about this change
+	 */
+	info?: SeriesUpdateInfo;
 }
 
 export interface DataUpdateResponse {
@@ -155,6 +159,26 @@ function createEmptyTimePointData(timePoint: TimePoint): TimePointData {
 	return { index: 0 as TimePointIndex, mapping: new Map(), timePoint };
 }
 
+function seriesRowsLastTime(seriesRows: SeriesPlotRow[] | undefined): UTCTimestamp | undefined {
+	if (seriesRows === undefined) {
+		return undefined;
+	}
+
+	return seriesRows.length > 0 ? seriesRows[seriesRows.length - 1].time.timestamp : undefined;
+}
+
+function seriesUpdateInfo(seriesRows: SeriesPlotRow[] | undefined, prevSeriesRows: SeriesPlotRow[] | undefined): SeriesUpdateInfo | undefined {
+	const lastTime = seriesRowsLastTime(seriesRows);
+	if (lastTime !== undefined) {
+		const prevLastTime = seriesRowsLastTime(prevSeriesRows);
+		if (prevLastTime !== undefined && lastTime >= prevLastTime) {
+			return { lastBarUpdatedOrNewBarsAddedToTheRight: true };
+		}
+	}
+
+	return undefined;
+}
+
 export class DataLayer {
 	// note that _pointDataByTimePoint and _seriesRowsBySeries shares THE SAME objects in their values between each other
 	// it's just different kind of maps to make usages/perf better
@@ -177,7 +201,9 @@ export class DataLayer {
 
 		let isTimeScaleAffected = false;
 
-		if (this._seriesRowsBySeries.has(series)) {
+		// save previous series rows data before it's replaced inside this._setRowsToSeries
+		const prevSeriesRows = this._seriesRowsBySeries.get(series);
+		if (prevSeriesRows !== undefined) {
 			if (this._seriesRowsBySeries.size === 1) {
 				needCleanupPoints = false;
 				isTimeScaleAffected = true;
@@ -242,7 +268,11 @@ export class DataLayer {
 			firstChangedPointIndex = this._replaceTimeScalePoints(newTimeScalePoints);
 		}
 
-		return this._getUpdateResponse(series, firstChangedPointIndex);
+		return this._getUpdateResponse(
+			series,
+			firstChangedPointIndex,
+			seriesUpdateInfo(this._seriesRowsBySeries.get(series), prevSeriesRows)
+		);
 	}
 
 	public removeSeries(series: Series): DataUpdateResponse {
@@ -277,9 +307,11 @@ export class DataLayer {
 
 		this._updateLastSeriesRow(series, plotRow);
 
+		const info: SeriesUpdateInfo = { lastBarUpdatedOrNewBarsAddedToTheRight: true };
+
 		// if point already exist on the time scale - we don't need to make a full update and just make an incremental one
 		if (!affectsTimeScale) {
-			return this._getUpdateResponse(series, -1);
+			return this._getUpdateResponse(series, -1, info);
 		}
 
 		const newPoint: InternalTimeScalePoint = { timeWeight: 0, time: pointDataAtTime.timePoint, pointData: pointDataAtTime };
@@ -297,7 +329,7 @@ export class DataLayer {
 
 		fillWeightsForPoints(this._sortedTimePoints, insertIndex);
 
-		return this._getUpdateResponse(series, insertIndex);
+		return this._getUpdateResponse(series, insertIndex, info);
 	}
 
 	private _updateLastSeriesRow(series: Series, plotRow: SeriesPlotRow | WhitespacePlotRow): void {
@@ -411,7 +443,7 @@ export class DataLayer {
 		return baseIndex;
 	}
 
-	private _getUpdateResponse(updatedSeries: Series, firstChangedPointIndex: number): DataUpdateResponse {
+	private _getUpdateResponse(updatedSeries: Series, firstChangedPointIndex: number, info?: SeriesUpdateInfo): DataUpdateResponse {
 		const dataUpdateResponse: DataUpdateResponse = {
 			series: new Map(),
 			timeScale: {
@@ -423,14 +455,20 @@ export class DataLayer {
 			// TODO: it's possible to make perf improvements by checking what series has data after firstChangedPointIndex
 			// but let's skip for now
 			this._seriesRowsBySeries.forEach((data: SeriesPlotRow[], s: Series) => {
-				dataUpdateResponse.series.set(s, { data });
+				dataUpdateResponse.series.set(
+					s,
+					{
+						data,
+						info: s === updatedSeries ? info : undefined,
+					}
+				);
 			});
 
 			// if the series data was set to [] it will have already been removed from _seriesRowBySeries
 			// meaning the forEach above won't add the series to the data update response
 			// so we handle that case here
 			if (!this._seriesRowsBySeries.has(updatedSeries)) {
-				dataUpdateResponse.series.set(updatedSeries, { data: [] });
+				dataUpdateResponse.series.set(updatedSeries, { data: [], info });
 			}
 
 			dataUpdateResponse.timeScale.points = this._sortedTimePoints;
@@ -438,7 +476,7 @@ export class DataLayer {
 		} else {
 			const seriesData = this._seriesRowsBySeries.get(updatedSeries);
 			// if no seriesData found that means that we just removed the series
-			dataUpdateResponse.series.set(updatedSeries, { data: seriesData || [] });
+			dataUpdateResponse.series.set(updatedSeries, { data: seriesData || [], info });
 		}
 
 		return dataUpdateResponse;

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -85,6 +85,10 @@ export interface SeriesDataAtTypeMap {
 	Histogram: BarPrice;
 }
 
+export interface SeriesUpdateInfo {
+	lastBarUpdatedOrNewBarsAddedToTheRight: boolean;
+}
+
 // TODO: uncomment following strings after fixing typescript bug
 // https://github.com/microsoft/TypeScript/issues/36981
 // export type SeriesOptionsInternal<T extends SeriesType = SeriesType> = Omit<SeriesPartialOptionsMap[T], 'overlay'>;
@@ -239,10 +243,7 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 		this._paneView.update('options');
 	}
 
-	public setData(data: readonly SeriesPlotRow<T>[]): void {
-		const lastIndex = this._data.lastIndex();
-		const newRealtimeDataReceived = lastIndex !== null && data.length > 0 && data[data.length - 1].index >= lastIndex;
-
+	public setData(data: readonly SeriesPlotRow<T>[], updateInfo?: SeriesUpdateInfo): void {
 		this._data.setData(data);
 
 		this._recalculateMarkers();
@@ -250,12 +251,11 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 		this._paneView.update('data');
 		this._markersPaneView.update('data');
 
-		const lastPriceAnimationPaneView = this._lastPriceAnimationPaneView;
-		if (lastPriceAnimationPaneView !== null) {
-			if (newRealtimeDataReceived) {
-				lastPriceAnimationPaneView.onNewRealtimeDataReceived();
+		if (this._lastPriceAnimationPaneView !== null) {
+			if (updateInfo && updateInfo.lastBarUpdatedOrNewBarsAddedToTheRight) {
+				this._lastPriceAnimationPaneView.onNewRealtimeDataReceived();
 			} else if (data.length === 0) {
-				lastPriceAnimationPaneView.onDataCleared();
+				this._lastPriceAnimationPaneView.onDataCleared();
 			}
 		}
 

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-adding-whitespace.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-adding-whitespace.js
@@ -1,0 +1,18 @@
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const series = chart.addLineSeries({
+		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,
+	});
+	series.setData([
+		{ time: '1990-04-24', value: 0 },
+		{ time: '1990-04-25', value: 1 },
+		{ time: '1990-04-26', value: 2 },
+		{ time: '1990-04-28', value: 3 },
+	]);
+
+	series.update({ time: '1990-04-29' });
+	series.update({ time: '1990-04-29' });
+
+	return new Promise(resolve => setTimeout(resolve, 500));
+}

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data-after-reseting-data.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data-after-reseting-data.js
@@ -1,0 +1,23 @@
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const series = chart.addLineSeries({
+		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,
+	});
+	series.setData([
+		{ time: '1990-04-24', value: 0 },
+		{ time: '1990-04-25', value: 1 },
+		{ time: '1990-04-26', value: 2 },
+	]);
+
+	series.setData([]);
+
+	series.setData([
+		{ time: '1990-04-24', value: 0 },
+		{ time: '1990-04-25', value: 1 },
+		{ time: '1990-04-26', value: 2 },
+		{ time: '1990-04-28', value: 3 },
+	]);
+
+	return new Promise(resolve => setTimeout(resolve, 500));
+}

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data.js
@@ -1,0 +1,15 @@
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const series = chart.addLineSeries({
+		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,
+	});
+	series.setData([
+		{ time: '1990-04-24', value: 0 },
+		{ time: '1990-04-25', value: 1 },
+		{ time: '1990-04-26', value: 2 },
+		{ time: '1990-04-28', value: 3 },
+	]);
+
+	return new Promise(resolve => setTimeout(resolve, 500));
+}

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-loading-history-data.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-loading-history-data.js
@@ -1,0 +1,23 @@
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const series = chart.addLineSeries({
+		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,
+	});
+	series.setData([
+		{ time: '1990-04-24', value: 0 },
+		{ time: '1990-04-25', value: 1 },
+		{ time: '1990-04-26', value: 2 },
+		{ time: '1990-04-28', value: 3 },
+	]);
+
+	series.setData([
+		{ time: '1990-04-23', value: -1 },
+		{ time: '1990-04-24', value: 0 },
+		{ time: '1990-04-25', value: 1 },
+		{ time: '1990-04-26', value: 2 },
+		{ time: '1990-04-28', value: 3 },
+	]);
+
+	return new Promise(resolve => setTimeout(resolve, 500));
+}


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [x] Addresses an existing issue: fixes #886
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Fixed incorrect last price animation on first `setData` and adding new data to the left side
