### PR TITLE
Set CUSTOM_COMMIT_MESSAGE to skip CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ jobs:
       USE_SSH: "true"
       # We should be able to remove GIT_USER when we have upgraded to a Docusaurus version > 2.0.0-beta.9
       GIT_USER: "tvrobot"
+      CUSTOM_COMMIT_MESSAGE: "[skip ci] Deploy website"
     steps:
       - checkout-with-deps
       - attach_workspace:


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

Set the `CUSTOM_COMMIT_MESSAGE` to include "[skip ci]" so that we don't trigger CircleCI builds for pushes to `gh-pages` from the deploy job.
