### PR TITLE
Add Algolia DocSearch configuration

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,6 +116,13 @@ const config = {
 				theme: lightCodeTheme,
 				darkTheme: darkCodeTheme,
 			},
+			algolia: {
+				appId: 'BH4D9OD16A',
+				// Public API key: it is safe to commit it
+				apiKey: 'bd84607b54c71800365e661f500cad8e',
+				indexName: 'lightweight-charts',
+				contextualSearch: true,
+			},
 		}),
 
 	plugins: [

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.9",
     "@docusaurus/preset-classic": "2.0.0-beta.9",
+    "@docusaurus/theme-search-algolia": "2.0.0-beta.9",
     "@mdx-js/react": "~1.6.21",
     "@svgr/webpack": "~5.5.0",
     "clsx": "~1.1.1",


### PR DESCRIPTION
**Type of PR:** enhancement
**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

Now that we have been accepted by Algolia into their free DocSearch service (https://docsearch.algolia.com) these changes add the configuration needed to enable search on our docs website.

See https://docusaurus.io/docs/next/search#connecting-algolia for details about these configuration properties.

<!-- optional -->
