### PR TITLE
Disable Docusaurus blog and pages, use CIRCLE_SHA1 in commit message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       USE_SSH: "true"
       # We should be able to remove GIT_USER when we have upgraded to a Docusaurus version > 2.0.0-beta.9
       GIT_USER: "tvrobot"
-      CUSTOM_COMMIT_MESSAGE: "[skip ci] Deploy website"
+      CUSTOM_COMMIT_MESSAGE: "[skip ci] Deploy website based on $CIRCLE_SHA1"
     steps:
       - checkout-with-deps
       - attach_workspace:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -27,6 +27,8 @@ const config = {
 			'@docusaurus/preset-classic',
 			/** @type {import('@docusaurus/preset-classic').Options} */
 			({
+				blog: false,
+				pages: false,
 				docs: {
 					sidebarPath: require.resolve('./sidebars.js'),
 					routeBasePath: '/',


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

The built-in Docusaurus blog archive is being included in our builds. We don't want it so let's disable the blog, and pages too, so we're only using the "docs" features.

Also change the `CUSTOM_COMMIT_MESSAGE` used when pushing to the gh-pages branch to include the current commit hash.

<!-- optional -->
