### PR TITLE
fix: overlay align to the right when no left/right price scale defined

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -9,6 +9,6 @@ module.exports = [
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '44.0 KB',
+		limit: '44.01 KB',
 	},
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -9,6 +9,6 @@ module.exports = [
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '44.01 KB',
+		limit: '44.05 KB',
 	},
 ];

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -480,7 +480,7 @@ export class PriceAxisWidget implements IDestroyable {
 		const rendererOptions = this.rendererOptions();
 
 		// if we are default price scale, append labels from no-scale
-		const isDefault = this._priceScale === paneState.defaultPriceScale();
+		const isDefault = this._priceScale === paneState.defaultVisiblePriceScale();
 
 		if (isDefault) {
 			this._pane.state().orderedSources().forEach((source: IPriceDataSource) => {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -385,6 +385,18 @@ export class ChartModel implements IDestroyable {
 	}
 
 	public applyPriceScaleOptions(priceScaleId: string, options: DeepPartial<PriceScaleOptions>): void {
+		if (priceScaleId === DefaultPriceScaleId.Left) {
+			this.applyOptions({
+				leftPriceScale: options,
+			});
+			return;
+		} else if (priceScaleId === DefaultPriceScaleId.Right) {
+			this.applyOptions({
+				rightPriceScale: options,
+			});
+			return;
+		}
+
 		const res = this.findPriceScale(priceScaleId);
 
 		if (res === null) {
@@ -394,18 +406,9 @@ export class ChartModel implements IDestroyable {
 
 			return;
 		}
-		if (priceScaleId === 'left') {
-			this.applyOptions({
-				leftPriceScale: options,
-			});
-		} else if (priceScaleId === 'right') {
-			this.applyOptions({
-				rightPriceScale: options,
-			});
-		} else {
-			res.priceScale.applyOptions(options);
-			this._priceScalesOptionsChanged.fire();
-		}
+
+		res.priceScale.applyOptions(options);
+		this._priceScalesOptionsChanged.fire();
 	}
 
 	public findPriceScale(priceScaleId: string): PriceScaleOnPane | null {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -394,9 +394,18 @@ export class ChartModel implements IDestroyable {
 
 			return;
 		}
-
-		res.priceScale.applyOptions(options);
-		this._priceScalesOptionsChanged.fire();
+		if (priceScaleId === 'left') {
+			this.applyOptions({
+				leftPriceScale: options,
+			});
+		} else if (priceScaleId === 'right') {
+			this.applyOptions({
+				rightPriceScale: options,
+			});
+		} else {
+			res.priceScale.applyOptions(options);
+			this._priceScalesOptionsChanged.fire();
+		}
 	}
 
 	public findPriceScale(priceScaleId: string): PriceScaleOnPane | null {

--- a/src/model/pane.ts
+++ b/src/model/pane.ts
@@ -274,6 +274,17 @@ export class Pane implements IDestroyable {
 		return priceScale;
 	}
 
+	public defaultVisiblePriceScalePosition(): Exclude<PriceScalePosition, 'overlay'> | null {
+		let priceScalePosition: Exclude<PriceScalePosition, 'overlay'> | null = null;
+
+		if (this._model.options().rightPriceScale.visible) {
+			priceScalePosition = 'right';
+		} else if (this._model.options().leftPriceScale.visible) {
+			priceScalePosition = 'left';
+		}
+		return priceScalePosition;
+	}
+
 	public recalculatePriceScale(priceScale: PriceScale | null): void {
 		if (priceScale === null || !priceScale.isAutoScale()) {
 			return;

--- a/src/model/pane.ts
+++ b/src/model/pane.ts
@@ -274,15 +274,15 @@ export class Pane implements IDestroyable {
 		return priceScale;
 	}
 
-	public defaultVisiblePriceScalePosition(): Exclude<PriceScalePosition, 'overlay'> | null {
-		let priceScalePosition: Exclude<PriceScalePosition, 'overlay'> | null = null;
+	public defaultVisiblePriceScale(): PriceScale | null {
+		let priceScale: PriceScale | null = null;
 
 		if (this._model.options().rightPriceScale.visible) {
-			priceScalePosition = 'right';
+			priceScale = this._rightPriceScale;
 		} else if (this._model.options().leftPriceScale.visible) {
-			priceScalePosition = 'left';
+			priceScale = this._leftPriceScale;
 		}
-		return priceScalePosition;
+		return priceScale;
 	}
 
 	public recalculatePriceScale(priceScale: PriceScale | null): void {

--- a/src/views/pane/pane-price-axis-view.ts
+++ b/src/views/pane/pane-price-axis-view.ts
@@ -69,8 +69,11 @@ export class PanePriceAxisView implements IPaneView {
 		}
 
 		const position = pane.priceScalePosition(priceScale);
-		// with no left and right price scale, overlay will be align to the right
-		const align = position === 'overlay' ? 'right' : position;
+		// with no left and right price scale, overlay will be align with the visible one
+		const align = position === 'overlay' ? pane.defaultVisiblePriceScalePosition() : position;
+		if (align === null) {
+			return null;
+		}
 
 		const options = this._chartModel.priceAxisRendererOptions();
 		if (options.fontSize !== this._fontSize) {

--- a/src/views/pane/pane-price-axis-view.ts
+++ b/src/views/pane/pane-price-axis-view.ts
@@ -69,9 +69,8 @@ export class PanePriceAxisView implements IPaneView {
 		}
 
 		const position = pane.priceScalePosition(priceScale);
-		if (position === 'overlay') {
-			return null;
-		}
+		// with no left and right price scale, overlay will be align to the right
+		const align = position === 'overlay' ? 'right' : position;
 
 		const options = this._chartModel.priceAxisRendererOptions();
 		if (options.fontSize !== this._fontSize) {
@@ -79,7 +78,7 @@ export class PanePriceAxisView implements IPaneView {
 			this._textWidthCache.reset();
 		}
 
-		this._renderer.setParams(this._priceAxisView.paneRenderer(), options, width, position);
+		this._renderer.setParams(this._priceAxisView.paneRenderer(), options, width, align);
 		return this._renderer;
 	}
 }

--- a/src/views/pane/pane-price-axis-view.ts
+++ b/src/views/pane/pane-price-axis-view.ts
@@ -63,15 +63,13 @@ export class PanePriceAxisView implements IPaneView {
 		}
 
 		// this price scale will be used to find label placement only (left, right, none)
-		const priceScale = pane.isOverlay(this._dataSource) ? pane.defaultPriceScale() : this._dataSource.priceScale();
+		const priceScale = pane.isOverlay(this._dataSource) ? pane.defaultVisiblePriceScale() : this._dataSource.priceScale();
 		if (priceScale === null) {
 			return null;
 		}
 
 		const position = pane.priceScalePosition(priceScale);
-		// with no left and right price scale, overlay will be align with the visible one
-		const align = position === 'overlay' ? pane.defaultVisiblePriceScalePosition() : position;
-		if (align === null) {
+		if (position === 'overlay') {
 			return null;
 		}
 
@@ -81,7 +79,7 @@ export class PanePriceAxisView implements IPaneView {
 			this._textWidthCache.reset();
 		}
 
-		this._renderer.setParams(this._priceAxisView.paneRenderer(), options, width, align);
+		this._renderer.setParams(this._priceAxisView.paneRenderer(), options, width, position);
 		return this._renderer;
 	}
 }

--- a/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-price-scale.js
+++ b/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-price-scale.js
@@ -1,0 +1,31 @@
+function generateData(func) {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: func(i),
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const line1 = chart.addLineSeries({
+		priceScaleId: 'overlay',
+		color: 'rgb(255, 0, 0)',
+		title: 'SIN',
+	});
+	const line2 = chart.addLineSeries({
+		priceScaleId: 'overlay',
+		color: 'rgb(0, 255, 0)',
+		title: 'COS',
+	});
+
+	line1.setData(generateData(Math.sin));
+	line2.setData(generateData(Math.cos));
+}

--- a/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-stacked.js
+++ b/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-stacked.js
@@ -1,0 +1,38 @@
+function generateData(func, shouldAddValue) {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: func(i) + (shouldAddValue ? 0.01 : 0),
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	chart.priceScale('right').applyOptions({
+		visible: false,
+	});
+	chart.priceScale('left').applyOptions({
+		visible: true,
+	});
+
+	const line1 = chart.addLineSeries({
+		priceScaleId: 'overlay',
+		color: 'rgb(255, 0, 0)',
+		title: 'SIN',
+	});
+	const line2 = chart.addLineSeries({
+		priceScaleId: 'overlay',
+		color: 'rgb(0, 255, 0)',
+		title: 'COS',
+	});
+
+	line1.setData(generateData(Math.sin, true));
+	line2.setData(generateData(Math.sin, false));
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #926
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

The price scale should have an indication about where it should be align (left or right).
The default price scale is an overlay if there is no left/right price scale.
Changes essentially make overlay price scale align to the right by default.

Related issue: the option is not reflected in `this._model.options().leftPriceScale.visible` when changing with
`chart.pricescale('left').applyOptions({ visible: true })`.

**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
