### PR TITLE
Check whether a scrolling is enabled dynamically in mouse event handler

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,7 +4,7 @@ module.exports = [
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.esm.production.js',
-		limit: '44.85 KB',
+		limit: '44.9 KB',
 	},
 	{
 		name: 'Standalone',

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -199,6 +199,9 @@ export class ChartWidget implements IDestroyable {
 	}
 
 	public applyOptions(options: DeepPartial<ChartOptionsInternal>): void {
+		// we don't need to merge options here because it's done in chart model
+		// and since both model and widget share the same object it will be done automatically for widget as well
+		// not ideal solution for sure, but it work's for now ¯\_(ツ)_/¯
 		this._model.applyOptions(options);
 		this._updateTimeAxisVisibility();
 

--- a/src/gui/mouse-event-handler.ts
+++ b/src/gui/mouse-event-handler.ts
@@ -93,8 +93,8 @@ const enum Constants {
 }
 
 export interface MouseEventHandlerOptions {
-	treatVertTouchDragAsPageScroll: boolean;
-	treatHorzTouchDragAsPageScroll: boolean;
+	treatVertTouchDragAsPageScroll: () => boolean;
+	treatHorzTouchDragAsPageScroll: () => boolean;
 }
 
 interface TouchMouseMoveWithDownInfo {
@@ -290,8 +290,8 @@ export class MouseEventHandler implements IDestroyable {
 			const correctedXOffset = xOffset * 0.5;
 
 			// a drag can be only if touch page scroll isn't allowed
-			const isVertDrag = yOffset >= correctedXOffset && !this._options.treatVertTouchDragAsPageScroll;
-			const isHorzDrag = correctedXOffset > yOffset && !this._options.treatHorzTouchDragAsPageScroll;
+			const isVertDrag = yOffset >= correctedXOffset && !this._options.treatVertTouchDragAsPageScroll();
+			const isHorzDrag = correctedXOffset > yOffset && !this._options.treatHorzTouchDragAsPageScroll();
 
 			// if drag event happened then we should revert preventDefault state to original one
 			// and try to process the drag event

--- a/src/gui/pane-separator.ts
+++ b/src/gui/pane-separator.ts
@@ -64,8 +64,8 @@ export class PaneSeparator implements IDestroyable {
 				this._handle,
 				handlers,
 				{
-					treatVertTouchDragAsPageScroll: false,
-					treatHorzTouchDragAsPageScroll: true,
+					treatVertTouchDragAsPageScroll: () => false,
+					treatHorzTouchDragAsPageScroll: () => true,
 				}
 			);
 		}

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -138,13 +138,12 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 		this._rowElement.appendChild(this._rightAxisCell);
 		this.updatePriceAxisWidgets();
 
-		const scrollOptions = this.chart().options().handleScroll;
 		this._mouseEventHandler = new MouseEventHandler(
 			this._topCanvasBinding.canvas,
 			this,
 			{
-				treatVertTouchDragAsPageScroll: !scrollOptions.vertTouchDrag,
-				treatHorzTouchDragAsPageScroll: !scrollOptions.horzTouchDrag,
+				treatVertTouchDragAsPageScroll: () => this._startTrackPoint === null && !this._chart.options().handleScroll.vertTouchDrag,
+				treatHorzTouchDragAsPageScroll: () => this._startTrackPoint === null && !this._chart.options().handleScroll.horzTouchDrag,
 			}
 		);
 	}

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -106,8 +106,8 @@ export class PriceAxisWidget implements IDestroyable {
 			this._topCanvasBinding.canvas,
 			handler,
 			{
-				treatVertTouchDragAsPageScroll: false,
-				treatHorzTouchDragAsPageScroll: true,
+				treatVertTouchDragAsPageScroll: () => false,
+				treatHorzTouchDragAsPageScroll: () => true,
 			}
 		);
 	}

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -102,8 +102,8 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 			this._topCanvasBinding.canvas,
 			this,
 			{
-				treatVertTouchDragAsPageScroll: true,
-				treatHorzTouchDragAsPageScroll: false,
+				treatVertTouchDragAsPageScroll: () => true,
+				treatHorzTouchDragAsPageScroll: () => false,
 			}
 		);
 	}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #434
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

Since the state might be changed because of some state, like enabled tracking mode for example, we have to check these values every time, not just once on init.

Another fix here is that now it is possible to change these 2 options in runtime.