### PR TITLE
Disallowed downscaling on canvas to make sure that bars will render

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -9,6 +9,6 @@ module.exports = [
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '45.4 KB',
+		limit: '45.5 KB',
 	},
 ];

--- a/src/gui/canvas-utils.ts
+++ b/src/gui/canvas-utils.ts
@@ -51,7 +51,7 @@ export function createBoundCanvas(parentElement: HTMLElement, size: Size): Canva
 	const canvas = doc.createElement('canvas');
 	parentElement.appendChild(canvas);
 
-	const binding = bindToDevicePixelRatio(canvas);
+	const binding = bindToDevicePixelRatio(canvas, { allowDownsampling: false });
 	binding.resizeCanvas({
 		width: size.w,
 		height: size.h,


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #982
- [ ] Includes tests
- [ ] Documentation update
