### PR TITLE
fix: move crosshair with mouse move event

### DIFF
--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -275,6 +275,7 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 	public pressedMouseMoveEvent(event: MouseEventHandlerMouseEvent): void {
 		this._onMouseEvent();
 		this._pressedMouseTouchMoveEvent(event);
+		this._setCrosshairPosition(event.localX, event.localY);
 	}
 
 	public mouseUpEvent(event: MouseEventHandlerMouseEvent): void {


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #987
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**
Added back missing `setCrosshair` function to the mouse move event. It was wrongly removed by #972. 


<!-- optional -->
