### PR TITLE
Fix landing page chart overflow

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -81,8 +81,3 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 	--color: var(--icon-color);
 }
 
-.main-wrapper {
-	display: flex;
-	justify-content: center;
-	gap: 2rem;
-}

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -8,6 +8,10 @@
 	display: none;
 }
 
+.HeroChartContainer * {
+	overflow: hidden;
+}
+
 .HeroTextContainer {
 	display: flex;
 	flex-direction: column;
@@ -159,6 +163,10 @@
 }
 
 @media (min-width: 767.5px) {
+	.RootContainer {
+		max-width: unset;
+	}
+
 	.HeroButtonsContainer {
 		min-width: unset;
 		flex-wrap: unset;
@@ -210,9 +218,8 @@
 
 	.HeroChartContainer {
 		display: unset;
-		/* width: 100%; */
-		height: 40vh;
-		width: 100vw;
+		min-height: 500px;
+		width: 100%;
 	}
 
 	.HeroTextContainer {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -12,6 +12,11 @@
 	overflow: hidden;
 }
 
+.HeroChartContainer table td,
+.HeroChartContainer table tr {
+	border: none;
+}
+
 .HeroTextContainer {
 	display: flex;
 	flex-direction: column;
@@ -243,7 +248,7 @@
 	.LargeCardContainer {
 		flex-wrap: nowrap;
 	}
-	
+
 	.LargeCard, LargeCard3 {
 		flex: 0 1 30%;
 	}
@@ -251,7 +256,7 @@
 	.SmallCardContainer {
 		flex-wrap: nowrap;
 	}
-	
+
 	.SmallCard {
 		flex: 0 1 23%;
 	}
@@ -297,7 +302,7 @@
 	.LargeCardContainer {
 		max-width: 77%;
 	}
-	
+
 	.SmallCardContainer {
 		max-width: 77%;
 	}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -52,6 +52,9 @@ function HeroChart(): JSX.Element {
 
 			const c = createChart(container, {
 				layout,
+				rightPriceScale: {
+					borderVisible: false,
+				},
 				grid: {
 					horzLines: {
 						visible: false,
@@ -61,6 +64,7 @@ function HeroChart(): JSX.Element {
 					},
 				},
 				timeScale: {
+					borderVisible: false,
 					fixLeftEdge: true,
 					fixRightEdge: true,
 					lockVisibleTimeRangeOnResize: true,

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -87,7 +87,7 @@ function HeroChart(): JSX.Element {
 			orangeSeries.setData(data.orangeData as LineData[]);
 			blueSeries.setData(data.blueData as LineData[]);
 
-			c.timeScale().setVisibleLogicalRange({ from: 1, to: data.orangeData.length - 2 });
+			c.timeScale().setVisibleLogicalRange({ from: 0.5, to: data.orangeData.length - 1.5 });
 
 			const resizeListener = () => {
 				const { width, height } = container.getBoundingClientRect();

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -42,7 +42,7 @@ function HeroChart(): JSX.Element {
 
 	const [chart, setChart] = React.useState<IChartApi | null>(null);
 
-	React.useLayoutEffect(
+	React.useEffect(
 		() => {
 			const container = ref.current;
 


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

* Fixes overflow of the chart container caused by a built-in Docusaurus style that allows overflow on table elements.

* Fixes chart container itself overflowing out of the available visual width.

* Changes an unnecessary `useLayoutEffect` to `useEffect` 
