### PR TITLE
Realign time scale marks if both scrolling and scaling are disabled

### DIFF
--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -451,6 +451,7 @@ export class TimeScale {
 		return this._rightOffset;
 	}
 
+	// eslint-disable-next-line complexity
 	public marks(): TimeMark[] | null {
 		if (this.isEmpty()) {
 			return null;
@@ -506,7 +507,7 @@ export class TimeScale {
 				this._labels.push(label);
 			}
 
-			if (this._barSpacing > (maxLabelWidth / 2)) {
+			if (this._barSpacing > (maxLabelWidth / 2) && !isAllScalingAndScrollingDisabled) {
 				// if there is enough space then let's show all tick marks as usual
 				label.needAlignCoordinate = false;
 			} else {

--- a/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-marks.js
+++ b/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-marks.js
@@ -1,0 +1,21 @@
+function runTestCase(container) {
+	const chart = LightweightCharts.createChart(container, {
+		handleScroll: false,
+		handleScale: false,
+	});
+
+	const mainSeries = chart.addLineSeries();
+
+	const data = [
+		{ time: 1639037531, value: 41.162 },
+		{ time: 1639040640, value: 41.366 },
+		{ time: 1639040700, value: 41.37 },
+		{ time: 1639040760, value: 41.372 },
+		{ time: 1639040940, value: 41.341 },
+		{ time: 1639041000, value: 41.334 },
+	];
+
+	mainSeries.setData(data);
+
+	chart.timeScale().setVisibleLogicalRange({ from: 0.5, to: data.length - 1.5 });
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

_Before:_

![Screen Shot 2022-01-28 at 16 47 24](https://user-images.githubusercontent.com/3112183/151587723-7fb45ea3-b7e6-4616-a303-af5f8939ec66.png)

_After:_

![Screen Shot 2022-01-28 at 16 49 20](https://user-images.githubusercontent.com/3112183/151587836-9ecc0940-4b27-45bc-8d90-dd9e55f31e23.png)

