### PR TITLE
Changed rendering of baseline and area series when using scaleMargins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ debug.html
 
 # graphics tests out data
 /tests/e2e/graphics/.gendata/
+
+# MacOS
+.DS_Store

--- a/src/renderers/area-renderer.ts
+++ b/src/renderers/area-renderer.ts
@@ -12,6 +12,7 @@ export interface PaneRendererAreaDataBase {
 	lineWidth: LineWidth;
 	lineStyle: LineStyle;
 
+	top: Coordinate;
 	bottom: Coordinate;
 	baseLevelCoordinate: Coordinate;
 
@@ -79,7 +80,7 @@ export class PaneRendererArea extends PaneRendererAreaBase<PaneRendererAreaData>
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const data = this._data!;
 
-		const gradient = ctx.createLinearGradient(0, 0, 0, data.bottom);
+		const gradient = ctx.createLinearGradient(0, data.top, 0, data.bottom);
 		gradient.addColorStop(0, data.topColor);
 		gradient.addColorStop(1, data.bottomColor);
 		return gradient;

--- a/src/renderers/baseline-renderer.ts
+++ b/src/renderers/baseline-renderer.ts
@@ -18,8 +18,10 @@ export class PaneRendererBaselineArea extends PaneRendererAreaBase<PaneRendererB
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		const data = this._data!;
 
-		const gradient = ctx.createLinearGradient(0, 0, 0, data.bottom);
-		const baselinePercent = clamp(data.baseLevelCoordinate / data.bottom, 0, 1);
+		const gradient = ctx.createLinearGradient(0, data.top, 0, data.bottom);
+		const base = data.baseLevelCoordinate - data.top;
+		const height = data.bottom - data.top;
+		const baselinePercent = clamp(base / height, 0, 1);
 
 		gradient.addColorStop(0, data.topFillColor1);
 		gradient.addColorStop(baselinePercent, data.topFillColor2);

--- a/src/views/pane/area-pane-view.ts
+++ b/src/views/pane/area-pane-view.ts
@@ -26,10 +26,17 @@ export class SeriesAreaPaneView extends LinePaneViewBase<'Area', LineItem> {
 		}
 
 		const areaStyleProperties = this._series.options();
-		const priceScaleProps = this._series.priceScale().options();
+		const priceScale = this._series.priceScale();
+		const priceScaleProps = priceScale.options();
+		const isCustomScale = priceScale.id() !== 'right' && priceScale.id() !== 'left';
 
-		const bottom = height;
-		const top = priceScaleProps.scaleMargins ? priceScaleProps.scaleMargins.top * height : 0;
+		let top = 0;
+		let bottom = height;
+
+		if (isCustomScale && priceScaleProps.scaleMargins) {
+			bottom = height;
+			top = priceScaleProps.scaleMargins.top * height;
+		}
 
 		this._makeValid();
 

--- a/src/views/pane/area-pane-view.ts
+++ b/src/views/pane/area-pane-view.ts
@@ -26,6 +26,10 @@ export class SeriesAreaPaneView extends LinePaneViewBase<'Area', LineItem> {
 		}
 
 		const areaStyleProperties = this._series.options();
+		const priceScaleProps = this._series.priceScale().options();
+
+		const bottom = height;
+		const top = priceScaleProps.scaleMargins ? priceScaleProps.scaleMargins.top * height : 0;
 
 		this._makeValid();
 
@@ -37,7 +41,8 @@ export class SeriesAreaPaneView extends LinePaneViewBase<'Area', LineItem> {
 			topColor: areaStyleProperties.topColor,
 			bottomColor: areaStyleProperties.bottomColor,
 			baseLevelCoordinate: height as Coordinate,
-			bottom: height as Coordinate,
+			top: top as Coordinate,
+			bottom: bottom as Coordinate,
 			visibleRange: this._itemsVisibleRange,
 			barWidth: this._model.timeScale().barSpacing(),
 		});

--- a/src/views/pane/baseline-pane-view.ts
+++ b/src/views/pane/baseline-pane-view.ts
@@ -32,15 +32,22 @@ export class SeriesBaselinePaneView extends LinePaneViewBase<'Baseline', LineIte
 		}
 
 		const baselineProps = this._series.options();
-		const priceScaleProps = this._series.priceScale().options();
+		const priceScale = this._series.priceScale();
+		const priceScaleProps = priceScale.options();
+		const isCustomScale = priceScale.id() !== 'right' && priceScale.id() !== 'left';
 
 		this._makeValid();
 
-		const baseLevelCoordinate = this._series.priceScale().priceToCoordinate(baselineProps.baseValue.price, firstValue.value);
+		const baseLevelCoordinate = priceScale.priceToCoordinate(baselineProps.baseValue.price, firstValue.value);
 		const barWidth = this._model.timeScale().barSpacing();
 
-		const bottom = priceScaleProps.scaleMargins ? (1 - priceScaleProps.scaleMargins.bottom) * height : height;
-		const top = priceScaleProps.scaleMargins ? priceScaleProps.scaleMargins.top * height : 0;
+		let top = 0;
+		let bottom = height;
+
+		if (baselineProps.baseValue.type === 'price' && isCustomScale && priceScaleProps.scaleMargins) {
+			bottom = height * (1 - priceScaleProps.scaleMargins.bottom);
+			top = height * priceScaleProps.scaleMargins.top;
+		}
 
 		this._baselineAreaRenderer.setData({
 			items: this._items,

--- a/src/views/pane/baseline-pane-view.ts
+++ b/src/views/pane/baseline-pane-view.ts
@@ -32,11 +32,15 @@ export class SeriesBaselinePaneView extends LinePaneViewBase<'Baseline', LineIte
 		}
 
 		const baselineProps = this._series.options();
+		const priceScaleProps = this._series.priceScale().options();
 
 		this._makeValid();
 
 		const baseLevelCoordinate = this._series.priceScale().priceToCoordinate(baselineProps.baseValue.price, firstValue.value);
 		const barWidth = this._model.timeScale().barSpacing();
+
+		const bottom = priceScaleProps.scaleMargins ? (1 - priceScaleProps.scaleMargins.bottom) * height : height;
+		const top = priceScaleProps.scaleMargins ? priceScaleProps.scaleMargins.top * height : 0;
 
 		this._baselineAreaRenderer.setData({
 			items: this._items,
@@ -51,7 +55,8 @@ export class SeriesBaselinePaneView extends LinePaneViewBase<'Baseline', LineIte
 			lineType: LineType.Simple,
 
 			baseLevelCoordinate,
-			bottom: height as Coordinate,
+			top: top as Coordinate,
+			bottom: bottom as Coordinate,
 
 			visibleRange: this._itemsVisibleRange,
 			barWidth,


### PR DESCRIPTION
**Type of PR:** 
Enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1005
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**
This change will make the rendering of color stops in the baseline and area series gradients more consistent when using scaleMargins. 

The gradient will now always reach the full color whether it is scaled to the top or bottom of the view (as I'd expect from setting its color options). 


**Is there anything you'd like reviewers to focus on?**
The gradient is only changed when using a _custom_ price scale, since it seems that these cannot be moved manually. Is this correct? Otherwise, the gradient will go into negative values, giving unwanted results. 

Furthermore, I'm using the code below to check whether or not we are on a custom price scale: 
```js 
const isCustomScale = priceScale.id() !== 'right' && priceScale.id() !== 'left';
```
Not sure if this is the best method, open for suggestions. Maybe use the `DefaultPriceScaleId` enum? 

