### PR TITLE
textAlignRight for PriceAxisWidget

### DIFF
--- a/src/api/options/price-scale-options-defaults.ts
+++ b/src/api/options/price-scale-options-defaults.ts
@@ -8,6 +8,7 @@ export const priceScaleOptionsDefaults: PriceScaleOptions = {
 	borderVisible: true,
 	borderColor: '#2B2B43',
 	entireTextOnly: false,
+	textAlignRight: false,
 	visible: false,
 	drawTicks: true,
 	scaleMargins: {

--- a/src/gui/labels-image-cache.ts
+++ b/src/gui/labels-image-cache.ts
@@ -38,6 +38,14 @@ export class LabelsImageCache implements IDestroyable {
 		this._hash.clear();
 	}
 
+	public calculateAlignRightOffset(ctx: CanvasRenderingContext2D, text: string, maxLengthText: string): number {
+		const pixelRatio = getCanvasDevicePixelRatio(ctx.canvas);
+		const label = this._getLabelImage(ctx, text);
+		const maxLengthLabel = this._getLabelImage(ctx, maxLengthText);
+
+		return Math.floor(maxLengthLabel.textWidth * pixelRatio) - Math.floor(label.textWidth * pixelRatio);
+	}
+
 	public paintTo(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, align: string): void {
 		const label = this._getLabelImage(ctx, text);
 		if (align !== 'left') {

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -161,6 +161,13 @@ export interface PriceScaleOptions {
 	borderColor: string;
 
 	/**
+	 * Align price labels to the right when using `rightPriceScale`
+	 *
+	 * @defaultValue `false`
+	 */
+	textAlignRight: boolean;
+
+	/**
 	 * Show top and bottom corner labels only if entire text is visible.
 	 *
 	 * @defaultValue `false`

--- a/src/renderers/iprice-axis-view-renderer.ts
+++ b/src/renderers/iprice-axis-view-renderer.ts
@@ -44,6 +44,7 @@ export interface IPriceAxisViewRenderer {
 
 	height(rendererOptions: PriceAxisViewRendererOptions, useSecondLine: boolean): number;
 	setData(data: PriceAxisViewRendererData, commonData: PriceAxisViewRendererCommonData): void;
+	setMaxLengthText(maxLengthText: string | null): void;
 }
 
 export type IPriceAxisViewRendererConstructor = new(data: PriceAxisViewRendererData, commonData: PriceAxisViewRendererCommonData) => IPriceAxisViewRenderer;

--- a/src/renderers/price-axis-view-renderer.ts
+++ b/src/renderers/price-axis-view-renderer.ts
@@ -12,6 +12,7 @@ import {
 export class PriceAxisViewRenderer implements IPriceAxisViewRenderer {
 	private _data!: PriceAxisViewRendererData;
 	private _commonData!: PriceAxisViewRendererCommonData;
+	private _maxLengthText: string | null = null;
 
 	public constructor(data: PriceAxisViewRendererData, commonData: PriceAxisViewRendererCommonData) {
 		this.setData(data, commonData);
@@ -20,6 +21,10 @@ export class PriceAxisViewRenderer implements IPriceAxisViewRenderer {
 	public setData(data: PriceAxisViewRendererData, commonData: PriceAxisViewRendererCommonData): void {
 		this._data = data;
 		this._commonData = commonData;
+	}
+
+	public setMaxLengthText(maxLengthText: string | null): void {
+		this._maxLengthText = maxLengthText;
 	}
 
 	public draw(
@@ -91,6 +96,10 @@ export class PriceAxisViewRenderer implements IPriceAxisViewRenderer {
 				xOutside = xInside + totalWidth;
 				xTick = xInside + tickSize;
 				xText = xInside + horzBorder + tickSize + paddingInner;
+			}
+
+			if (this._maxLengthText !== null) {
+				xText += Math.ceil(textWidthCache.measureText(ctx, this._maxLengthText)) - textWidth;
 			}
 
 			const tickHeight = Math.max(1, Math.floor(pixelRatio));


### PR DESCRIPTION
**Type of PR: enhancement** <!-- bugfix, enhancement, fix typo, etc -->

This PR adds an option to align price axis labels to the right when using `rightPriceScale`.

**PR checklist:**

- [x] Addresses an existing issue: fixes #1007
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

- added `textAlignRight: boolean` to
 `PriceScaleOptions`
- added `calculateAlignRightOffset` to `LabelsImageCache`
- added offset calculation to `PriceAxisViewRenderer.draw`

![Capture](https://user-images.githubusercontent.com/17497826/154131792-dd6d90ae-fddd-4489-abf0-e42c35c970d9.PNG)

