### PR TITLE
Price line labels formatting

### DIFF
--- a/src/model/pane.ts
+++ b/src/model/pane.ts
@@ -50,7 +50,7 @@ export class Pane implements IDestroyable {
 		this._rightPriceScale = this._createPriceScale(DefaultPriceScaleId.Right, options.rightPriceScale);
 
 		this._leftPriceScale.modeChanged().subscribe(this._onPriceScaleModeChanged.bind(this, this._leftPriceScale), this);
-		this._rightPriceScale.modeChanged().subscribe(this._onPriceScaleModeChanged.bind(this, this._leftPriceScale), this);
+		this._rightPriceScale.modeChanged().subscribe(this._onPriceScaleModeChanged.bind(this, this._rightPriceScale), this);
 
 		this.applyScaleOptions(options);
 	}

--- a/src/views/price-axis/custom-price-line-price-axis-view.ts
+++ b/src/views/price-axis/custom-price-line-price-axis-view.ts
@@ -49,12 +49,21 @@ export class CustomPriceLinePriceAxisView extends PriceAxisView {
 
 		paneRendererData.borderColor = series.model().backgroundColorAtYPercentFromTop(y / series.priceScale().height());
 
-		axisRendererData.text = series.priceScale().formatPriceAbsolute(options.price);
+		axisRendererData.text = this._formatPrice(options.price);
 		axisRendererData.visible = true;
 
 		const colors = generateContrastColors(options.color);
 		commonData.background = colors.background;
 		commonData.color = colors.foreground;
 		commonData.coordinate = y;
+	}
+
+	private _formatPrice(price: number): string {
+		const firstValue = this._series.firstValue();
+		if (firstValue === null) {
+			return '';
+		}
+
+		return this._series.priceScale().formatPrice(price, firstValue.value);
 	}
 }


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1032

**Overview of change:**
When setting the price scale mode to anything than 'Normal' price for PriceLine wasn't properly calculated.