### PR TITLE
Time axis ticks visibility

### DIFF
--- a/src/api/options/price-scale-options-defaults.ts
+++ b/src/api/options/price-scale-options-defaults.ts
@@ -9,7 +9,7 @@ export const priceScaleOptionsDefaults: PriceScaleOptions = {
 	borderColor: '#2B2B43',
 	entireTextOnly: false,
 	visible: false,
-	drawTicks: true,
+	ticksVisible: true,
 	scaleMargins: {
 		bottom: 0.1,
 		top: 0.2,

--- a/src/api/options/time-scale-options-defaults.ts
+++ b/src/api/options/time-scale-options-defaults.ts
@@ -14,4 +14,5 @@ export const timeScaleOptionsDefaults: TimeScaleOptions = {
 	timeVisible: false,
 	secondsVisible: true,
 	shiftVisibleRangeOnNewBar: true,
+	ticksVisible: true,
 };

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -446,7 +446,6 @@ export class PriceAxisWidget implements IDestroyable {
 		ctx.font = this.baseFont();
 		ctx.fillStyle = this.lineColor();
 		const rendererOptions = this.rendererOptions();
-		const drawTicks = this._priceScale.options().borderVisible && this._priceScale.options().drawTicks;
 
 		const tickMarkLeftX = this._isLeft ?
 			Math.floor((this._size.w - rendererOptions.tickLength) * pixelRatio - rendererOptions.borderSize * pixelRatio) :
@@ -460,7 +459,8 @@ export class PriceAxisWidget implements IDestroyable {
 		const tickHeight = Math.max(1, Math.floor(pixelRatio));
 		const tickOffset = Math.floor(pixelRatio * 0.5);
 
-		if (drawTicks) {
+		const options = this._priceScale.options();
+		if (options.borderVisible && options.ticksVisible) {
 			const tickLength = Math.round(rendererOptions.tickLength * pixelRatio);
 			ctx.beginPath();
 			for (const tickMark of tickMarks) {

--- a/src/gui/time-axis-widget.ts
+++ b/src/gui/time-axis-widget.ts
@@ -314,7 +314,8 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 	}
 
 	private _drawTickMarks(ctx: CanvasRenderingContext2D, pixelRatio: number): void {
-		const tickMarks = this._chart.model().timeScale().marks();
+		const timeScale = this._chart.model().timeScale();
+		const tickMarks = timeScale.marks();
 
 		if (!tickMarks || tickMarks.length === 0) {
 			return;
@@ -348,7 +349,8 @@ export class TimeAxisWidget implements MouseEventHandlers, IDestroyable {
 		const tickWidth = Math.max(1, Math.floor(pixelRatio));
 		const tickOffset = Math.floor(pixelRatio * 0.5);
 
-		if (this._chart.model().timeScale().options().borderVisible) {
+		const options = timeScale.options();
+		if (options.borderVisible && options.ticksVisible) {
 			ctx.beginPath();
 			const tickLen = Math.round(rendererOptions.tickLength * pixelRatio);
 			for (let index = tickMarks.length; index--;) {

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -166,7 +166,7 @@ export interface PriceScaleOptions {
 	 *
 	 * @defaultValue `true`
 	 */
-	drawTicks: boolean;
+	ticksVisible: boolean;
 }
 
 interface RangeCache {

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -195,6 +195,13 @@ export interface TimeScaleOptions {
 	 * @defaultValue `undefined`
 	 */
 	tickMarkFormatter?: TickMarkFormatter;
+
+	/**
+	 * Draw small vertical line on time axis labels.
+	 *
+	 * @defaultValue `true`
+	 */
+	ticksVisible: boolean;
 }
 
 export class TimeScale {

--- a/src/renderers/time-axis-view-renderer.ts
+++ b/src/renderers/time-axis-view-renderer.ts
@@ -10,6 +10,7 @@ export interface TimeAxisViewRendererData {
 	color: string;
 	background: string;
 	visible: boolean;
+	tickVisible: boolean;
 }
 
 const optimizationReplacementRe = /[1-9]/g;
@@ -73,14 +74,16 @@ export class TimeAxisViewRenderer implements ITimeAxisViewRenderer {
 		const y2scaled = Math.round(y2 * pixelRatio);
 		ctx.fillRect(x1scaled, y1scaled, x2scaled - x1scaled, y2scaled - y1scaled);
 
-		const tickX = Math.round(this._data.coordinate * pixelRatio);
-		const tickTop = y1scaled;
-		const tickBottom = Math.round((tickTop + rendererOptions.borderSize + rendererOptions.tickLength) * pixelRatio);
+		if (this._data.tickVisible) {
+			const tickX = Math.round(this._data.coordinate * pixelRatio);
+			const tickTop = y1scaled;
+			const tickBottom = Math.round((tickTop + rendererOptions.borderSize + rendererOptions.tickLength) * pixelRatio);
 
-		ctx.fillStyle = this._data.color;
-		const tickWidth = Math.max(1, Math.floor(pixelRatio));
-		const tickOffset = Math.floor(pixelRatio * 0.5);
-		ctx.fillRect(tickX - tickOffset, tickTop, tickWidth, tickBottom - tickTop);
+			ctx.fillStyle = this._data.color;
+			const tickWidth = Math.max(1, Math.floor(pixelRatio));
+			const tickOffset = Math.floor(pixelRatio * 0.5);
+			ctx.fillRect(tickX - tickOffset, tickTop, tickWidth, tickBottom - tickTop);
+		}
 
 		const yText = y2 - rendererOptions.baselineOffset - rendererOptions.paddingBottom;
 		ctx.textAlign = 'left';

--- a/src/views/price-axis/price-axis-view.ts
+++ b/src/views/price-axis/price-axis-view.ts
@@ -87,8 +87,8 @@ export abstract class PriceAxisView implements IPriceAxisView {
 		// force update tickVisible state from price scale options
 		// because we don't have and we can't have price axis in other methods
 		// (like paneRenderer or any other who call _updateRendererDataIfNeeded)
-		this._axisRendererData.tickVisible = this._axisRendererData.tickVisible && priceScale.options().drawTicks;
-		this._paneRendererData.tickVisible = this._paneRendererData.tickVisible && priceScale.options().drawTicks;
+		this._axisRendererData.tickVisible = this._axisRendererData.tickVisible && priceScale.options().ticksVisible;
+		this._paneRendererData.tickVisible = this._paneRendererData.tickVisible && priceScale.options().ticksVisible;
 
 		this._axisRenderer.setData(this._axisRendererData, this._commonRendererData);
 		this._paneRenderer.setData(this._paneRendererData, this._commonRendererData);

--- a/src/views/time-axis/crosshair-time-axis-view.ts
+++ b/src/views/time-axis/crosshair-time-axis-view.ts
@@ -20,6 +20,7 @@ export class CrosshairTimeAxisView implements ITimeAxisView {
 		text: '',
 		width: 0,
 		coordinate: NaN,
+		tickVisible: true,
 	};
 
 	public constructor(crosshair: Crosshair, model: ChartModel, valueProvider: TimeAndCoordinateProvider) {
@@ -73,5 +74,6 @@ export class CrosshairTimeAxisView implements ITimeAxisView {
 		const colors = generateContrastColors(options.labelBackgroundColor);
 		data.background = colors.background;
 		data.color = colors.foreground;
+		data.tickVisible = timeScale.options().ticksVisible;
 	}
 }

--- a/tests/e2e/graphics/test-cases/applying-options/apply-do-not-draw-price-ticks.js
+++ b/tests/e2e/graphics/test-cases/applying-options/apply-do-not-draw-price-ticks.js
@@ -15,7 +15,7 @@ function generateData() {
 function runTestCase(container) {
 	const chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
-			drawTicks: false,
+			ticksVisible: false,
 		},
 	});
 
@@ -27,7 +27,7 @@ function runTestCase(container) {
 		setTimeout(() => {
 			chart.applyOptions({
 				rightPriceScale: {
-					drawTicks: true,
+					ticksVisible: true,
 				},
 			});
 

--- a/tests/e2e/graphics/test-cases/fit-content-with-lot-data.js
+++ b/tests/e2e/graphics/test-cases/fit-content-with-lot-data.js
@@ -17,7 +17,7 @@ function runTestCase(container) {
 	const chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
-			drawTicks: false,
+			ticksVisible: false,
 		},
 		timeScale: {
 			borderVisible: false,

--- a/tests/e2e/graphics/test-cases/initial-options/do-not-draw-time-ticks.js
+++ b/tests/e2e/graphics/test-cases/initial-options/do-not-draw-time-ticks.js
@@ -14,7 +14,7 @@ function generateData() {
 
 function runTestCase(container) {
 	const chart = LightweightCharts.createChart(container, {
-		rightPriceScale: {
+		timeScale: {
 			ticksVisible: false,
 		},
 	});

--- a/tests/e2e/graphics/test-cases/series/price-lines-on-two-axis.js
+++ b/tests/e2e/graphics/test-cases/series/price-lines-on-two-axis.js
@@ -17,12 +17,12 @@ function runTestCase(container) {
 		leftPriceScale: {
 			visible: true,
 			borderColor: '#EFF2F5',
-			drawTicks: false,
+			ticksVisible: false,
 		},
 		rightPriceScale: {
 			visible: true,
 			borderColor: '#EFF2F5',
-			drawTicks: false,
+			ticksVisible: false,
 		},
 	});
 

--- a/website/docs/migrations/from-v3-to-v4.md
+++ b/website/docs/migrations/from-v3-to-v4.md
@@ -80,6 +80,21 @@ const rightPriceScale = chart.priceScale('right');
 const leftPriceScale = chart.priceScale('left');
 ```
 
+## `drawTicks` from `leftPriceScale` and `rightPriceScale` options has been renamed to `ticksVisible`
+
+Since v4 you have to use `ticksVisible` instead of `drawTicks`.
+
+```js
+const chart = createChart({
+    leftPriceScale: {
+        ticksVisible: false,
+    },
+    rightPriceScale: {
+        ticksVisible: false,
+    },
+});
+```
+
 ## The type of outbound time values has been changed
 
 Affected API:


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1043
- [x] Includes tests
- [x] Documentation update

**Overview of change:**

Added `ticksVisible` to `TimeScaleOptions`,  renamed  `drawTicks` to `ticksVisible` in `PriceScaleOptions`
