### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/check-markdown-links.js
+++ b/scripts/check-markdown-links.js
@@ -127,7 +127,7 @@ function collectFilesData(inputFiles, checkWebsiteLinks) {
 						.replace(/-+/g, '-');
 
 					if (result.charAt(0) === '-') {
-						return result.substr(1);
+						return result.slice(1);
 					}
 
 					return result;


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.