### PR TITLE
Implement basic box drawing

### DIFF
--- a/src/api/box-api.ts
+++ b/src/api/box-api.ts
@@ -1,0 +1,23 @@
+import { BoxOptions } from '../model/box-options';
+import { CustomBox } from '../model/custom-box';
+
+import { IBox } from './ibox';
+
+export class Box implements IBox {
+	private readonly _box: CustomBox;
+
+	public constructor(box: CustomBox) {
+		this._box = box;
+	}
+
+	public applyOptions(options: Partial<BoxOptions>): void {
+		this._box.applyOptions(options);
+	}
+	public options(): Readonly<BoxOptions> {
+		return this._box.options();
+	}
+
+	public box(): CustomBox {
+		return this._box;
+	}
+}

--- a/src/api/data-validators.ts
+++ b/src/api/data-validators.ts
@@ -23,10 +23,14 @@ export function checkBoxOptions(options: BoxOptions): void {
 		return;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/tslint/config
-	assert(typeof options.lowPrice === 'number', `the type of 'lowPrice' box's property must be a number, got '${typeof options.lowPrice}'`);
-	// eslint-disable-next-line @typescript-eslint/tslint/config
-	assert(typeof options.highPrice === 'number', `the type of 'highPrice' box's property must be a number, got '${typeof options.highPrice}'`);
+	if (options.corners.length === 0) {
+		// eslint-disable-next-line @typescript-eslint/tslint/config
+		assert(typeof options.lowPrice === 'number', `the type of 'lowPrice' box's property must be a number, got '${typeof options.lowPrice}'`);
+		// eslint-disable-next-line @typescript-eslint/tslint/config
+		assert(typeof options.highPrice === 'number', `the type of 'highPrice' box's property must be a number, got '${typeof options.highPrice}'`);
+	} else {
+		assert(options.corners.length !== 1, `at least 2 corners must be specified, but only got 1 corner`);
+	}
 }
 
 export function checkItemsAreOrdered(data: readonly (SeriesMarker<Time> | SeriesDataItemTypeMap[SeriesType])[], allowDuplicates: boolean = false): void {

--- a/src/api/data-validators.ts
+++ b/src/api/data-validators.ts
@@ -1,5 +1,6 @@
 import { assert } from '../helpers/assertions';
 
+import { BoxOptions } from '../model/box-options';
 import { CreatePriceLineOptions } from '../model/price-line-options';
 import { SeriesMarker } from '../model/series-markers';
 import { SeriesType } from '../model/series-options';
@@ -15,6 +16,17 @@ export function checkPriceLineOptions(options: CreatePriceLineOptions): void {
 
 	// eslint-disable-next-line @typescript-eslint/tslint/config
 	assert(typeof options.price === 'number', `the type of 'price' price line's property must be a number, got '${typeof options.price}'`);
+}
+
+export function checkBoxOptions(options: BoxOptions): void {
+	if (process.env.NODE_ENV === 'production') {
+		return;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/tslint/config
+	assert(typeof options.lowPrice === 'number', `the type of 'lowPrice' box's property must be a number, got '${typeof options.lowPrice}'`);
+	// eslint-disable-next-line @typescript-eslint/tslint/config
+	assert(typeof options.highPrice === 'number', `the type of 'highPrice' box's property must be a number, got '${typeof options.highPrice}'`);
 }
 
 export function checkItemsAreOrdered(data: readonly (SeriesMarker<Time> | SeriesDataItemTypeMap[SeriesType])[], allowDuplicates: boolean = false): void {

--- a/src/api/ibox.ts
+++ b/src/api/ibox.ts
@@ -1,0 +1,34 @@
+import { BoxOptions } from '../model/box-options';
+
+/**
+ * Represents the interface for interacting with boxes.
+ */
+export interface IBox {
+	/**
+	 * Apply options to the box.
+	 *
+	 * @param options - Any subset of options.
+	 * @example
+	 * ```js
+	 * box.applyOptions({
+	 *     lowPrice: 80.0,
+	 *     highPrice: 90.0,
+	 *     earlyTime: 1641240000, // 2022-01-03 20:00:00
+	 *     lateTime: 1641250000, // 2022-01-03 22:46:40
+	 *     borderColor: '#0ff',
+	 *     borderWidth: 1,
+	 *     borderStyle: LightweightCharts.LineStyle.Solid,
+	 *     fillColor: '#0ff',
+	 *     fillOpacity: 0.5,
+	 *     borderVisible: true,
+	 *     axisLabelVisible: false,
+	 *     title: 'My box',
+	 * });
+	 * ```
+	 */
+	applyOptions(options: Partial<BoxOptions>): void;
+	/**
+	 * Get the currently applied options.
+	 */
+	options(): Readonly<BoxOptions>;
+}

--- a/src/api/ibox.ts
+++ b/src/api/ibox.ts
@@ -11,6 +11,10 @@ export interface IBox {
 	 * @example
 	 * ```js
 	 * box.applyOptions({
+	 *     corners: [
+	 *         { time: 1641240000, price: 80 },
+	 *         { time: 1641040000, price: 70 },
+	 *     ],
 	 *     lowPrice: 80.0,
 	 *     highPrice: 90.0,
 	 *     earlyTime: 1641240000, // 2022-01-03 20:00:00

--- a/src/api/iseries-api.ts
+++ b/src/api/iseries-api.ts
@@ -1,6 +1,7 @@
 import { IPriceFormatter } from '../formatters/iprice-formatter';
 
 import { BarPrice } from '../model/bar';
+import { BoxOptions } from '../model/box-options';
 import { Coordinate } from '../model/coordinate';
 import { MismatchDirection } from '../model/plot-list';
 import { CreatePriceLineOptions } from '../model/price-line-options';
@@ -13,6 +14,7 @@ import {
 import { Range, Time } from '../model/time-data';
 
 import { SeriesDataItemTypeMap } from './data-consumer';
+import { IBox } from './ibox';
 import { IPriceLine } from './iprice-line';
 import { IPriceScaleApi } from './iprice-scale-api';
 
@@ -248,6 +250,42 @@ export interface ISeriesApi<TSeriesType extends SeriesType> {
 	 * ```
 	 */
 	removePriceLine(line: IPriceLine): void;
+
+	/**
+	 * Creates a new box.
+	 *
+	 * @param options - Any subset of options.
+	 * @example
+	 * ```js
+	 * box.applyOptions({
+	 *     lowPrice: 80.0,
+	 *     highPrice: 90.0,
+	 *     earlyTime: 1641240000, // 2022-01-03 20:00:00
+	 *     lateTime: 1641250000, // 2022-01-03 22:46:40
+	 *     borderColor: '#0ff',
+	 *     borderWidth: 1,
+	 *     borderStyle: LightweightCharts.LineStyle.Solid,
+	 *     fillColor: '#0ff',
+	 *     fillOpacity: 50,
+	 *     borderVisible: true,
+	 *     axisLabelVisible: false,
+	 *     title: 'My box',
+	 * });
+	 * ```
+	 */
+	createBox(options: BoxOptions): IBox;
+
+	/**
+	 * Removes the box that was created before.
+	 *
+	 * @param box - A box to remove.
+	 * @example
+	 * ```js
+	 * const box = series.createBox({ lowPrice: 80.0 });
+	 * series.removeBox(box);
+	 * ```
+	 */
+	removeBox(box: IBox): void;
 
 	/**
 	 * Return current series type.

--- a/src/api/iseries-api.ts
+++ b/src/api/iseries-api.ts
@@ -258,6 +258,10 @@ export interface ISeriesApi<TSeriesType extends SeriesType> {
 	 * @example
 	 * ```js
 	 * box.applyOptions({
+	 *     corners: [
+	 *         { time: 1641240000, price: 80 },
+         *         { time: 1641040000, price: 70 },
+	 *     ],
 	 *     lowPrice: 80.0,
 	 *     highPrice: 90.0,
 	 *     earlyTime: 1641240000, // 2022-01-03 20:00:00

--- a/src/api/options/box-options-defaults.ts
+++ b/src/api/options/box-options-defaults.ts
@@ -1,0 +1,17 @@
+import { BoxOptions } from '../../model/box-options';
+import { LineStyle } from '../../renderers/draw-line';
+
+export const boxOptionsDefaults: BoxOptions = {
+	lowPrice: 0.0,
+	highPrice: 0.0,
+	earlyTime: 0,
+	lateTime: 0,
+	borderColor: '#0FF',
+	borderWidth: 1,
+	borderStyle: LineStyle.Solid,
+	fillColor: '#0FF',
+	fillOpacity: 1,
+	borderVisible: true,
+	axisLabelVisible: false,
+	title: '',
+};

--- a/src/api/options/box-options-defaults.ts
+++ b/src/api/options/box-options-defaults.ts
@@ -2,6 +2,7 @@ import { BoxOptions } from '../../model/box-options';
 import { LineStyle } from '../../renderers/draw-line';
 
 export const boxOptionsDefaults: BoxOptions = {
+	corners: [],
 	lowPrice: 0.0,
 	highPrice: 0.0,
 	earlyTime: 0,

--- a/src/api/series-api.ts
+++ b/src/api/series-api.ts
@@ -4,6 +4,7 @@ import { ensureNotNull } from '../helpers/assertions';
 import { clone, merge } from '../helpers/strict-type-checks';
 
 import { BarPrice } from '../model/bar';
+import { BoxOptions } from '../model/box-options';
 import { Coordinate } from '../model/coordinate';
 import { MismatchDirection } from '../model/plot-list';
 import { CreatePriceLineOptions, PriceLineOptions } from '../model/price-line-options';
@@ -18,14 +19,17 @@ import {
 import { Logical, OriginalTime, Range, Time, TimePoint, TimePointIndex } from '../model/time-data';
 import { TimeScaleVisibleRange } from '../model/time-scale-visible-range';
 
+import { Box } from './box-api';
 import { IPriceScaleApiProvider } from './chart-api';
 import { DataUpdatesConsumer, SeriesDataItemTypeMap } from './data-consumer';
 import { convertTime } from './data-layer';
-import { checkItemsAreOrdered, checkPriceLineOptions, checkSeriesValuesType } from './data-validators';
+import { checkBoxOptions, checkItemsAreOrdered, checkPriceLineOptions, checkSeriesValuesType } from './data-validators';
 import { getSeriesDataCreator } from './get-series-data-creator';
+import { IBox } from './ibox';
 import { IPriceLine } from './iprice-line';
 import { IPriceScaleApi } from './iprice-scale-api';
 import { BarsInfo, ISeriesApi } from './iseries-api';
+import { boxOptionsDefaults } from './options/box-options-defaults';
 import { priceLineOptionsDefaults } from './options/price-line-options-defaults';
 import { PriceLine } from './price-line-api';
 
@@ -180,6 +184,18 @@ export class SeriesApi<TSeriesType extends SeriesType> implements ISeriesApi<TSe
 
 	public removePriceLine(line: IPriceLine): void {
 		this._series.removePriceLine((line as PriceLine).priceLine());
+	}
+
+	public createBox(options: BoxOptions): IBox {
+		checkBoxOptions(options);
+
+		const strictOptions = merge(clone(boxOptionsDefaults), options) as BoxOptions;
+		const box = this._series.createBox(strictOptions);
+		return new Box(box);
+	}
+
+	public removeBox(box: IBox): void {
+		this._series.removeBox((box as Box).box());
 	}
 
 	public seriesType(): TSeriesType {

--- a/src/api/series-api.ts
+++ b/src/api/series-api.ts
@@ -187,10 +187,12 @@ export class SeriesApi<TSeriesType extends SeriesType> implements ISeriesApi<TSe
 	}
 
 	public createBox(options: BoxOptions): IBox {
-		checkBoxOptions(options);
-
 		const strictOptions = merge(clone(boxOptionsDefaults), options) as BoxOptions;
+
+		checkBoxOptions(strictOptions);
+
 		const box = this._series.createBox(strictOptions);
+
 		return new Box(box);
 	}
 

--- a/src/model/box-options.ts
+++ b/src/model/box-options.ts
@@ -1,0 +1,79 @@
+import { LineStyle, LineWidth } from '../renderers/draw-line';
+
+/**
+ * Represents a box options.
+ */
+export interface BoxOptions {
+	/**
+	 * Line: bottom.
+	 *
+	 * @defaultValue `0`
+	 */
+	lowPrice: number;
+	/**
+	 * Line: top.
+	 *
+	 * @defaultValue `0`
+	 */
+	highPrice: number;
+	/**
+	 * Line: left.
+	 *
+	 * @defaultValue `0`
+	 */
+	earlyTime: number;
+	/**
+	 * Line: right.
+	 *
+	 * @defaultValue `0`
+	 */
+	lateTime: number;
+	/**
+	 * Border color.
+	 *
+	 * @defaultValue `''`
+	 */
+	borderColor: string;
+	/**
+	 * Border width in pixels.
+	 *
+	 * @defaultValue `1`
+	 */
+	borderWidth: LineWidth;
+	/**
+	 * Border style.
+	 *
+	 * @defaultValue {@link LineStyle.Solid}
+	 */
+	borderStyle: LineStyle;
+	/**
+	 * Fill color.
+	 *
+	 * @defaultValue `''`
+	 */
+	fillColor: string;
+	/**
+	 * Fill opacity.
+	 *
+	 * @defaultValue `1`
+	 */
+	fillOpacity: number;
+	/**
+	 * Display border.
+	 *
+	 * @defaultValue `true`
+	 */
+	borderVisible: boolean;
+	/**
+	 * Display the current price value in on the price scale.
+	 *
+	 * @defaultValue `false`
+	 */
+	axisLabelVisible: boolean;
+	/**
+	 * Price line's on the chart pane.
+	 *
+	 * @defaultValue `''`
+	 */
+	title: string;
+}

--- a/src/model/box-options.ts
+++ b/src/model/box-options.ts
@@ -1,9 +1,16 @@
+import { UserPoint } from '../model/point';
 import { LineStyle, LineWidth } from '../renderers/draw-line';
 
 /**
  * Represents a box options.
  */
 export interface BoxOptions {
+	/**
+	 * Corners of the shape.
+	 *
+	 * @defaultValue `[]`
+	 */
+	corners: UserPoint[];
 	/**
 	 * Line: bottom.
 	 *

--- a/src/model/custom-box.ts
+++ b/src/model/custom-box.ts
@@ -1,0 +1,103 @@
+import { merge } from '../helpers/strict-type-checks';
+
+import { CustomBoxPaneView } from '../views/pane/custom-box-pane-view';
+import { IPaneView } from '../views/pane/ipane-view';
+// TODO: show prices for box Y coords
+// import { PanePriceAxisView } from '../views/pane/pane-price-axis-view';
+// import { CustomPriceLinePriceAxisView } from '../views/price-axis/custom-price-line-price-axis-view';
+// import { IPriceAxisView } from '../views/price-axis/iprice-axis-view';
+
+import { BoxOptions } from './box-options';
+import { Coordinate } from './coordinate';
+import { Series } from './series';
+import { UTCTimestamp } from './time-data';
+
+export class CustomBox {
+	private readonly _series: Series;
+	private readonly _boxView: CustomBoxPaneView;
+	// private readonly _priceAxisView: CustomPriceLinePriceAxisView;
+	// private readonly _panePriceAxisView: PanePriceAxisView;
+	private readonly _options: BoxOptions;
+
+	public constructor(series: Series, options: BoxOptions) {
+		this._series = series;
+		this._options = options;
+		this._boxView = new CustomBoxPaneView(series, this);
+		// this._priceAxisView = new CustomPriceLinePriceAxisView(series, this);
+		// this._panePriceAxisView = new PanePriceAxisView(this._priceAxisView, series, series.model());
+	}
+
+	public applyOptions(options: Partial<BoxOptions>): void {
+		merge(this._options, options);
+		this.update();
+		this._series.model().lightUpdate();
+	}
+
+	public options(): BoxOptions {
+		return this._options;
+	}
+
+	public paneView(): IPaneView {
+		return this._boxView;
+	}
+
+	// public labelPaneView(): IPaneView {
+	// 	return this._panePriceAxisView;
+	// }
+
+	// public priceAxisView(): IPriceAxisView {
+	// 	return this._priceAxisView;
+	// }
+
+	public update(): void {
+		this._boxView.update();
+		// this._priceAxisView.update();
+	}
+
+	public xLowCoord(): Coordinate | null {
+		return this._xCoord(this._options.earlyTime as UTCTimestamp);
+	}
+
+	public xHighCoord(): Coordinate | null {
+		return this._xCoord(this._options.lateTime as UTCTimestamp);
+	}
+
+	public yLowCoord(): Coordinate | null {
+		// low Y coord = the high price (it is intentionally flipped)
+		return this._yCoord(this._options.highPrice);
+	}
+
+	public yHighCoord(): Coordinate | null {
+		// high Y coord = the low price (it is intentionally flipped)
+		return this._yCoord(this._options.lowPrice);
+	}
+
+	private _xCoord(time: UTCTimestamp): Coordinate | null {
+		const series = this._series;
+		const timeScale = series.model().timeScale();
+		const timeIndex = timeScale.timeToIndex({ timestamp: time }, true);
+
+		if (timeScale.isEmpty() || timeIndex === null) {
+			return null;
+		}
+
+		return timeScale.indexToCoordinate(timeIndex);
+	}
+
+	private _yCoord(price: number): Coordinate | null {
+		const series = this._series;
+		const priceScale = series.priceScale();
+		const timeScale = series.model().timeScale();
+
+		if (timeScale.isEmpty() || priceScale.isEmpty()) {
+			return null;
+		}
+
+		const firstValue = series.firstValue();
+		if (firstValue === null) {
+			return null;
+		}
+
+		return priceScale.priceToCoordinate(price, firstValue.value);
+	}
+}

--- a/src/model/custom-box.ts
+++ b/src/model/custom-box.ts
@@ -55,24 +55,24 @@ export class CustomBox {
 	}
 
 	public xLowCoord(): Coordinate | null {
-		return this._xCoord(this._options.earlyTime as UTCTimestamp);
+		return this.xCoord(this._options.earlyTime as UTCTimestamp);
 	}
 
 	public xHighCoord(): Coordinate | null {
-		return this._xCoord(this._options.lateTime as UTCTimestamp);
+		return this.xCoord(this._options.lateTime as UTCTimestamp);
 	}
 
 	public yLowCoord(): Coordinate | null {
 		// low Y coord = the high price (it is intentionally flipped)
-		return this._yCoord(this._options.highPrice);
+		return this.yCoord(this._options.highPrice);
 	}
 
 	public yHighCoord(): Coordinate | null {
 		// high Y coord = the low price (it is intentionally flipped)
-		return this._yCoord(this._options.lowPrice);
+		return this.yCoord(this._options.lowPrice);
 	}
 
-	private _xCoord(time: UTCTimestamp): Coordinate | null {
+	public xCoord(time: UTCTimestamp): Coordinate | null {
 		const series = this._series;
 		const timeScale = series.model().timeScale();
 		const timeIndex = timeScale.timeToIndex({ timestamp: time }, true);
@@ -84,7 +84,7 @@ export class CustomBox {
 		return timeScale.indexToCoordinate(timeIndex);
 	}
 
-	private _yCoord(price: number): Coordinate | null {
+	public yCoord(price: number): Coordinate | null {
 		const series = this._series;
 		const priceScale = series.priceScale();
 		const timeScale = series.model().timeScale();

--- a/src/model/point.ts
+++ b/src/model/point.ts
@@ -13,3 +13,17 @@ export interface Point {
 	 */
 	readonly y: Coordinate;
 }
+
+/**
+ * Represents a point input from the user.
+ */
+export interface UserPoint {
+	/**
+	 * The x coordinate.
+	 */
+	readonly time: number;
+	/**
+	 * The y coordinate.
+	 */
+	readonly price: number;
+}

--- a/src/renderers/box-renderer.ts
+++ b/src/renderers/box-renderer.ts
@@ -1,0 +1,95 @@
+import { Coordinate } from '../model/coordinate';
+
+import { LineStyle, LineWidth, setLineStyle } from './draw-line';
+import { IPaneRenderer } from './ipane-renderer';
+
+export interface BoxRendererData {
+	fillColor: string;
+	fillOpacity: number;
+	borderColor: string;
+	borderStyle: LineStyle;
+	borderWidth: LineWidth;
+	borderVisible: boolean;
+
+	xLow: Coordinate; // earlyTime
+	xHigh: Coordinate; // lateTime
+	yLow: Coordinate; // lowPrice
+	yHigh: Coordinate; // highPrice
+	visible?: boolean;
+
+	// axisLabelVisible
+	// title
+	width: number; // Canvas width?
+	height: number; // Canvas height?
+}
+
+export class BoxRenderer implements IPaneRenderer {
+	private _data: BoxRendererData | null = null;
+
+	public setData(data: BoxRendererData): void {
+		this._data = data;
+	}
+
+	public draw(ctx: CanvasRenderingContext2D, pixelRatio: number, isHovered: boolean, hitTestData?: unknown): void {
+		if (this._data === null) {
+			return;
+		}
+
+		if (this._data.visible === false) {
+			return;
+		}
+
+		const height = Math.ceil(this._data.height * pixelRatio);
+		const yLow = Math.round(this._data.yLow * pixelRatio);
+
+		if (yLow > height) {
+			return;
+		}
+
+		const yHigh = Math.round(this._data.yHigh * pixelRatio);
+
+		if (yHigh < 0) {
+			return;
+		}
+
+		const width = Math.ceil(this._data.width * pixelRatio);
+		const xLow = Math.round(this._data.xLow * pixelRatio);
+
+		if (xLow > width) {
+			return;
+		}
+
+		const xHigh = Math.round(this._data.xHigh * pixelRatio);
+
+		if (xHigh < 0) {
+			return;
+		}
+
+		ctx.beginPath();
+		ctx.fillStyle = this._hexToRgba(this._data.fillColor, this._data.fillOpacity);
+		ctx.fillRect(xLow, yLow, xHigh - xLow, yHigh - yLow);
+
+		if (this._data.borderVisible) {
+			ctx.strokeStyle = this._data.borderColor;
+			ctx.lineWidth = this._data.borderWidth;
+			setLineStyle(ctx, this._data.borderStyle);
+			ctx.strokeRect(xLow, yLow, xHigh - xLow, yHigh - yLow);
+		}
+
+		ctx.stroke();
+	}
+
+	private _hexToRgba(hex: string, opacity: number): string {
+		hex = hex.substring(1);
+
+		if (hex.length === 3) {
+			hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`;
+		}
+
+		const r = parseInt(hex.substring(0, 2), 16);
+		const g = parseInt(hex.substring(2, 4), 16);
+		const b = parseInt(hex.substring(4, 6), 16);
+
+		return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+	}
+}

--- a/src/renderers/box-renderer.ts
+++ b/src/renderers/box-renderer.ts
@@ -1,4 +1,5 @@
 import { Coordinate } from '../model/coordinate';
+import { Point } from '../model/point';
 
 import { LineStyle, LineWidth, setLineStyle } from './draw-line';
 import { IPaneRenderer } from './ipane-renderer';
@@ -11,6 +12,7 @@ export interface BoxRendererData {
 	borderWidth: LineWidth;
 	borderVisible: boolean;
 
+	corners: Point[];
 	xLow: Coordinate; // earlyTime
 	xHigh: Coordinate; // lateTime
 	yLow: Coordinate; // lowPrice
@@ -39,41 +41,64 @@ export class BoxRenderer implements IPaneRenderer {
 			return;
 		}
 
-		const height = Math.ceil(this._data.height * pixelRatio);
-		const yLow = Math.round(this._data.yLow * pixelRatio);
+		let corners: Point[] = [];
 
-		if (yLow > height) {
-			return;
-		}
+		if (this._data.corners.length === 0) {
+			const height = Math.ceil(this._data.height * pixelRatio);
+			const yLow = Math.round(this._data.yLow * pixelRatio) as Coordinate;
 
-		const yHigh = Math.round(this._data.yHigh * pixelRatio);
+			if (yLow > height) {
+				return;
+			}
 
-		if (yHigh < 0) {
-			return;
-		}
+			const yHigh = Math.round(this._data.yHigh * pixelRatio) as Coordinate;
 
-		const width = Math.ceil(this._data.width * pixelRatio);
-		const xLow = Math.round(this._data.xLow * pixelRatio);
+			if (yHigh < 0) {
+				return;
+			}
 
-		if (xLow > width) {
-			return;
-		}
+			const width = Math.ceil(this._data.width * pixelRatio);
+			const xLow = Math.round(this._data.xLow * pixelRatio) as Coordinate;
 
-		const xHigh = Math.round(this._data.xHigh * pixelRatio);
+			if (xLow > width) {
+				return;
+			}
 
-		if (xHigh < 0) {
-			return;
+			const xHigh = Math.round(this._data.xHigh * pixelRatio) as Coordinate;
+
+			if (xHigh < 0) {
+				return;
+			}
+
+			corners = [
+				{ x: xLow, y: yLow },
+				{ x: xLow, y: yHigh },
+				{ x: xHigh, y: yHigh },
+				{ x: xHigh, y: yLow },
+			];
+		} else {
+			for (let i = 0; i < this._data.corners.length; ++i) {
+				corners.push({
+					x: Math.round(this._data.corners[i].x * pixelRatio) as Coordinate,
+					y: Math.round(this._data.corners[i].y * pixelRatio) as Coordinate,
+				});
+			}
 		}
 
 		ctx.beginPath();
+		ctx.moveTo(corners[corners.length - 1].x, corners[corners.length - 1].y);
+
+		for (let i = 0; i < corners.length; ++i) {
+			ctx.lineTo(corners[i].x, corners[i].y);
+		}
+
 		ctx.fillStyle = this._hexToRgba(this._data.fillColor, this._data.fillOpacity);
-		ctx.fillRect(xLow, yLow, xHigh - xLow, yHigh - yLow);
+		ctx.fill();
 
 		if (this._data.borderVisible) {
 			ctx.strokeStyle = this._data.borderColor;
 			ctx.lineWidth = this._data.borderWidth;
 			setLineStyle(ctx, this._data.borderStyle);
-			ctx.strokeRect(xLow, yLow, xHigh - xLow, yHigh - yLow);
 		}
 
 		ctx.stroke();

--- a/src/renderers/box-renderer.ts
+++ b/src/renderers/box-renderer.ts
@@ -1,8 +1,10 @@
+import { BitmapCoordinatesRenderingScope } from 'fancy-canvas';
+
 import { Coordinate } from '../model/coordinate';
 import { Point } from '../model/point';
 
+import { BitmapCoordinatesPaneRenderer } from './bitmap-coordinates-pane-renderer';
 import { LineStyle, LineWidth, setLineStyle } from './draw-line';
-import { IPaneRenderer } from './ipane-renderer';
 
 export interface BoxRendererData {
 	fillColor: string;
@@ -25,14 +27,14 @@ export interface BoxRendererData {
 	height: number; // Canvas height?
 }
 
-export class BoxRenderer implements IPaneRenderer {
+export class BoxRenderer extends BitmapCoordinatesPaneRenderer {
 	private _data: BoxRendererData | null = null;
 
 	public setData(data: BoxRendererData): void {
 		this._data = data;
 	}
 
-	public draw(ctx: CanvasRenderingContext2D, pixelRatio: number, isHovered: boolean, hitTestData?: unknown): void {
+	protected _drawImpl({ context: ctx, bitmapSize, horizontalPixelRatio, verticalPixelRatio }: BitmapCoordinatesRenderingScope): void {
 		if (this._data === null) {
 			return;
 		}
@@ -44,27 +46,25 @@ export class BoxRenderer implements IPaneRenderer {
 		let corners: Point[] = [];
 
 		if (this._data.corners.length === 0) {
-			const height = Math.ceil(this._data.height * pixelRatio);
-			const yLow = Math.round(this._data.yLow * pixelRatio) as Coordinate;
+			const yLow = Math.round(this._data.yLow * verticalPixelRatio) as Coordinate;
 
-			if (yLow > height) {
+			if (yLow > bitmapSize.height) {
 				return;
 			}
 
-			const yHigh = Math.round(this._data.yHigh * pixelRatio) as Coordinate;
+			const yHigh = Math.round(this._data.yHigh * verticalPixelRatio) as Coordinate;
 
 			if (yHigh < 0) {
 				return;
 			}
 
-			const width = Math.ceil(this._data.width * pixelRatio);
-			const xLow = Math.round(this._data.xLow * pixelRatio) as Coordinate;
+			const xLow = Math.round(this._data.xLow * horizontalPixelRatio) as Coordinate;
 
-			if (xLow > width) {
+			if (xLow > bitmapSize.width) {
 				return;
 			}
 
-			const xHigh = Math.round(this._data.xHigh * pixelRatio) as Coordinate;
+			const xHigh = Math.round(this._data.xHigh * horizontalPixelRatio) as Coordinate;
 
 			if (xHigh < 0) {
 				return;
@@ -79,8 +79,8 @@ export class BoxRenderer implements IPaneRenderer {
 		} else {
 			for (let i = 0; i < this._data.corners.length; ++i) {
 				corners.push({
-					x: Math.round(this._data.corners[i].x * pixelRatio) as Coordinate,
-					y: Math.round(this._data.corners[i].y * pixelRatio) as Coordinate,
+					x: Math.round(this._data.corners[i].x * horizontalPixelRatio) as Coordinate,
+					y: Math.round(this._data.corners[i].y * verticalPixelRatio) as Coordinate,
 				});
 			}
 		}

--- a/src/renderers/box-renderer.ts
+++ b/src/renderers/box-renderer.ts
@@ -99,6 +99,9 @@ export class BoxRenderer implements IPaneRenderer {
 			ctx.strokeStyle = this._data.borderColor;
 			ctx.lineWidth = this._data.borderWidth;
 			setLineStyle(ctx, this._data.borderStyle);
+		} else { // border will default to a thin black line without the following
+			ctx.lineWidth = 0.00001;
+			ctx.strokeStyle = this._hexToRgba(this._data.fillColor, this._data.fillOpacity);
 		}
 
 		ctx.stroke();

--- a/src/views/pane/custom-box-pane-view.ts
+++ b/src/views/pane/custom-box-pane-view.ts
@@ -1,0 +1,53 @@
+import { CustomBox } from '../../model/custom-box';
+import { Series } from '../../model/series';
+
+import { SeriesBoxPaneView } from './series-box-pane-view';
+
+export class CustomBoxPaneView extends SeriesBoxPaneView {
+	private readonly _box: CustomBox;
+
+	public constructor(series: Series, box: CustomBox) {
+		super(series);
+		this._box = box;
+	}
+
+	protected _updateImpl(height: number, width: number): void {
+		const data = this._boxRendererData;
+		data.visible = false;
+
+		const boxOptions = this._box.options();
+
+		if (!this._series.visible()) {
+			return;
+		}
+
+		const yLow = this._box.yLowCoord();
+		const yHigh = this._box.yHighCoord();
+
+		if (yLow === null || yHigh === null) {
+			return;
+		}
+
+		const xLow = this._box.xLowCoord();
+		const xHigh = this._box.xHighCoord();
+
+		if (xLow === null || xHigh === null) {
+			return;
+		}
+
+		data.fillColor = boxOptions.fillColor;
+		data.fillOpacity = boxOptions.fillOpacity;
+		data.borderColor = boxOptions.borderColor;
+		data.borderStyle = boxOptions.borderStyle;
+		data.borderWidth = boxOptions.borderWidth;
+		data.borderVisible = boxOptions.borderVisible;
+		data.xLow = xLow;
+		data.xHigh = xHigh;
+		data.yLow = yLow;
+		data.yHigh = yHigh;
+		data.visible = true;
+
+		data.width = width;
+		data.height = height;
+	}
+}

--- a/src/views/pane/custom-box-pane-view.ts
+++ b/src/views/pane/custom-box-pane-view.ts
@@ -12,7 +12,7 @@ export class CustomBoxPaneView extends SeriesBoxPaneView {
 		this._box = box;
 	}
 
-	protected _updateImpl(height: number, width: number): void {
+	protected _updateImpl(): void {
 		const data = this._boxRendererData;
 		const boxOptions = this._box.options();
 
@@ -30,9 +30,6 @@ export class CustomBoxPaneView extends SeriesBoxPaneView {
 		data.borderVisible = boxOptions.borderVisible;
 		data.corners = [];
 		data.visible = true;
-
-		data.width = width;
-		data.height = height;
 
 		if (boxOptions.corners.length === 0) {
 			const yLow = this._box.yLowCoord();

--- a/src/views/pane/custom-box-pane-view.ts
+++ b/src/views/pane/custom-box-pane-view.ts
@@ -1,5 +1,6 @@
 import { CustomBox } from '../../model/custom-box';
 import { Series } from '../../model/series';
+import { UTCTimestamp } from '../../model/time-data';
 
 import { SeriesBoxPaneView } from './series-box-pane-view';
 
@@ -13,25 +14,11 @@ export class CustomBoxPaneView extends SeriesBoxPaneView {
 
 	protected _updateImpl(height: number, width: number): void {
 		const data = this._boxRendererData;
-		data.visible = false;
-
 		const boxOptions = this._box.options();
 
+		data.visible = false;
+
 		if (!this._series.visible()) {
-			return;
-		}
-
-		const yLow = this._box.yLowCoord();
-		const yHigh = this._box.yHighCoord();
-
-		if (yLow === null || yHigh === null) {
-			return;
-		}
-
-		const xLow = this._box.xLowCoord();
-		const xHigh = this._box.xHighCoord();
-
-		if (xLow === null || xHigh === null) {
 			return;
 		}
 
@@ -41,13 +28,42 @@ export class CustomBoxPaneView extends SeriesBoxPaneView {
 		data.borderStyle = boxOptions.borderStyle;
 		data.borderWidth = boxOptions.borderWidth;
 		data.borderVisible = boxOptions.borderVisible;
-		data.xLow = xLow;
-		data.xHigh = xHigh;
-		data.yLow = yLow;
-		data.yHigh = yHigh;
+		data.corners = [];
 		data.visible = true;
 
 		data.width = width;
 		data.height = height;
+
+		if (boxOptions.corners.length === 0) {
+			const yLow = this._box.yLowCoord();
+			const yHigh = this._box.yHighCoord();
+
+			if (yLow === null || yHigh === null) {
+				return;
+			}
+
+			const xLow = this._box.xLowCoord();
+			const xHigh = this._box.xHighCoord();
+
+			if (xLow === null || xHigh === null) {
+				return;
+			}
+
+			data.xLow = xLow;
+			data.xHigh = xHigh;
+			data.yLow = yLow;
+			data.yHigh = yHigh;
+		} else {
+			for (let i = 0; i < boxOptions.corners.length; ++i) {
+				const x = this._box.xCoord(boxOptions.corners[i].time as UTCTimestamp);
+				const y = this._box.yCoord(boxOptions.corners[i].price);
+
+				if (x === null || y === null) {
+					return;
+				}
+
+				data.corners.push({ x: x, y: y });
+			}
+		}
 	}
 }

--- a/src/views/pane/series-box-pane-view.ts
+++ b/src/views/pane/series-box-pane-view.ts
@@ -1,0 +1,56 @@
+import { ChartModel } from '../../model/chart-model';
+import { Coordinate } from '../../model/coordinate';
+import { Series } from '../../model/series';
+import { BoxRenderer, BoxRendererData } from '../../renderers/box-renderer';
+import { LineStyle } from '../../renderers/draw-line';
+import { IPaneRenderer } from '../../renderers/ipane-renderer';
+
+import { IPaneView } from './ipane-view';
+
+export abstract class SeriesBoxPaneView implements IPaneView {
+	protected readonly _boxRendererData: BoxRendererData = {
+		fillColor: '#000',
+		fillOpacity: 1,
+		borderColor: '#000',
+		borderStyle: LineStyle.Solid,
+		borderWidth: 1,
+		borderVisible: false,
+		xLow: 0 as Coordinate,
+		xHigh: 0 as Coordinate,
+		yLow: 0 as Coordinate,
+		yHigh: 0 as Coordinate,
+		visible: false,
+
+		width: 0,
+		height: 0,
+	};
+
+	protected readonly _series: Series;
+	protected readonly _model: ChartModel;
+	protected readonly _boxRenderer: BoxRenderer = new BoxRenderer();
+	private _invalidated: boolean = true;
+
+	protected constructor(series: Series) {
+		this._series = series;
+		this._model = series.model();
+		this._boxRenderer.setData(this._boxRendererData);
+	}
+
+	public update(): void {
+		this._invalidated = true;
+	}
+
+	public renderer(height: number, width: number): IPaneRenderer | null {
+		if (!this._series.visible()) {
+			return null;
+		}
+
+		if (this._invalidated) {
+			this._updateImpl(height, width);
+			this._invalidated = false;
+		}
+		return this._boxRenderer;
+	}
+
+	protected abstract _updateImpl(height: number, width: number): void;
+}

--- a/src/views/pane/series-box-pane-view.ts
+++ b/src/views/pane/series-box-pane-view.ts
@@ -15,6 +15,7 @@ export abstract class SeriesBoxPaneView implements IPaneView {
 		borderStyle: LineStyle.Solid,
 		borderWidth: 1,
 		borderVisible: false,
+		corners: [],
 		xLow: 0 as Coordinate,
 		xHigh: 0 as Coordinate,
 		yLow: 0 as Coordinate,

--- a/src/views/pane/series-box-pane-view.ts
+++ b/src/views/pane/series-box-pane-view.ts
@@ -41,17 +41,17 @@ export abstract class SeriesBoxPaneView implements IPaneView {
 		this._invalidated = true;
 	}
 
-	public renderer(height: number, width: number): IPaneRenderer | null {
+	public renderer(): IPaneRenderer | null {
 		if (!this._series.visible()) {
 			return null;
 		}
 
 		if (this._invalidated) {
-			this._updateImpl(height, width);
+			this._updateImpl();
 			this._invalidated = false;
 		}
 		return this._boxRenderer;
 	}
 
-	protected abstract _updateImpl(height: number, width: number): void;
+	protected abstract _updateImpl(): void;
 }


### PR DESCRIPTION
**Type of PR:** Enhancement

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

I have implemented basic box/rectangle drawing. This feature has been requested a few times in the past (#706, #408, in online chatrooms, on discord, etc). I realise it has been discussed to expose the raw canvas also as a potential solution, but it seems there is some complexity around this (e.g. there are multiple canvases). It also feels as though basic features such as this (that complement the line drawing abilities) would be much better suited to be integrated into the library itself (which would also benefit from having the objects rescaled upon the rescaling of axes).

Things done:
 - Box creation based upon two prices and two times
 - Box moving with the rescaling of the axes
 - Box border (with colour, styling, thickness, and the ability to disable it)
 - Box fill colour with configurable opacity

Things remaining to do:
 - Ability to add a title to the box
 - Add prices to the Y axis for the top/bottom of the box
 - Add tests
 - Update the documentation

If this is desirable to have in the main project, then I am happy to spend some more time on finishing things up. If this is not desirable though, then I'll simply use my fork, and this PR can be closed.

Code example:
```js
const box = {
  lowPrice: 2713.0,
  highPrice: 2797.0,
  earlyTime: 1641409200,
  lateTime: 1641823200,
  borderColor: '#00008B',
  borderWidth: 3,
  borderStyle: LightweightCharts.LineStyle.Dashed,
  fillColor: '#0ff',
  fillOpacity: 0.2,
  borderVisible: true,
  axisLabelVisible: false,
  title: 'My box',
};

const createdBox = mainSeries.createBox(box);

// mainSeries.removeBox(createdBox);
```

<details>
  <summary>Example pictures</summary>
  <img width="1166" alt="Screenshot 2022-04-17 at 16 52 55" src="https://user-images.githubusercontent.com/1403064/163722223-f5d6cf4d-2143-4af2-b1ee-6a94aadb8892.png">
  
  ![ezgif-2-4852b5dc20](https://user-images.githubusercontent.com/1403064/163722771-208bc068-2a8d-4313-83f7-910656cd5d99.gif)
</details>

**Is there anything you'd like reviewers to focus on?**

Whether this feature is desirable to have in the core library.

# PR Update:
See https://github.com/tradingview/lightweight-charts/pull/1064#issuecomment-1304812364 of this PR for more abilities.