### PR TITLE
Fire clicked delegate on tap event

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,11 +4,11 @@ module.exports = [
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.esm.production.js',
-		limit: '43.02 KB',
+		limit: '43.03 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '43.58 KB',
+		limit: '43.6 KB',
 	},
 ];

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -20,7 +20,7 @@ import { IPaneView } from '../views/pane/ipane-view';
 import { createBoundCanvas, getContext2D, Size } from './canvas-utils';
 import { ChartWidget } from './chart-widget';
 import { KineticAnimation } from './kinetic-animation';
-import { MouseEventHandler, MouseEventHandlerMouseEvent, MouseEventHandlers, MouseEventHandlerTouchEvent, Position, TouchMouseEvent } from './mouse-event-handler';
+import { MouseEventHandler, MouseEventHandlerEventBase, MouseEventHandlerMouseEvent, MouseEventHandlers, MouseEventHandlerTouchEvent, Position, TouchMouseEvent } from './mouse-event-handler';
 import { PriceAxisWidget, PriceAxisWidgetSide } from './price-axis-widget';
 
 const enum Constants {
@@ -276,14 +276,7 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 			return;
 		}
 		this._onMouseEvent();
-
-		const x = event.localX;
-		const y = event.localY;
-
-		if (this._clicked.hasListeners()) {
-			const currentTime = this._model().crosshairSource().appliedIndex();
-			this._clicked.fire(currentTime, { x, y });
-		}
+		this._fireClickedDelegate(event);
 	}
 
 	public pressedMouseMoveEvent(event: MouseEventHandlerMouseEvent): void {
@@ -301,6 +294,13 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 		this._longTap = false;
 
 		this._endScroll(event);
+	}
+
+	public tapEvent(event: MouseEventHandlerTouchEvent): void {
+		if (this._state === null) {
+			return;
+		}
+		this._fireClickedDelegate(event);
 	}
 
 	public longTapEvent(event: MouseEventHandlerTouchEvent): void {
@@ -507,6 +507,15 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 		}
 
 		this._state = null;
+	}
+
+	private _fireClickedDelegate(event: MouseEventHandlerEventBase): void {
+		const x = event.localX;
+		const y = event.localY;
+
+		if (this._clicked.hasListeners()) {
+			this._clicked.fire(this._model().timeScale().coordinateToIndex(x), { x, y });
+		}
 	}
 
 	private _drawBackground(ctx: CanvasRenderingContext2D, pixelRatio: number): void {


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes https://github.com/tradingview/lightweight-charts-android/issues/117
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

`touchend` events used to fire click subscribers when touch events shared a handler with mouse events but it was broken here: https://github.com/tradingview/lightweight-charts/pull/972/files#diff-a8593fafd0e49d2f131e71359219e132a0c427ffde2a361da4d501ef97557bb5L328

These changes handle the tap event and fire the click subscribers. 

<!-- optional -->
