### PR TITLE
Fix ts2746 error

### DIFF
--- a/website/plugins/enhanced-codeblock/theme/CodeBlock/chart.tsx
+++ b/website/plugins/enhanced-codeblock/theme/CodeBlock/chart.tsx
@@ -9,8 +9,7 @@ interface ChartProps {
 }
 
 type IFrameWindow = Window & {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	createChart: (...args: Parameters<LightweightChartsApi['createChart']>) => any;
+	createChart: (...args: Parameters<LightweightChartsApi['createChart']>) => ReturnType<LightweightChartsApi['createChart']>;
 	run?: () => void;
 };
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -206,7 +206,7 @@ function Index(): JSX.Element {
 				</div>
 				<div className={[styles.SmallCard, styles.SmallCard2].join(' ')}>
 					<Paperplane />
-					<h3>Ultra lightweight - just {siteConfig.customFields?.bundleSize} Kb</h3>
+					<h3>{`Ultra lightweight - just ${siteConfig.customFields?.bundleSize} Kb`}</h3>
 					<p>HTML5 Canvas technology no larger than a standard GIF file.</p>
 				</div>
 				<div className={[styles.SmallCard, styles.SmallCard3].join(' ')}>


### PR DESCRIPTION
**Type of PR:** bugfix

Fix a ts lint error (see below) and improve the types used in the chart code block plugin.

```
$ npm run tsc-verify

> lightweight-charts@4.0.0 tsc-verify
> node website/scripts/generate-versions-dts.js && tsc -b tsconfig.composite.json

website/src/pages/index.tsx:209:7 - error TS2746: This JSX tag's 'children' prop expects a single child of type 'ReactNode', but multiple children were provided.

209      <h3>Ultra lightweight - just {siteConfig.customFields?.bundleSize} Kb</h3>
          ~~


Found 1 error.
```