### PR TITLE
fix tests for newer version of puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "npm-run-all": "~4.1.5",
     "pixelmatch": "~5.3.0",
     "pngjs": "~6.0.0",
-    "puppeteer": "~16.1.0",
+    "puppeteer": "~16.1.1",
     "rimraf": "~3.0.2",
     "rollup": "~2.77.2",
     "rollup-plugin-terser": "~7.0.2",


### PR DESCRIPTION
**Type of PR:** bugfix

**Issue:**

Minor puppeteer update (16.1.1) breaks the coverage and memory leak tests due to:
* added deprecations 
* and removal of a private field.

**Overview of change:**

* updated the puppeteer version in the package.json to `~16.1.1`.
* updated the `doMouseScrolls` function to use the `page.mouse.wheel()` method.
* replaced any calls to `frame.executionContext()` which has been deprecated in favour of methods on the `Page` instance.
* replaced deprecated `page.waitForTimeout` method

**Note:**

* coverage test was already failing `85.4% < 87.0% (±1.0%)` and this PR doesn't resolve that issue.

**Checked:**
- [x] `npm run verify`
- [x] mem tests run and pass
- [x] graphics tests run and pass
- [x] coverage test runs (but fails, which was expected and correct)  

**Alternative:**

We could alternatively fix the puppeteer version to `16.1.0` by removing the `~` from the version specified within the package.json

**References:**

* Commit which broke the tests: https://github.com/puppeteer/puppeteer/commit/a238f5758dd2c0e92186966478cd382affac2280#
* [puppeteer.mouse.wheel](https://pptr.dev/api/puppeteer.mouse.wheel)
* deprecated : [puppeteer.executionContext](https://pptr.dev/api/puppeteer.executioncontext)
* deprecated : [puppeteer.page.waitfortimeout](https://pptr.dev/api/puppeteer.page.waitfortimeout)
* deprecated : [puppeteer.executioncontext.queryobjects](https://pptr.dev/api/puppeteer.executioncontext.queryobjects)
* [puppeteer.page.queryobjects](https://pptr.dev/api/puppeteer.page.queryobjects)