### PR TITLE
fix type for createPriceLine options parameter

### DIFF
--- a/src/api/data-validators.ts
+++ b/src/api/data-validators.ts
@@ -8,12 +8,11 @@ import { Time } from '../model/time-data';
 import { isFulfilledData, SeriesDataItemTypeMap } from './data-consumer';
 import { convertTime } from './data-layer';
 
-export function checkPriceLineOptions(options: PriceLineOptions): void {
+export function checkPriceLineOptions(options: Partial<PriceLineOptions>): void {
 	if (process.env.NODE_ENV === 'production') {
 		return;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/tslint/config
 	assert(typeof options.price === 'number', `the type of 'price' price line's property must be a number, got '${typeof options.price}'`);
 }
 

--- a/src/api/data-validators.ts
+++ b/src/api/data-validators.ts
@@ -1,6 +1,6 @@
 import { assert } from '../helpers/assertions';
 
-import { PriceLineOptions } from '../model/price-line-options';
+import { CreatePriceLineOptions } from '../model/price-line-options';
 import { SeriesMarker } from '../model/series-markers';
 import { SeriesType } from '../model/series-options';
 import { Time } from '../model/time-data';
@@ -8,11 +8,12 @@ import { Time } from '../model/time-data';
 import { isFulfilledData, SeriesDataItemTypeMap } from './data-consumer';
 import { convertTime } from './data-layer';
 
-export function checkPriceLineOptions(options: Partial<PriceLineOptions>): void {
+export function checkPriceLineOptions(options: CreatePriceLineOptions): void {
 	if (process.env.NODE_ENV === 'production') {
 		return;
 	}
 
+	// eslint-disable-next-line @typescript-eslint/tslint/config
 	assert(typeof options.price === 'number', `the type of 'price' price line's property must be a number, got '${typeof options.price}'`);
 }
 

--- a/src/api/iseries-api.ts
+++ b/src/api/iseries-api.ts
@@ -3,7 +3,7 @@ import { IPriceFormatter } from '../formatters/iprice-formatter';
 import { BarPrice } from '../model/bar';
 import { Coordinate } from '../model/coordinate';
 import { MismatchDirection } from '../model/plot-list';
-import { PriceLineOptions } from '../model/price-line-options';
+import { CreatePriceLineOptions } from '../model/price-line-options';
 import { SeriesMarker } from '../model/series-markers';
 import {
 	SeriesOptionsMap,
@@ -222,7 +222,7 @@ export interface ISeriesApi<TSeriesType extends SeriesType> {
 	/**
 	 * Creates a new price line
 	 *
-	 * @param options - Any subset of options.
+	 * @param options - Any subset of options, however `price` is required.
 	 * @example
 	 * ```js
 	 * const priceLine = series.createPriceLine({
@@ -235,7 +235,7 @@ export interface ISeriesApi<TSeriesType extends SeriesType> {
 	 * });
 	 * ```
 	 */
-	createPriceLine(options: PriceLineOptions): IPriceLine;
+	createPriceLine(options: CreatePriceLineOptions): IPriceLine;
 
 	/**
 	 * Removes the price line that was created before.

--- a/src/api/series-api.ts
+++ b/src/api/series-api.ts
@@ -170,7 +170,7 @@ export class SeriesApi<TSeriesType extends SeriesType> implements ISeriesApi<TSe
 		return this._priceScaleApiProvider.priceScale(this._series.priceScale().id());
 	}
 
-	public createPriceLine(options: PriceLineOptions): IPriceLine {
+	public createPriceLine(options: Partial<PriceLineOptions>): IPriceLine {
 		checkPriceLineOptions(options);
 
 		const strictOptions = merge(clone(priceLineOptionsDefaults), options) as PriceLineOptions;

--- a/src/api/series-api.ts
+++ b/src/api/series-api.ts
@@ -6,7 +6,7 @@ import { clone, merge } from '../helpers/strict-type-checks';
 import { BarPrice } from '../model/bar';
 import { Coordinate } from '../model/coordinate';
 import { MismatchDirection } from '../model/plot-list';
-import { PriceLineOptions } from '../model/price-line-options';
+import { CreatePriceLineOptions, PriceLineOptions } from '../model/price-line-options';
 import { RangeImpl } from '../model/range-impl';
 import { Series } from '../model/series';
 import { SeriesMarker } from '../model/series-markers';
@@ -170,7 +170,7 @@ export class SeriesApi<TSeriesType extends SeriesType> implements ISeriesApi<TSe
 		return this._priceScaleApiProvider.priceScale(this._series.priceScale().id());
 	}
 
-	public createPriceLine(options: Partial<PriceLineOptions>): IPriceLine {
+	public createPriceLine(options: CreatePriceLineOptions): IPriceLine {
 		checkPriceLineOptions(options);
 
 		const strictOptions = merge(clone(priceLineOptionsDefaults), options) as PriceLineOptions;

--- a/src/model/price-line-options.ts
+++ b/src/model/price-line-options.ts
@@ -47,3 +47,10 @@ export interface PriceLineOptions {
 	 */
 	title: string;
 }
+
+/**
+ * Price line options for the {@link ISeriesApi.createPriceLine} method.
+ *
+ * `price` is required, while the rest of the options are optional.
+ */
+export type CreatePriceLineOptions = Partial<PriceLineOptions> & Pick<PriceLineOptions, 'price'>;


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1091
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

Some change to fix the type for the `createPriceLine` options parameter which should be a `Partial`
