### PR TITLE
Improve reliability of graphics tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "eslint-plugin-markdown": "~3.0.0",
     "eslint-plugin-mdx": "~1.17.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",
+    "eslint-plugin-react": "~7.30.1",
     "eslint-plugin-tsdoc": "~0.2.16",
     "eslint-plugin-unicorn": "~40.1.0",
-    "eslint-plugin-react": "~7.30.1",
     "express": "~4.18.1",
     "glob": "~8.0.3",
     "markdown-it": "~13.0.1",
@@ -83,7 +83,8 @@
     "tslint-eslint-rules": "~5.4.0",
     "tslint-microsoft-contrib": "~6.2.0",
     "ttypescript": "~1.5.13",
-    "typescript": "4.7.3"
+    "typescript": "4.7.3",
+    "yargs": "~17.6.0"
   },
   "scripts": {
     "postinstall": "npm run install-hooks",

--- a/tests/e2e/graphics/README.md
+++ b/tests/e2e/graphics/README.md
@@ -47,7 +47,13 @@ If file is local then local server will be runner to serve that file (see [serve
     After that in `.gendata/test-case-name/1.golden.html` you can find a HTML page.
     To open this page properly you can run `./tests/e2e/serve-static-files.js golden.js:./golden/standalone/module.js test.js:./test/standalone/module.js` and then open that page in the browser to debug.
 
-1. The following enviromental variables can be used to adjust the test:
+1. The following environmental variables can be used to adjust the test:
 
     - `PRODUCTION_BUILD`: Set to true if testing a Production build
     - `DEVICE_PIXEL_RATIO`: Device pixel ratio to simulate during the test (number)
+
+1. You can set Mocha options from the command line arguments:
+
+```bash
+node ./tests/e2e/graphics/runner.js ./path/to/golden/standalone/module.js ./path/to/test/standalone/module.js --bail --grep "add-series"
+```

--- a/tests/e2e/graphics/helpers/screenshoter.ts
+++ b/tests/e2e/graphics/helpers/screenshoter.ts
@@ -71,8 +71,27 @@ export class Screenshoter {
 				return (window as any).testCaseReady;
 			});
 
+			// move mouse to top-left corner
+			await page.mouse.move(0, 0);
+
+			const waitForMouseMove = page.evaluate(() => {
+				/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
+				if ((window as any).IGNORE_MOUSE_MOVE) { return Promise.resolve(); }
+				return new Promise<number[]>((resolve: (value: number[]) => void) => {
+					const chart = (window as any).getChartInstance();
+					chart.subscribeCrosshairMove((param: any) => {
+						if (param.point.x > 0 && param.point.y > 0) {
+							requestAnimationFrame(() => resolve([param.point.x, param.point.y] as number[]));
+						}
+					});
+				});
+				/* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
+			});
+
 			// to avoid random cursor position
 			await page.mouse.move(viewportWidth / 2, viewportHeight / 2);
+
+			await waitForMouseMove;
 
 			// let's wait until the next af to make sure that everything is repainted
 			await page.evaluate(() => {

--- a/tests/e2e/graphics/runner.js
+++ b/tests/e2e/graphics/runner.js
@@ -3,6 +3,9 @@
 const fs = require('fs');
 const path = require('path');
 
+const yargs = require('yargs/yargs');
+const argv = yargs(process.argv.slice(4)).argv;
+
 const Mocha = require('mocha');
 
 const serveLocalFiles = require('../serve-local-files').serveLocalFiles;
@@ -16,7 +19,7 @@ mochaConfig.require.forEach(module => {
 	require(module);
 });
 
-if (process.argv.length !== 4) {
+if (process.argv.length < 4) {
 	console.log('Usage: runner PATH_TO_GOLDEN_STANDALONE_MODULE PATH_TO_TEST_STANDALONE_MODULE');
 	process.exit(1);
 }
@@ -48,11 +51,18 @@ process.env.TEST_STANDALONE_PATH = testStandalonePath;
 
 function runMocha(closeServer) {
 	console.log('Running tests...');
+
+	/** @type Partial<Mocha.MochaOptions> */
+	const mochaOptions = Object.fromEntries(
+		Object.entries(argv).filter(entry => !['_', '$0'].includes(entry[0]))
+	);
+
 	const mocha = new Mocha({
 		timeout: 20000,
 		slow: 10000,
 		reporter: mochaConfig.reporter,
 		reporterOptions: mochaConfig._reporterOptions,
+		...mochaOptions,
 	});
 
 	if (mochaConfig.checkLeaks) {

--- a/tests/e2e/graphics/test-cases/.eslintrc.js
+++ b/tests/e2e/graphics/test-cases/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 		node: false,
 	},
 	rules: {
-		'no-unused-vars': ['error', { varsIgnorePattern: '^runTestCase$', args: 'none' }],
+		'no-unused-vars': ['error', { varsIgnorePattern: '^(runTestCase|getChartInstance)$', args: 'none' }],
 	},
 	globals: {
 		LightweightCharts: false,

--- a/tests/e2e/graphics/test-cases/add-series-after-time.js
+++ b/tests/e2e/graphics/test-cases/add-series-after-time.js
@@ -12,8 +12,15 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container, {
+		height: 500, width: 600,
+	});
 
 	return new Promise(resolve => {
 		setTimeout(() => {

--- a/tests/e2e/graphics/test-cases/api/getting-series-price-scale.js
+++ b/tests/e2e/graphics/test-cases/api/getting-series-price-scale.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const series = chart.addAreaSeries();
 	series.setData([
 		{ time: '1990-04-24', value: 0 },

--- a/tests/e2e/graphics/test-cases/api/price-scale-width.js
+++ b/tests/e2e/graphics/test-cases/api/price-scale-width.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			visible: true,
 		},

--- a/tests/e2e/graphics/test-cases/api/series-data-by-index.js
+++ b/tests/e2e/graphics/test-cases/api/series-data-by-index.js
@@ -89,8 +89,13 @@ function checkSeries(series, data, compareItemsFn) {
 	}
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries();
 	checkSeries(

--- a/tests/e2e/graphics/test-cases/api/series-markers.js
+++ b/tests/e2e/graphics/test-cases/api/series-markers.js
@@ -2,8 +2,13 @@ function compare(markers, seriesApiMarkers) {
 	return JSON.stringify(markers) === JSON.stringify(seriesApiMarkers);
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const series = chart.addAreaSeries();
 	series.setData([
 		{ time: '1990-04-24', value: 0 },

--- a/tests/e2e/graphics/test-cases/api/subscribe-crosshair-move.js
+++ b/tests/e2e/graphics/test-cases/api/subscribe-crosshair-move.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const series = chart.addAreaSeries();
 	series.setData([
 		{ time: '1990-04-24', value: 0 },

--- a/tests/e2e/graphics/test-cases/api/time-scale-coordinate-to-logical.js
+++ b/tests/e2e/graphics/test-cases/api/time-scale-coordinate-to-logical.js
@@ -1,6 +1,14 @@
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const width = 400;
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: width,
 		height: 200,
 		rightPriceScale: {

--- a/tests/e2e/graphics/test-cases/api/time-scale-coordinate-to-time.js
+++ b/tests/e2e/graphics/test-cases/api/time-scale-coordinate-to-time.js
@@ -1,6 +1,14 @@
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const width = 400;
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: width,
 		height: 200,
 		rightPriceScale: {

--- a/tests/e2e/graphics/test-cases/api/time-scale-logical-to-coordinate.js
+++ b/tests/e2e/graphics/test-cases/api/time-scale-logical-to-coordinate.js
@@ -2,9 +2,17 @@ function inRange(from, value, to) {
 	return !isNaN(value) && from < value && value < to;
 }
 
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const width = 400;
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: width,
 		height: 200,
 		rightPriceScale: {

--- a/tests/e2e/graphics/test-cases/api/time-scale-time-to-coordinate.js
+++ b/tests/e2e/graphics/test-cases/api/time-scale-time-to-coordinate.js
@@ -2,9 +2,17 @@ function inRange(from, value, to) {
 	return !isNaN(value) && from < value && value < to;
 }
 
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const width = 400;
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: width,
 		height: 200,
 		rightPriceScale: {

--- a/tests/e2e/graphics/test-cases/applying-options/apply-do-not-draw-price-ticks.js
+++ b/tests/e2e/graphics/test-cases/applying-options/apply-do-not-draw-price-ticks.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			ticksVisible: true,
 		},

--- a/tests/e2e/graphics/test-cases/applying-options/change-bar-colors.js
+++ b/tests/e2e/graphics/test-cases/applying-options/change-bar-colors.js
@@ -38,8 +38,13 @@ function generateData() {
 	];
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 40,
 			timeVisible: true,

--- a/tests/e2e/graphics/test-cases/applying-options/change-candlestick-colors.js
+++ b/tests/e2e/graphics/test-cases/applying-options/change-candlestick-colors.js
@@ -38,8 +38,13 @@ function generateData() {
 	];
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 40,
 			timeVisible: true,

--- a/tests/e2e/graphics/test-cases/applying-options/empty-time-scale-options.js
+++ b/tests/e2e/graphics/test-cases/applying-options/empty-time-scale-options.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/applying-options/fix-both-edges-then-scroll.js
+++ b/tests/e2e/graphics/test-cases/applying-options/fix-both-edges-then-scroll.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/applying-options/fix-both-edges-time-scale-labels.js
+++ b/tests/e2e/graphics/test-cases/applying-options/fix-both-edges-time-scale-labels.js
@@ -29,8 +29,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			fixLeftEdge: true,
 			fixRightEdge: true,

--- a/tests/e2e/graphics/test-cases/applying-options/fix-both-edges.js
+++ b/tests/e2e/graphics/test-cases/applying-options/fix-both-edges.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			fixLeftEdge: true,
 			fixRightEdge: true,

--- a/tests/e2e/graphics/test-cases/applying-options/fix-left-edge.js
+++ b/tests/e2e/graphics/test-cases/applying-options/fix-left-edge.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/applying-options/increase-min-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/applying-options/increase-min-bar-spacing.js
@@ -22,8 +22,13 @@ function generateData(startValue) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			minBarSpacing: 0.001,
 		},

--- a/tests/e2e/graphics/test-cases/applying-options/make-series-hidden.js
+++ b/tests/e2e/graphics/test-cases/applying-options/make-series-hidden.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.IndexedTo100,
 		},

--- a/tests/e2e/graphics/test-cases/applying-options/make-series-visible.js
+++ b/tests/e2e/graphics/test-cases/applying-options/make-series-visible.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.IndexedTo100,
 		},

--- a/tests/e2e/graphics/test-cases/applying-options/move-price-scale.js
+++ b/tests/e2e/graphics/test-cases/applying-options/move-price-scale.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: { visible: true },
 		leftPriceScale: { visible: false },
 	});

--- a/tests/e2e/graphics/test-cases/applying-options/move-series-from-right-to-left.js
+++ b/tests/e2e/graphics/test-cases/applying-options/move-series-from-right-to-left.js
@@ -13,8 +13,13 @@ function generateData(offset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
 		},

--- a/tests/e2e/graphics/test-cases/applying-options/move-series-to-overlay.js
+++ b/tests/e2e/graphics/test-cases/applying-options/move-series-to-overlay.js
@@ -13,8 +13,13 @@ function generateData(offset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addLineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/applying-options/reduce-min-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/applying-options/reduce-min-bar-spacing.js
@@ -22,8 +22,13 @@ function generateData(startValue) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/applying-options/scale-margins-for-overlay-series.js
+++ b/tests/e2e/graphics/test-cases/applying-options/scale-margins-for-overlay-series.js
@@ -13,8 +13,13 @@ function generateData(valueOffset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addLineSeries({
 		color: 'blue',

--- a/tests/e2e/graphics/test-cases/applying-options/scroll-to-future-then-fix-right-edge.js
+++ b/tests/e2e/graphics/test-cases/applying-options/scroll-to-future-then-fix-right-edge.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/applying-options/scroll-to-past-then-fix-right-edge.js
+++ b/tests/e2e/graphics/test-cases/applying-options/scroll-to-past-then-fix-right-edge.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/applying-options/series-price-format.js
+++ b/tests/e2e/graphics/test-cases/applying-options/series-price-format.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		priceFormat: {

--- a/tests/e2e/graphics/test-cases/applying-options/series-title.js
+++ b/tests/e2e/graphics/test-cases/applying-options/series-title.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addLineSeries({
 		title: 'Initial title',

--- a/tests/e2e/graphics/test-cases/applying-options/unfix-right-edge-then-scroll-to-future.js
+++ b/tests/e2e/graphics/test-cases/applying-options/unfix-right-edge-then-scroll-to-future.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/applying-options/update-chart-width.js
+++ b/tests/e2e/graphics/test-cases/applying-options/update-chart-width.js
@@ -22,9 +22,14 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const box = container.getBoundingClientRect();
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: 2000,
 		height: box.height,
 		timeScale: {

--- a/tests/e2e/graphics/test-cases/applying-options/watermark.js
+++ b/tests/e2e/graphics/test-cases/applying-options/watermark.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/applying-options/zoom-in-then-fix-both-edges.js
+++ b/tests/e2e/graphics/test-cases/applying-options/zoom-in-then-fix-both-edges.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/applying-options/zoom-out-then-fix-both-edges.js
+++ b/tests/e2e/graphics/test-cases/applying-options/zoom-out-then-fix-both-edges.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	mainSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/correct-price-range-in-autoscale.js
+++ b/tests/e2e/graphics/test-cases/correct-price-range-in-autoscale.js
@@ -14,8 +14,13 @@ function generateData(valueOffset, daysStep) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addLineSeries();
 	const secondSeries = chart.addLineSeries();

--- a/tests/e2e/graphics/test-cases/data-validation.js
+++ b/tests/e2e/graphics/test-cases/data-validation.js
@@ -5,6 +5,10 @@ function getChartInstance() {
 
 function runTestCase(container) {
 	if (window.BUILD_MODE === 'production') {
+		// Ignore the mouse movement check because we don't run this test on production
+		window.IGNORE_MOUSE_MOVE = true;
+
+		// don't run this test on production build.
 		return;
 	}
 

--- a/tests/e2e/graphics/test-cases/data-validation.js
+++ b/tests/e2e/graphics/test-cases/data-validation.js
@@ -1,3 +1,8 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	if (window.BUILD_MODE === 'production') {
 		return;
@@ -10,7 +15,7 @@ function runTestCase(container) {
 		// passed
 	}
 
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const lineSeries = chart.addLineSeries();
 	const barSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/indexed-to-100-scale.js
+++ b/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/indexed-to-100-scale.js
@@ -15,8 +15,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.IndexedTo100,
 		},

--- a/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/normal-scale.js
+++ b/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/normal-scale.js
@@ -15,8 +15,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Normal,
 		},

--- a/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/percentage-scale.js
+++ b/tests/e2e/graphics/test-cases/degenerative-horizontal-series-with-integer-min-tick/percentage-scale.js
@@ -15,8 +15,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 		},

--- a/tests/e2e/graphics/test-cases/fit-content-with-few-data.js
+++ b/tests/e2e/graphics/test-cases/fit-content-with-few-data.js
@@ -13,8 +13,13 @@ function generateData(valueOffset, count) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/fit-content-with-lot-data.js
+++ b/tests/e2e/graphics/test-cases/fit-content-with-lot-data.js
@@ -13,8 +13,13 @@ function generateData(valueOffset, count) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
 			ticksVisible: false,

--- a/tests/e2e/graphics/test-cases/incorrect-autoscale-when-prices-are-small.js
+++ b/tests/e2e/graphics/test-cases/incorrect-autoscale-when-prices-are-small.js
@@ -17,8 +17,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addLineSeries();
 	const secondSeries = chart.addLineSeries();

--- a/tests/e2e/graphics/test-cases/initial-options/base-line-style.js
+++ b/tests/e2e/graphics/test-cases/initial-options/base-line-style.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/chart-width-and-height.js
+++ b/tests/e2e/graphics/test-cases/initial-options/chart-width-and-height.js
@@ -13,6 +13,28 @@ function generateData() {
 	return res;
 }
 
+// Ignore the mouse movement check because we are generating multiple charts
+window.IGNORE_MOUSE_MOVE = true;
+
+const chartOptionsToHideCrosshair = {
+	vertLine: {
+		visible: false,
+		labelVisible: false,
+	},
+	horzLine: {
+		visible: false,
+		labelVisible: false,
+	},
+};
+
+const seriesOptionsToHideCrosshair = {
+	crosshairMarkerVisible: false,
+};
+
+function getChartInstance() {
+	return null;
+}
+
 function runTestCase(container) {
 	const configs = [{}, { width: 500 }, { height: 100 }, { width: 500, height: 100 }];
 
@@ -27,8 +49,8 @@ function runTestCase(container) {
 
 		container.appendChild(box);
 
-		const chart = LightweightCharts.createChart(box, config);
-		const mainSeries = chart.addAreaSeries();
+		const chart = LightweightCharts.createChart(box, { ...config, ...chartOptionsToHideCrosshair });
+		const mainSeries = chart.addAreaSeries(seriesOptionsToHideCrosshair);
 
 		mainSeries.setData(generateData());
 	});

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-with-transparency.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-with-transparency.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		crosshair: {
 			vertLine: {
 				labelBackgroundColor: 'rgba(123, 123, 123, 0.5)',

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		crosshair: {
 			vertLine: {
 				labelBackgroundColor: '#ffffff',

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		crosshair: {
 			vertLine: {
 				color: '#ff0000',

--- a/tests/e2e/graphics/test-cases/initial-options/custom-date-format.js
+++ b/tests/e2e/graphics/test-cases/initial-options/custom-date-format.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		localization: {
 			dateFormat: 'Year: yy (MM-yyyy)',
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/custom-price-format-with-extending-axis.js
+++ b/tests/e2e/graphics/test-cases/initial-options/custom-price-format-with-extending-axis.js
@@ -18,8 +18,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({
 		priceFormat: {

--- a/tests/e2e/graphics/test-cases/initial-options/custom-price-format.js
+++ b/tests/e2e/graphics/test-cases/initial-options/custom-price-format.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries({
 		priceFormat: {

--- a/tests/e2e/graphics/test-cases/initial-options/date-format.js
+++ b/tests/e2e/graphics/test-cases/initial-options/date-format.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		localization: {
 			dateFormat: 'MMM dd, yyyy',
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/draw-price-ticks.js
+++ b/tests/e2e/graphics/test-cases/initial-options/draw-price-ticks.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			ticksVisible: true,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/draw-time-ticks.js
+++ b/tests/e2e/graphics/test-cases/initial-options/draw-time-ticks.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			ticksVisible: true,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/fat-bars.js
+++ b/tests/e2e/graphics/test-cases/initial-options/fat-bars.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 20,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/fix-left-edge-and-update-data.js
+++ b/tests/e2e/graphics/test-cases/initial-options/fix-left-edge-and-update-data.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			fixLeftEdge: true,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/fix-left-edge.js
+++ b/tests/e2e/graphics/test-cases/initial-options/fix-left-edge.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			fixLeftEdge: true,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/gradient-background.js
+++ b/tests/e2e/graphics/test-cases/initial-options/gradient-background.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		layout: {
 			background: {
 				type: LightweightCharts.ColorType.VerticalGradient,

--- a/tests/e2e/graphics/test-cases/initial-options/invalid-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/initial-options/invalid-bar-spacing.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 1000,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/left-price-scale.js
+++ b/tests/e2e/graphics/test-cases/initial-options/left-price-scale.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: { visible: false },
 		leftPriceScale: { visible: true },
 	});

--- a/tests/e2e/graphics/test-cases/initial-options/log-price-scale-mode.js
+++ b/tests/e2e/graphics/test-cases/initial-options/log-price-scale-mode.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Logarithmic,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/min-visible-bars.js
+++ b/tests/e2e/graphics/test-cases/initial-options/min-visible-bars.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 1000000,
 			rightOffset: 100000,

--- a/tests/e2e/graphics/test-cases/initial-options/no-autoscale.js
+++ b/tests/e2e/graphics/test-cases/initial-options/no-autoscale.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			autoScale: false,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/no-base-line.js
+++ b/tests/e2e/graphics/test-cases/initial-options/no-base-line.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/no-price-line.js
+++ b/tests/e2e/graphics/test-cases/initial-options/no-price-line.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/no-price-scale.js
+++ b/tests/e2e/graphics/test-cases/initial-options/no-price-scale.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: { visible: false },
 		leftPriceScale: { visible: false },
 	});

--- a/tests/e2e/graphics/test-cases/initial-options/non-auto-scale-price-scale.js
+++ b/tests/e2e/graphics/test-cases/initial-options/non-auto-scale-price-scale.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			autoScale: false,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/price-format.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-format.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	// see issue#55
 	const mainSeries = chart.addLineSeries({

--- a/tests/e2e/graphics/test-cases/initial-options/price-line-source-default.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-line-source-default.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/initial-options/price-line-source-last-visible.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-line-source-last-visible.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({
 		priceLineSource: LightweightCharts.PriceLineSource.LastVisible,

--- a/tests/e2e/graphics/test-cases/initial-options/price-line-style.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-line-style.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/price-scale-entire-text-only.js
+++ b/tests/e2e/graphics/test-cases/initial-options/price-scale-entire-text-only.js
@@ -1,5 +1,13 @@
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: 600,
 		height: 300,
 		rightPriceScale: {

--- a/tests/e2e/graphics/test-cases/initial-options/small-candlesticks.js
+++ b/tests/e2e/graphics/test-cases/initial-options/small-candlesticks.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 20,
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/tick-marks-formatter-2.js
+++ b/tests/e2e/graphics/test-cases/initial-options/tick-marks-formatter-2.js
@@ -18,8 +18,13 @@ function getData() {
 	];
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			tickMarkFormatter: (time, tickMarkType, locale) => time, // return time as is
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/tick-marks-formatter.js
+++ b/tests/e2e/graphics/test-cases/initial-options/tick-marks-formatter.js
@@ -17,8 +17,13 @@ function getData() {
 	];
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			timeVisible: true,
 			secondsVisible: true,

--- a/tests/e2e/graphics/test-cases/initial-options/time-formatter-2.js
+++ b/tests/e2e/graphics/test-cases/initial-options/time-formatter-2.js
@@ -18,8 +18,13 @@ function getData() {
 	];
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		localization: {
 			timeFormatter: time => time, // return time as is
 		},

--- a/tests/e2e/graphics/test-cases/initial-options/time-formatter.js
+++ b/tests/e2e/graphics/test-cases/initial-options/time-formatter.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		localization: {
 			timeFormatter: businessDayOrTimestamp => {
 				if (LightweightCharts.isBusinessDay(businessDayOrTimestamp)) {

--- a/tests/e2e/graphics/test-cases/initial-options/time-scale.js
+++ b/tests/e2e/graphics/test-cases/initial-options/time-scale.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 10,
 			barSpacing: 12,

--- a/tests/e2e/graphics/test-cases/initial-options/transparent-background.js
+++ b/tests/e2e/graphics/test-cases/initial-options/transparent-background.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		layout: {
 			background: {
 				type: LightweightCharts.ColorType.Solid,

--- a/tests/e2e/graphics/test-cases/initial-options/watermark.js
+++ b/tests/e2e/graphics/test-cases/initial-options/watermark.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		watermark: {
 			visible: true,
 			color: 'red',

--- a/tests/e2e/graphics/test-cases/initial-options/zero-precision.js
+++ b/tests/e2e/graphics/test-cases/initial-options/zero-precision.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	// see issue#59
 	const mainSeries = chart.addLineSeries({

--- a/tests/e2e/graphics/test-cases/logical-range/bars-in-gap.js
+++ b/tests/e2e/graphics/test-cases/logical-range/bars-in-gap.js
@@ -13,8 +13,13 @@ function generateData(count) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 	const series = chart.addLineSeries();

--- a/tests/e2e/graphics/test-cases/logical-range/bars-in-range.js
+++ b/tests/e2e/graphics/test-cases/logical-range/bars-in-range.js
@@ -13,8 +13,13 @@ function generateData(count) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/logical-range/subscribe-visible-logical-range-change.js
+++ b/tests/e2e/graphics/test-cases/logical-range/subscribe-visible-logical-range-change.js
@@ -13,8 +13,13 @@ function generateData(count) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/months-chart.js
+++ b/tests/e2e/graphics/test-cases/months-chart.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addLineSeries();
 	firstSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/price-scale/logarithmic-scale-on-extra-small-values.js
+++ b/tests/e2e/graphics/test-cases/price-scale/logarithmic-scale-on-extra-small-values.js
@@ -10,8 +10,13 @@ function generateData() {
 	return result;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Logarithmic,
 		},

--- a/tests/e2e/graphics/test-cases/price-scale/logarithmic-scale-on-small-values.js
+++ b/tests/e2e/graphics/test-cases/price-scale/logarithmic-scale-on-small-values.js
@@ -10,8 +10,13 @@ function generateData() {
 	return result;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Logarithmic,
 		},

--- a/tests/e2e/graphics/test-cases/price-scale/no-empty-mark-on-price-scale.js
+++ b/tests/e2e/graphics/test-cases/price-scale/no-empty-mark-on-price-scale.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/remove-series-extended-time-scale.js
+++ b/tests/e2e/graphics/test-cases/remove-series-extended-time-scale.js
@@ -12,8 +12,13 @@ function generateData(step, startDay) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		color: '#0000ff',

--- a/tests/e2e/graphics/test-cases/series-markers/marker-in-gap-from-left.js
+++ b/tests/e2e/graphics/test-cases/series-markers/marker-in-gap-from-left.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/marker-in-gap.js
+++ b/tests/e2e/graphics/test-cases/series-markers/marker-in-gap.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-arrow-markers.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-arrow-markers.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-circle-markers.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-circle-markers.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-aligned.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-aligned.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const line = chart.addLineSeries();
 	line.setData([

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-max-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-max-bar-spacing.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-min-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-min-bar-spacing.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-object-business-day.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-object-business-day.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const line = chart.addLineSeries();
 	line.setData([

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-out-of-visible-range.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-out-of-visible-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-re-aligned.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-re-aligned.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const line = chart.addLineSeries();
 	line.setData([

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-update.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-update.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-with-text.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-with-text.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(
+	chart = LightweightCharts.createChart(
 		container,
 		{
 			layout: {

--- a/tests/e2e/graphics/test-cases/series-markers/series-square-markers.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-square-markers.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/series-markers/set-markers-before-series-data.js
+++ b/tests/e2e/graphics/test-cases/series-markers/set-markers-before-series-data.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series/2-baseline-series.js
+++ b/tests/e2e/graphics/test-cases/series/2-baseline-series.js
@@ -39,8 +39,13 @@ function generateData(valueOffset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const firstSeries = chart.addBaselineSeries({
 		baseValue: {

--- a/tests/e2e/graphics/test-cases/series/2-points-line-series.js
+++ b/tests/e2e/graphics/test-cases/series/2-points-line-series.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 	const lineSeries = chart.addLineSeries();

--- a/tests/e2e/graphics/test-cases/series/add-series-after-volume.js
+++ b/tests/e2e/graphics/test-cases/series/add-series-after-volume.js
@@ -1,8 +1,13 @@
 // fix the first case from
 // https://github.com/tradingview/lightweight-charts/issues/110
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries(); // or any other series type
 	const volumeSeries = chart.addHistogramSeries();

--- a/tests/e2e/graphics/test-cases/series/alternate-histogram-items-with-gaps.js
+++ b/tests/e2e/graphics/test-cases/series/alternate-histogram-items-with-gaps.js
@@ -14,8 +14,13 @@ function generateData(step) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 100,
 		},

--- a/tests/e2e/graphics/test-cases/series/area-out-of-viewport.js
+++ b/tests/e2e/graphics/test-cases/series/area-out-of-viewport.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries();
 	areaSeries.setData([

--- a/tests/e2e/graphics/test-cases/series/area-with-custom-colors.js
+++ b/tests/e2e/graphics/test-cases/series/area-with-custom-colors.js
@@ -25,8 +25,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addAreaSeries();
 

--- a/tests/e2e/graphics/test-cases/series/area-with-whitespaces.js
+++ b/tests/e2e/graphics/test-cases/series/area-with-whitespaces.js
@@ -16,8 +16,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addAreaSeries();
 

--- a/tests/e2e/graphics/test-cases/series/area.js
+++ b/tests/e2e/graphics/test-cases/series/area.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addAreaSeries();
 

--- a/tests/e2e/graphics/test-cases/series/bar-semitransparent.js
+++ b/tests/e2e/graphics/test-cases/series/bar-semitransparent.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries({
 		upColor: 'rgba(0, 250, 0, 0.3)',

--- a/tests/e2e/graphics/test-cases/series/bar-with-custom-colors.js
+++ b/tests/e2e/graphics/test-cases/series/bar-with-custom-colors.js
@@ -26,8 +26,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/series/bar.js
+++ b/tests/e2e/graphics/test-cases/series/bar.js
@@ -22,8 +22,13 @@ function generateData(startValue) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/series/bars-with-whitespaces.js
+++ b/tests/e2e/graphics/test-cases/series/bars-with-whitespaces.js
@@ -24,8 +24,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries();
 

--- a/tests/e2e/graphics/test-cases/series/baseline-with-custom-colors.js
+++ b/tests/e2e/graphics/test-cases/series/baseline-with-custom-colors.js
@@ -34,8 +34,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBaselineSeries({ baseValue: { type: 'price', price: 88 } });
 

--- a/tests/e2e/graphics/test-cases/series/baseline.js
+++ b/tests/e2e/graphics/test-cases/series/baseline.js
@@ -39,8 +39,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBaselineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/candlesticks-semitransparent.js
+++ b/tests/e2e/graphics/test-cases/series/candlesticks-semitransparent.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries({
 		borderColor: 'rgba(0, 0, 255, 0.2)',

--- a/tests/e2e/graphics/test-cases/series/candlesticks-with-custom-colors.js
+++ b/tests/e2e/graphics/test-cases/series/candlesticks-with-custom-colors.js
@@ -28,8 +28,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/series/candlesticks-with-huge-range.js
+++ b/tests/e2e/graphics/test-cases/series/candlesticks-with-huge-range.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/series/candlesticks.js
+++ b/tests/e2e/graphics/test-cases/series/candlesticks.js
@@ -22,8 +22,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/series/candlestics-with-whitespaces.js
+++ b/tests/e2e/graphics/test-cases/series/candlestics-with-whitespaces.js
@@ -24,8 +24,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/series/change-colors-via-set-data-in-histogram.js
+++ b/tests/e2e/graphics/test-cases/series/change-colors-via-set-data-in-histogram.js
@@ -13,8 +13,13 @@ function generateData(colors) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addHistogramSeries();
 

--- a/tests/e2e/graphics/test-cases/series/crosshair-marker-colors-change-to-default.js
+++ b/tests/e2e/graphics/test-cases/series/crosshair-marker-colors-change-to-default.js
@@ -15,8 +15,13 @@ function generateData(step) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries({
 		crosshairMarkerBorderColor: '#ff00ff',

--- a/tests/e2e/graphics/test-cases/series/crosshair-marker-colors-change.js
+++ b/tests/e2e/graphics/test-cases/series/crosshair-marker-colors-change.js
@@ -15,8 +15,13 @@ function generateData(step) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries();
 	const lineSeries = chart.addLineSeries();

--- a/tests/e2e/graphics/test-cases/series/crosshair-marker-colors.js
+++ b/tests/e2e/graphics/test-cases/series/crosshair-marker-colors.js
@@ -15,8 +15,13 @@ function generateData(step) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries({
 		crosshairMarkerBorderColor: 'yellow',

--- a/tests/e2e/graphics/test-cases/series/curved-line-2-points.js
+++ b/tests/e2e/graphics/test-cases/series/curved-line-2-points.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries({
 		lineType: LightweightCharts.LineType.Curved,

--- a/tests/e2e/graphics/test-cases/series/curved-line-3-points.js
+++ b/tests/e2e/graphics/test-cases/series/curved-line-3-points.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries({
 		lineType: LightweightCharts.LineType.Curved,

--- a/tests/e2e/graphics/test-cases/series/curved-line-area.js
+++ b/tests/e2e/graphics/test-cases/series/curved-line-area.js
@@ -14,8 +14,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries({
 		lineType: LightweightCharts.LineType.Curved,

--- a/tests/e2e/graphics/test-cases/series/curved-line-baseline.js
+++ b/tests/e2e/graphics/test-cases/series/curved-line-baseline.js
@@ -14,8 +14,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const baselineSeries = chart.addBaselineSeries({
 		lineType: LightweightCharts.LineType.Curved,

--- a/tests/e2e/graphics/test-cases/series/curved-line-colored-items.js
+++ b/tests/e2e/graphics/test-cases/series/curved-line-colored-items.js
@@ -17,8 +17,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries({
 		lineType: LightweightCharts.LineType.Curved,

--- a/tests/e2e/graphics/test-cases/series/hidden-series-and-autoscale.js
+++ b/tests/e2e/graphics/test-cases/series/hidden-series-and-autoscale.js
@@ -13,8 +13,13 @@ function generateData(mul = 1) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries({ visible: false });
 	lineSeries.setData(generateData());

--- a/tests/e2e/graphics/test-cases/series/histogram-add-new-color-on-update.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-add-new-color-on-update.js
@@ -19,8 +19,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addHistogramSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/histogram-change-default-color.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-change-default-color.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addHistogramSeries({
 		color: 'blue',

--- a/tests/e2e/graphics/test-cases/series/histogram-out-of-range.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-out-of-range.js
@@ -1,7 +1,12 @@
 // see https://github.com/tradingview/lightweight-charts/issues/133
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const series = chart.addCandlestickSeries();
 
 	series.setData([

--- a/tests/e2e/graphics/test-cases/series/histogram-update-without-set-data.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-update-without-set-data.js
@@ -1,8 +1,13 @@
 // fix the second case from
 // https://github.com/tradingview/lightweight-charts/issues/110
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries();
 	const volumeSeries = chart.addHistogramSeries();

--- a/tests/e2e/graphics/test-cases/series/histogram-with-whitespaces.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-with-whitespaces.js
@@ -16,8 +16,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addHistogramSeries();
 

--- a/tests/e2e/graphics/test-cases/series/histogram.js
+++ b/tests/e2e/graphics/test-cases/series/histogram.js
@@ -19,8 +19,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addHistogramSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/line-dotted.js
+++ b/tests/e2e/graphics/test-cases/series/line-dotted.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/line-overlap.js
+++ b/tests/e2e/graphics/test-cases/series/line-overlap.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/line-with-custom-color-change-color-later.js
+++ b/tests/e2e/graphics/test-cases/series/line-with-custom-color-change-color-later.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series/line-with-custom-color.js
+++ b/tests/e2e/graphics/test-cases/series/line-with-custom-color.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series/line-with-steps-with-custom-color.js
+++ b/tests/e2e/graphics/test-cases/series/line-with-steps-with-custom-color.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		lineType: LightweightCharts.LineType.WithSteps,

--- a/tests/e2e/graphics/test-cases/series/line-with-whitespaces.js
+++ b/tests/e2e/graphics/test-cases/series/line-with-whitespaces.js
@@ -16,8 +16,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/series/line.js
+++ b/tests/e2e/graphics/test-cases/series/line.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-adding-whitespace.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-adding-whitespace.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({
 		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data-after-reseting-data.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data-after-reseting-data.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({
 		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-first-set-data.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({
 		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,

--- a/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-loading-history-data.js
+++ b/tests/e2e/graphics/test-cases/series/no-last-price-animation-on-loading-history-data.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({
 		lastPriceAnimation: LightweightCharts.LastPriceAnimationMode.OnDataUpdate,

--- a/tests/e2e/graphics/test-cases/series/no-visible-points-in-the-middle.js
+++ b/tests/e2e/graphics/test-cases/series/no-visible-points-in-the-middle.js
@@ -18,8 +18,13 @@ function generateData(priceOffset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 7,
 			barSpacing: 50,

--- a/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-price-scale.js
+++ b/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-price-scale.js
@@ -12,8 +12,13 @@ function generateData(func) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const line1 = chart.addLineSeries({
 		priceScaleId: 'overlay',

--- a/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-stacked.js
+++ b/tests/e2e/graphics/test-cases/series/overlay-series-title-only-overlay-stacked.js
@@ -12,8 +12,13 @@ function generateData(func, shouldAddValue) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	chart.priceScale('right').applyOptions({
 		visible: false,

--- a/tests/e2e/graphics/test-cases/series/overlay-series-title.js
+++ b/tests/e2e/graphics/test-cases/series/overlay-series-title.js
@@ -12,8 +12,13 @@ function generateData(func) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		color: '#ff0000',

--- a/tests/e2e/graphics/test-cases/series/override-autoscale-fixed-range.js
+++ b/tests/e2e/graphics/test-cases/series/override-autoscale-fixed-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			scaleMargins: {
 				bottom: 0,

--- a/tests/e2e/graphics/test-cases/series/price-line-apply-options.js
+++ b/tests/e2e/graphics/test-cases/series/price-line-apply-options.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 	series.setData(generateData());

--- a/tests/e2e/graphics/test-cases/series/price-line-line-visibility.js
+++ b/tests/e2e/graphics/test-cases/series/price-line-line-visibility.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 	series.setData(generateData());

--- a/tests/e2e/graphics/test-cases/series/price-line-overlapping-series-title.js
+++ b/tests/e2e/graphics/test-cases/series/price-line-overlapping-series-title.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries({ title: 'TITLE' });
 

--- a/tests/e2e/graphics/test-cases/series/price-line-with-percentage-scale-mode.js
+++ b/tests/e2e/graphics/test-cases/series/price-line-with-percentage-scale-mode.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 		},

--- a/tests/e2e/graphics/test-cases/series/price-lines-align-labels.js
+++ b/tests/e2e/graphics/test-cases/series/price-lines-align-labels.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 			alignLabels: true,

--- a/tests/e2e/graphics/test-cases/series/price-lines-do-not-align-labels.js
+++ b/tests/e2e/graphics/test-cases/series/price-lines-do-not-align-labels.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Percentage,
 			alignLabels: false,

--- a/tests/e2e/graphics/test-cases/series/price-lines-on-two-axis.js
+++ b/tests/e2e/graphics/test-cases/series/price-lines-on-two-axis.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
 			borderColor: '#EFF2F5',

--- a/tests/e2e/graphics/test-cases/series/price-lines-remove.js
+++ b/tests/e2e/graphics/test-cases/series/price-lines-remove.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 	series.setData(generateData());

--- a/tests/e2e/graphics/test-cases/series/price-lines.js
+++ b/tests/e2e/graphics/test-cases/series/price-lines.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const series = chart.addLineSeries();
 	series.setData(generateData());

--- a/tests/e2e/graphics/test-cases/series/series-price-formatter.js
+++ b/tests/e2e/graphics/test-cases/series/series-price-formatter.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries = chart.addLineSeries({
 		priceFormat: {

--- a/tests/e2e/graphics/test-cases/series/series-type.js
+++ b/tests/e2e/graphics/test-cases/series/series-type.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const line = chart.addLineSeries();
 	const area = chart.addAreaSeries();
 	const candlestick = chart.addCandlestickSeries();

--- a/tests/e2e/graphics/test-cases/series/series-visibility.js
+++ b/tests/e2e/graphics/test-cases/series/series-visibility.js
@@ -32,8 +32,13 @@ function generateBarData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.IndexedTo100,
 		},

--- a/tests/e2e/graphics/test-cases/series/set-empty-data-to-histogram.js
+++ b/tests/e2e/graphics/test-cases/series/set-empty-data-to-histogram.js
@@ -21,8 +21,13 @@ function generateColoredData() {
 	return data;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const areaSeries = chart.addAreaSeries();
 	const volumeSeries = chart.addHistogramSeries();

--- a/tests/e2e/graphics/test-cases/series/setting-same-data-after-time.js
+++ b/tests/e2e/graphics/test-cases/series/setting-same-data-after-time.js
@@ -2,8 +2,13 @@ function copy(data) {
 	return JSON.parse(JSON.stringify(data));
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	const lineSeries = chart.addLineSeries();
 
 	const data = [

--- a/tests/e2e/graphics/test-cases/series/several-non-regular-series.js
+++ b/tests/e2e/graphics/test-cases/series/several-non-regular-series.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const lineSeries1 = chart.addLineSeries();
 	const lineSeries2 = chart.addLineSeries();

--- a/tests/e2e/graphics/test-cases/series/single-point-area.js
+++ b/tests/e2e/graphics/test-cases/series/single-point-area.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 7,
 			barSpacing: 50,

--- a/tests/e2e/graphics/test-cases/series/single-point-line.js
+++ b/tests/e2e/graphics/test-cases/series/single-point-line.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 7,
 			barSpacing: 50,

--- a/tests/e2e/graphics/test-cases/series/single-visible-point-line-first-bar.js
+++ b/tests/e2e/graphics/test-cases/series/single-visible-point-line-first-bar.js
@@ -18,8 +18,13 @@ function generateData(priceOffset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 7,
 			barSpacing: 50,

--- a/tests/e2e/graphics/test-cases/series/single-visible-point-line-last-bar.js
+++ b/tests/e2e/graphics/test-cases/series/single-visible-point-line-last-bar.js
@@ -18,8 +18,13 @@ function generateData(priceOffset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 7,
 			barSpacing: 50,

--- a/tests/e2e/graphics/test-cases/series/step-line-area.js
+++ b/tests/e2e/graphics/test-cases/series/step-line-area.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addAreaSeries({
 		lineType: LightweightCharts.LineType.WithSteps,

--- a/tests/e2e/graphics/test-cases/series/step-line-baseline.js
+++ b/tests/e2e/graphics/test-cases/series/step-line-baseline.js
@@ -14,8 +14,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const baselineSeries = chart.addBaselineSeries({
 		lineType: LightweightCharts.LineType.WithSteps,

--- a/tests/e2e/graphics/test-cases/series/step-line.js
+++ b/tests/e2e/graphics/test-cases/series/step-line.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/two-series-one-not-autoscaled.js
+++ b/tests/e2e/graphics/test-cases/series/two-series-one-not-autoscaled.js
@@ -13,8 +13,13 @@ function generateData(amplitude) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		rightPriceScale: {
 			scaleMargins: {
 				bottom: 0,

--- a/tests/e2e/graphics/test-cases/series/update-baseline-base-value.js
+++ b/tests/e2e/graphics/test-cases/series/update-baseline-base-value.js
@@ -39,8 +39,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBaselineSeries({
 		lineWidth: 1,

--- a/tests/e2e/graphics/test-cases/series/update-removed-series-data.js
+++ b/tests/e2e/graphics/test-cases/series/update-removed-series-data.js
@@ -1,3 +1,11 @@
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const data1 = [
 		{
@@ -29,7 +37,7 @@ function runTestCase(container) {
 		},
 	];
 
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: 600,
 		height: 300,
 		timeScale: {

--- a/tests/e2e/graphics/test-cases/series/whitespace-updates.js
+++ b/tests/e2e/graphics/test-cases/series/whitespace-updates.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addCandlestickSeries();
 

--- a/tests/e2e/graphics/test-cases/set-price-line-label.js
+++ b/tests/e2e/graphics/test-cases/set-price-line-label.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/take-screenshot.js
+++ b/tests/e2e/graphics/test-cases/take-screenshot.js
@@ -43,8 +43,16 @@ function generateDataHist() {
 	return res;
 }
 
+// Ignore the mouse movement check because we are covering the chart.
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 20,
 		},

--- a/tests/e2e/graphics/test-cases/time-scale/add-data-to-left-two-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/add-data-to-left-two-series.js
@@ -36,6 +36,10 @@ let areaSeries1 = null;
 let areaSeries2 = null;
 const ONE_DAY_IN_SEC = 24 * 60 * 60;
 
+function getChartInstance() {
+	return chart;
+}
+
 function createChart(container) {
 	chart = LightweightCharts.createChart(container);
 }

--- a/tests/e2e/graphics/test-cases/time-scale/add-data-to-left.js
+++ b/tests/e2e/graphics/test-cases/time-scale/add-data-to-left.js
@@ -34,6 +34,10 @@ let chart = null;
 let areaSeries = null;
 const ONE_DAY_IN_SEC = 24 * 60 * 60;
 
+function getChartInstance() {
+	return chart;
+}
+
 function createChart(container) {
 	chart = LightweightCharts.createChart(container);
 }

--- a/tests/e2e/graphics/test-cases/time-scale/add-data-to-right-two-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/add-data-to-right-two-series.js
@@ -36,6 +36,10 @@ let areaSeries1 = null;
 let areaSeries2 = null;
 const ONE_DAY_IN_SEC = 24 * 60 * 60;
 
+function getChartInstance() {
+	return chart;
+}
+
 function createChart(container) {
 	chart = LightweightCharts.createChart(container);
 }

--- a/tests/e2e/graphics/test-cases/time-scale/add-data-to-right.js
+++ b/tests/e2e/graphics/test-cases/time-scale/add-data-to-right.js
@@ -34,6 +34,10 @@ let chart = null;
 let areaSeries = null;
 const ONE_DAY_IN_SEC = 24 * 60 * 60;
 
+function getChartInstance() {
+	return chart;
+}
+
 function createChart(container) {
 	chart = LightweightCharts.createChart(container);
 }

--- a/tests/e2e/graphics/test-cases/time-scale/do-not-shift-on-new-data-from-right.js
+++ b/tests/e2e/graphics/test-cases/time-scale/do-not-shift-on-new-data-from-right.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			rightOffset: 10,
 			shiftVisibleRangeOnNewBar: false,

--- a/tests/e2e/graphics/test-cases/time-scale/fit-content-pricescale-changes.js
+++ b/tests/e2e/graphics/test-cases/time-scale/fit-content-pricescale-changes.js
@@ -13,8 +13,16 @@ function generateData(down) {
 	return res;
 }
 
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		width: 600,
 		height: 300,
 	});

--- a/tests/e2e/graphics/test-cases/time-scale/hidden-time-scale-size.js
+++ b/tests/e2e/graphics/test-cases/time-scale/hidden-time-scale-size.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 async function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const timeScale = chart.timeScale();
 

--- a/tests/e2e/graphics/test-cases/time-scale/lock-visible-range-on-resize-and-fixing-edges.js
+++ b/tests/e2e/graphics/test-cases/time-scale/lock-visible-range-on-resize-and-fixing-edges.js
@@ -13,8 +13,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			fixLeftEdge: true,
 			fixRightEdge: true,

--- a/tests/e2e/graphics/test-cases/time-scale/min-bar-spacing.js
+++ b/tests/e2e/graphics/test-cases/time-scale/min-bar-spacing.js
@@ -22,8 +22,13 @@ function generateData(startValue) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			minBarSpacing: 0.001,
 		},

--- a/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-mark-on-left.js
+++ b/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-mark-on-left.js
@@ -68,8 +68,13 @@ function getData() {
 	];
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		handleScale: false,
 		handleScroll: false,
 		timeScale: {

--- a/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-mark-on-right.js
+++ b/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-mark-on-right.js
@@ -68,8 +68,16 @@ function getData() {
 	];
 }
 
+// Ignore the mouse movement check because height of chart is too short
+window.IGNORE_MOUSE_MOVE = true;
+
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		height: 200,
 		handleScale: false,
 		handleScroll: false,

--- a/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-marks.js
+++ b/tests/e2e/graphics/test-cases/time-scale/realign-partially-hidden-time-scale-marks.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		handleScroll: false,
 		handleScale: false,
 	});

--- a/tests/e2e/graphics/test-cases/time-scale/reset-time-scale-after-set-visible-range.js
+++ b/tests/e2e/graphics/test-cases/time-scale/reset-time-scale-after-set-visible-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/time-scale/scroll-to-position-after-set-visible-range.js
+++ b/tests/e2e/graphics/test-cases/time-scale/scroll-to-position-after-set-visible-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/time-scale/scroll-to-position-with-no-data.js
+++ b/tests/e2e/graphics/test-cases/time-scale/scroll-to-position-with-no-data.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	chart.timeScale().scrollToPosition(-100000);
 
 	// to force subscribe and emit event

--- a/tests/e2e/graphics/test-cases/time-scale/set-and-clear-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-and-clear-series.js
@@ -1,3 +1,8 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
 	const data = [
 		{ time: 1609459200, value: 500 },
@@ -5,7 +10,7 @@ function runTestCase(container) {
 		{ time: 1609632000, value: 700 },
 	];
 
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		timeScale: {
 			barSpacing: 40,
 		},

--- a/tests/e2e/graphics/test-cases/time-scale/set-right-offset-after-set-visible-range.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-right-offset-after-set-visible-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/time-scale/set-visible-logical-range-with-no-data.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-visible-logical-range-with-no-data.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 	chart.timeScale().setVisibleLogicalRange({ from: -1001000, to: -1000000 });
 
 	// to force subscribe and emit event

--- a/tests/e2e/graphics/test-cases/time-scale/set-visible-range-after-time.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-visible-range-after-time.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/time-scale/set-visible-range-with-small-range.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-visible-range-with-small-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/time-scale/set-visible-range-with-two-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-visible-range-with-two-series.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const line1 = chart.addLineSeries();
 	line1.setData([

--- a/tests/e2e/graphics/test-cases/time-scale/set-visible-range.js
+++ b/tests/e2e/graphics/test-cases/time-scale/set-visible-range.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addLineSeries();
 

--- a/tests/e2e/graphics/test-cases/time-scale/time-scale-size-on-changing-chart-size.js
+++ b/tests/e2e/graphics/test-cases/time-scale/time-scale-size-on-changing-chart-size.js
@@ -1,5 +1,13 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
+// Ignore the mouse movement check because height of chart is too thin
+window.IGNORE_MOUSE_MOVE = true;
+
 async function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, { width: 150 });
+	chart = LightweightCharts.createChart(container, { width: 150 });
 
 	const timeScale = chart.timeScale();
 

--- a/tests/e2e/graphics/test-cases/time-scale/time-scale-size-with-hidden-price-scale.js
+++ b/tests/e2e/graphics/test-cases/time-scale/time-scale-size-with-hidden-price-scale.js
@@ -1,5 +1,10 @@
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 async function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const timeScale = chart.timeScale();
 

--- a/tests/e2e/graphics/test-cases/transparent-color.js
+++ b/tests/e2e/graphics/test-cases/transparent-color.js
@@ -12,8 +12,13 @@ function generateData() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addHistogramSeries({
 		color: 'transparent',

--- a/tests/e2e/graphics/test-cases/two-scales/basic.js
+++ b/tests/e2e/graphics/test-cases/two-scales/basic.js
@@ -45,8 +45,13 @@ function generateDataHist() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
 			scaleMargins: {

--- a/tests/e2e/graphics/test-cases/two-scales/empty-price-scale-id.js
+++ b/tests/e2e/graphics/test-cases/two-scales/empty-price-scale-id.js
@@ -45,8 +45,13 @@ function generateDataLine(offset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries({
 		borderColor: 'rgba(0, 0, 255, 0.2)',

--- a/tests/e2e/graphics/test-cases/two-scales/left-percent.js
+++ b/tests/e2e/graphics/test-cases/two-scales/left-percent.js
@@ -45,8 +45,13 @@ function generateDataHist() {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
 			scaleMargins: {

--- a/tests/e2e/graphics/test-cases/two-scales/price-scale-text-colors.js
+++ b/tests/e2e/graphics/test-cases/two-scales/price-scale-text-colors.js
@@ -11,8 +11,13 @@ function generateData(offset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container, {
+	chart = LightweightCharts.createChart(container, {
 		leftPriceScale: {
 			visible: true,
 			textColor: 'blue',

--- a/tests/e2e/graphics/test-cases/two-scales/two-groups-of-overlays.js
+++ b/tests/e2e/graphics/test-cases/two-scales/two-groups-of-overlays.js
@@ -45,8 +45,13 @@ function generateDataLine(offset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries({
 		borderColor: 'rgba(0, 0, 255, 0.2)',

--- a/tests/e2e/graphics/test-cases/two-scales/two-overlays-share-scale.js
+++ b/tests/e2e/graphics/test-cases/two-scales/two-overlays-share-scale.js
@@ -45,8 +45,13 @@ function generateDataLine(offset) {
 	return res;
 }
 
+let chart;
+function getChartInstance() {
+	return chart;
+}
+
 function runTestCase(container) {
-	const chart = LightweightCharts.createChart(container);
+	chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addBarSeries({
 		borderColor: 'rgba(0, 0, 255, 0.2)',


### PR DESCRIPTION
**Type of PR:** bugfix / enhancement

The graphics tests are flaky when run on the CI server. This PR improves the reliability of the tests such false negatives should be greatly reduced.

Fixes #1154 

**Overview of changes:**
* When a test fails and is retried, it will then run in series instead of parallel.
* A `subscribeCrosshairMove` event handler is added to the chart such that the test case waits until the chart has reacted to the mouse movement before taking the screenshot
	* Test cases have been updated to have a `getChartInstance` function which is used to add the above crosshairMove handler. 
	* Setting `window.IGNORE_MOUSE_MOVE = true;` within the test case will disable the waiting for cursor (in cases where the chart is small, there are multiple charts, or the chart isn’t able to have mouse events (`take-screenshot.js`)
* Added the ability to pass Mocha options via terminal commands. (See `tests/e2e/graphics/README.md`). Useful for selecting subsets of tests to run using `--grep`.
