### PR TITLE
Invert filled area

### DIFF
--- a/src/api/options/series-options-defaults.ts
+++ b/src/api/options/series-options-defaults.ts
@@ -46,6 +46,7 @@ export const lineStyleDefaults: LineStyleOptions = {
 export const areaStyleDefaults: AreaStyleOptions = {
 	topColor: 'rgba( 46, 220, 135, 0.4)',
 	bottomColor: 'rgba( 40, 221, 100, 0)',
+	invertFilledArea: false,
 	lineColor: '#33D778',
 	lineStyle: LineStyle.Solid,
 	lineWidth: 3,

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -226,6 +226,13 @@ export interface AreaStyleOptions {
 	bottomColor: string;
 
 	/**
+	 * Invert the filled area. Fills the area above the line if set to true.
+	 *
+	 * @defaultValue `false`
+	 */
+	invertFilledArea: boolean;
+
+	/**
 	 * Line color.
 	 *
 	 * @defaultValue `'#33D778'`

--- a/src/views/pane/area-pane-view.ts
+++ b/src/views/pane/area-pane-view.ts
@@ -30,12 +30,14 @@ export class SeriesAreaPaneView extends LinePaneViewBase<'Area', AreaFillItem & 
 	protected _prepareRendererData(width: number, height: number): void {
 		const areaStyleProperties = this._series.options();
 
+		const baseLevelCoordinate = (areaStyleProperties.invertFilledArea ? 0 : height) as Coordinate;
+
 		this._areaRenderer.setData({
 			lineType: areaStyleProperties.lineType,
 			items: this._items,
 			lineStyle: areaStyleProperties.lineStyle,
 			lineWidth: areaStyleProperties.lineWidth,
-			baseLevelCoordinate: height as Coordinate,
+			baseLevelCoordinate,
 			bottom: height as Coordinate,
 			visibleRange: this._itemsVisibleRange,
 			barWidth: this._model.timeScale().barSpacing(),

--- a/tests/e2e/coverage/test-cases/series/area-inverted.js
+++ b/tests/e2e/coverage/test-cases/series/area-inverted.js
@@ -1,0 +1,31 @@
+function interactionsToPerform() {
+	return [];
+}
+
+async function awaitNewFrame() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+async function beforeInteractions(container) {
+	const chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addAreaSeries({
+		invertFilledArea: true,
+	});
+
+	mainSeries.setData(generateLineData());
+
+	await awaitNewFrame();
+
+	mainSeries.applyOptions({
+		invertFilledArea: false,
+	});
+
+	return Promise.resolve();
+}
+
+function afterInteractions() {
+	return Promise.resolve();
+}

--- a/tests/e2e/graphics/test-cases/series/area-inverted-after-delay.js
+++ b/tests/e2e/graphics/test-cases/series/area-inverted-after-delay.js
@@ -1,0 +1,32 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addAreaSeries({
+		invertFilledArea: false,
+	});
+
+	mainSeries.setData(generateData());
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			mainSeries.applyOptions({
+				invertFilledArea: true,
+			});
+			requestAnimationFrame(resolve);
+		});
+	});
+}

--- a/tests/e2e/graphics/test-cases/series/area-inverted.js
+++ b/tests/e2e/graphics/test-cases/series/area-inverted.js
@@ -1,0 +1,23 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addAreaSeries({
+		invertFilledArea: true,
+	});
+
+	mainSeries.setData(generateData());
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1115 
- [x] Includes tests. Coverage test and e2e graphics tests added
- [x] Documentation update. Updated via the `d.ts` generated API reference

**Overview of change:**

Adds `invertFilledArea` property to the `AreaStyleOptions` which when set to true will invert the filled area (draw above the line instead of below it).

*Note:* It is expected that the graphics test pipeline will fail because of the added tests for this specific feature. Likewise for the `dts` test.

**Example:**
<img width="681" alt="Screenshot 2022-10-20 at 16 57 28" src="https://user-images.githubusercontent.com/3482679/196999008-60bdf96f-b475-4648-ba7a-9f3099e85300.png">