### PR TITLE
fix scroll speed on Windows chromium browsers

### DIFF
--- a/src/helpers/browsers.ts
+++ b/src/helpers/browsers.ts
@@ -22,3 +22,17 @@ export function isChrome(): boolean {
 	return window.chrome !== undefined;
 }
 
+// Determine whether the browser is Chromium based and running on windows.
+export function userAgentWindowsChromium(): boolean {
+	if (
+		!navigator.userAgentData ||
+		navigator.userAgentData.platform !== 'Windows'
+	) {
+		return false;
+	}
+	return navigator.userAgentData.brands.some(
+		(brand: UADataBrand) => {
+			return brand.brand.includes('Chromium');
+		}
+	);
+}

--- a/src/typings/dom-not-standarted/index.d.ts
+++ b/src/typings/dom-not-standarted/index.d.ts
@@ -7,6 +7,23 @@ interface UIEvent {
 	sourceCapabilities?: InputDeviceCapabilities;
 }
 
+/**
+ * Navigator userAgentData
+ * https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData
+ * More reliable way of determining chromium browsers.
+ * Note: This is a partial type definition for the low entropy properties.
+ */
+interface UADataBrand {
+	brand: string; version: string;
+}
+interface Navigator {
+	userAgentData?: {
+		brands: UADataBrand[];
+		platform: string;
+		mobile: boolean;
+	};
+}
+
 interface Window {
 	chrome: unknown;
 }


### PR DESCRIPTION
**Type of PR:** bugfix (browser bug, not our bug)

**PR checklist:**

- [x] Addresses an existing issue: fixes #1168
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

- Library will check if the browser is Chromium based and whether it is running on windows.
- If it is, then the scroll wheel speed will be scaled by the `devicePixelRatio` to ensure that the scroll speed is consistent between all the different browsers.

https://bugs.chromium.org/p/chromium/issues/detail?id=1001735 
https://bugs.chromium.org/p/chromium/issues/detail?id=1207308 


**Is there anything you'd like reviewers to focus on?**

The browser check is using `navigator.userAgentData` which is a new API only supported by Chromium browsers (since mid 2021). This is a more reliable way of checking the user agent, and since we are only looking for Chromium browsers the browser support isn't important and actually improves the check.

https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData
