### PR TITLE
fix short code snippet for 'how to: add price line'

### DIFF
--- a/website/tutorials/how_to/price-line.mdx
+++ b/website/tutorials/how_to/price-line.mdx
@@ -20,8 +20,8 @@ A price line can be added to a chart by using the
 ```js
 const myPriceLine = {
     price: 1234,
-    color: BAR_UP_COLOR,
-    lineWidth: lineWidth,
+    color: '#3179F5',
+    lineWidth: 2,
     lineStyle: 2, // LineStyle.Dashed
     axisLabelVisible: true,
     title: 'my label',


### PR DESCRIPTION
**Type of PR:** fix typo

**PR checklist:**

- (N/A) ~Addresses an existing issue: fixes #~
- (N/A) ~Includes tests~
- [x] Documentation update

**Overview of change:**
The code snippet for the `How To: Add Price Line` ([link](https://tradingview.github.io/lightweight-charts/tutorials/how_to/price-line#short-answer)) included undefined constants instead of actual values. For example: `BAR_UP_COLOR` instead of `'#3179F5'`.
