### PR TITLE
Add possibility to use default tick mark formatter implementation as a fallback

### DIFF
--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -83,6 +83,8 @@ export const enum TickMarkType {
  * Note that the returned string should be the shortest possible value and should have no more than 8 characters.
  * Otherwise, the tick marks will overlap each other.
  *
+ * If the formatter function returns `null` then the default tick mark formatter will be used as a fallback.
+ *
  * @example
  * ```js
  * const customFormatter = (time, tickMarkType, locale) => {
@@ -90,7 +92,7 @@ export const enum TickMarkType {
  * };
  * ```
  */
-export type TickMarkFormatter = (time: Time, tickMarkType: TickMarkType, locale: string) => string;
+export type TickMarkFormatter = (time: Time, tickMarkType: TickMarkType, locale: string) => string | null;
 
 /**
  * Options for the time scale; the horizontal scale at the bottom of the chart that displays the time of data.
@@ -905,7 +907,14 @@ export class TimeScale {
 		const tickMarkType = weightToTickMarkType(tickMark.weight, this._options.timeVisible, this._options.secondsVisible);
 
 		if (this._options.tickMarkFormatter !== undefined) {
-			return this._options.tickMarkFormatter(tickMark.originalTime as unknown as Time, tickMarkType, this._localizationOptions.locale);
+			const tickMarkString = this._options.tickMarkFormatter(
+				tickMark.originalTime as unknown as Time,
+				tickMarkType,
+				this._localizationOptions.locale
+			);
+			if (tickMarkString !== null) {
+				return tickMarkString;
+			}
 		}
 
 		return defaultTickMarkFormatter(tickMark.time, tickMarkType, this._localizationOptions.locale);


### PR DESCRIPTION
Allow the custom tick mark formatter to return `null` so that it will use the default formatter for that specific mark.

**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1210
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

If the custom tick mark formatter returns `null` then it will use the default tick mark formatter for that specific tick mark.
