### PR TITLE
Fix props destructuring in react tutorials

### DIFF
--- a/website/plugins/enhanced-codeblock/theme/CodeBlock/index.jsx
+++ b/website/plugins/enhanced-codeblock/theme/CodeBlock/index.jsx
@@ -24,6 +24,10 @@ export function replaceThemeConstantStrings(originalString, isDarkTheme) {
 	return result;
 }
 
+export function removeUnwantedLines(originalString) {
+	return originalString.replace(new RegExp(/\/\/ delete-start[\w\W]*?\/\/ delete-end/, 'gm'), '');
+}
+
 const EnhancedCodeBlock = props => {
 	const { chart, replaceThemeConstants, hideableCode, ...rest } = props;
 	let { children } = props;
@@ -34,6 +38,7 @@ const EnhancedCodeBlock = props => {
 	if (replaceThemeConstants && typeof children === 'string') {
 		children = replaceThemeConstantStrings(children, isDarkTheme);
 	}
+	children = removeUnwantedLines(children);
 
 	if (chart || hideableCode) {
 		return (

--- a/website/src/components/tutorials/advanced-react-example.jsx
+++ b/website/src/components/tutorials/advanced-react-example.jsx
@@ -25,12 +25,19 @@ const currentDate = new Date(initialData[initialData.length - 1].time);
 
 export const App = props => {
 	const {
-		colors: {
-			backgroundColor = CHART_BACKGROUND_COLOR,
-			lineColor = LINE_LINE_COLOR,
-			textColor = CHART_TEXT_COLOR,
+		colors = {
+			backgroundColor: CHART_BACKGROUND_COLOR,
+			lineColor: LINE_LINE_COLOR,
+			textColor: CHART_TEXT_COLOR,
 		},
 	} = props;
+
+	const {
+		backgroundColor,
+		lineColor,
+		textColor,
+	} = colors;
+
 	const [chartLayoutOptions, setChartLayoutOptions] = useState({});
 	// The following variables illustrate how a series could be updated.
 	const series1 = useRef(null);

--- a/website/src/components/tutorials/advanced-react-example.jsx
+++ b/website/src/components/tutorials/advanced-react-example.jsx
@@ -1,3 +1,9 @@
+// hide-start
+/* Note: this file shouldn't be used directly because it has some constants which are set by
+the docusaurus site to ensure that the chart looks great in both dark and light color themes.
+If you want to use this example then please copy the code presented on the documentation site.
+[link](https://tradingview.github.io/lightweight-charts/tutorials/react/advanced) */
+// hide-end
 import { createChart } from 'lightweight-charts';
 import React, {
 	createContext,
@@ -25,18 +31,12 @@ const currentDate = new Date(initialData[initialData.length - 1].time);
 
 export const App = props => {
 	const {
-		colors = {
-			backgroundColor: CHART_BACKGROUND_COLOR,
-			lineColor: LINE_LINE_COLOR,
-			textColor: CHART_TEXT_COLOR,
-		},
+		colors: {
+			backgroundColor = CHART_BACKGROUND_COLOR,
+			lineColor = LINE_LINE_COLOR,
+			textColor = CHART_TEXT_COLOR,
+		} = {},
 	} = props;
-
-	const {
-		backgroundColor,
-		lineColor,
-		textColor,
-	} = colors;
 
 	const [chartLayoutOptions, setChartLayoutOptions] = useState({});
 	// The following variables illustrate how a series could be updated.

--- a/website/src/components/tutorials/advanced-react-example.jsx
+++ b/website/src/components/tutorials/advanced-react-example.jsx
@@ -1,9 +1,9 @@
-// hide-start
+// delete-start
 /* Note: this file shouldn't be used directly because it has some constants which are set by
 the docusaurus site to ensure that the chart looks great in both dark and light color themes.
 If you want to use this example then please copy the code presented on the documentation site.
 [link](https://tradingview.github.io/lightweight-charts/tutorials/react/advanced) */
-// hide-end
+// delete-end
 import { createChart } from 'lightweight-charts';
 import React, {
 	createContext,

--- a/website/src/components/tutorials/simple-react-example.jsx
+++ b/website/src/components/tutorials/simple-react-example.jsx
@@ -4,14 +4,23 @@ import React, { useEffect, useRef } from 'react';
 export const ChartComponent = props => {
 	const {
 		data,
-		colors: {
-			backgroundColor = CHART_BACKGROUND_COLOR,
-			lineColor = LINE_LINE_COLOR,
-			textColor = CHART_TEXT_COLOR,
-			areaTopColor = AREA_TOP_COLOR,
-			areaBottomColor = AREA_BOTTOM_COLOR,
+		colors = {
+			backgroundColor: CHART_BACKGROUND_COLOR,
+			lineColor: LINE_LINE_COLOR,
+			textColor: CHART_TEXT_COLOR,
+			areaTopColor: AREA_TOP_COLOR,
+			areaBottomColor: AREA_BOTTOM_COLOR,
 		},
 	} = props;
+
+	const {
+		backgroundColor,
+		lineColor,
+		textColor,
+		areaTopColor,
+		areaBottomColor,
+	} = colors;
+
 	const chartContainerRef = useRef();
 
 	useEffect(

--- a/website/src/components/tutorials/simple-react-example.jsx
+++ b/website/src/components/tutorials/simple-react-example.jsx
@@ -1,25 +1,23 @@
+// hide-start
+/* Note: this file shouldn't be used directly because it has some constants which are set by
+the docusaurus site to ensure that the chart looks great in both dark and light color themes.
+If you want to use this example then please copy the code presented on the documentation site.
+[link](https://tradingview.github.io/lightweight-charts/tutorials/react/simple) */
+// hide-end
 import { createChart, ColorType } from 'lightweight-charts';
 import React, { useEffect, useRef } from 'react';
 
 export const ChartComponent = props => {
 	const {
 		data,
-		colors = {
-			backgroundColor: CHART_BACKGROUND_COLOR,
-			lineColor: LINE_LINE_COLOR,
-			textColor: CHART_TEXT_COLOR,
-			areaTopColor: AREA_TOP_COLOR,
-			areaBottomColor: AREA_BOTTOM_COLOR,
-		},
+		colors: {
+			backgroundColor = CHART_BACKGROUND_COLOR,
+			lineColor = LINE_LINE_COLOR,
+			textColor = CHART_TEXT_COLOR,
+			areaTopColor = AREA_TOP_COLOR,
+			areaBottomColor = AREA_BOTTOM_COLOR,
+		} = {},
 	} = props;
-
-	const {
-		backgroundColor,
-		lineColor,
-		textColor,
-		areaTopColor,
-		areaBottomColor,
-	} = colors;
 
 	const chartContainerRef = useRef();
 

--- a/website/src/components/tutorials/simple-react-example.jsx
+++ b/website/src/components/tutorials/simple-react-example.jsx
@@ -1,9 +1,9 @@
-// hide-start
+// delete-start
 /* Note: this file shouldn't be used directly because it has some constants which are set by
 the docusaurus site to ensure that the chart looks great in both dark and light color themes.
 If you want to use this example then please copy the code presented on the documentation site.
 [link](https://tradingview.github.io/lightweight-charts/tutorials/react/simple) */
-// hide-end
+// delete-end
 import { createChart, ColorType } from 'lightweight-charts';
 import React, { useEffect, useRef } from 'react';
 


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**
- [X] Documentation update

**Overview of change:**
When i've tried to use code snippet from [React - Simple Example](https://tradingview.github.io/lightweight-charts/tutorials/react/simple) tutorial it gave me an error, stating that colors(which is destructured from props) is undefined. This problem appears additionally in [React - Advanced example](https://tradingview.github.io/lightweight-charts/tutorials/react/advanced)
