### PR TITLE
add retries to unpkg download during website build

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -54,7 +54,7 @@ function delay(duration) {
 	});
 }
 
-function downloadFile(urlString, filePath, retriesRemaining = 0) {
+function downloadFile(urlString, filePath, retriesRemaining = 0, attempt = 1) {
 	return new Promise((resolve, reject) => {
 		let file;
 
@@ -71,8 +71,8 @@ function downloadFile(urlString, filePath, retriesRemaining = 0) {
 			if (response.statusCode && (response.statusCode < 100 || response.statusCode > 299)) {
 				if (retriesRemaining > 0) {
 					logger.info(`Failed to download from ${urlString}, attempting again (${retriesRemaining - 1} retries remaining).`);
-					delay(200).then(() => {
-						downloadFile(url.toString(), filePath, retriesRemaining - 1).then(resolve, reject);
+					delay(Math.pow(2, attempt) * 200).then(() => {
+						downloadFile(url.toString(), filePath, retriesRemaining - 1, attempt + 1).then(resolve, reject);
 					});
 					return;
 				}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- `N/A` Addresses an existing issue
- `N/A` Includes tests
- `N/A` Documentation update

**Overview of change:**

The CI job for building the website seems to randomly fail on the rare occasion that `unpkg.com` has an issue on their side.

```
[ERROR] Error: Cannot download file "https://unpkg.com/lightweight-charts@3.8/dist/typings.d.ts", error code=520
```

This PR adds 'retries' to the downloadFile function so that it will attempt more than once to download the file (with a short 200ms exponential backoff delay between attempts).