### PR TITLE
fix timescale crosshair label during initial render

### DIFF
--- a/src/views/time-axis/crosshair-time-axis-view.ts
+++ b/src/views/time-axis/crosshair-time-axis-view.ts
@@ -62,7 +62,7 @@ export class CrosshairTimeAxisView implements ITimeAxisView {
 		data.width = timeScale.width();
 
 		const value = this._valueProvider();
-		if (!value.time || Number.isNaN(value.coordinate)) {
+		if (!value.time || !Number.isFinite(value.coordinate)) {
 			return;
 		}
 

--- a/src/views/time-axis/crosshair-time-axis-view.ts
+++ b/src/views/time-axis/crosshair-time-axis-view.ts
@@ -62,7 +62,7 @@ export class CrosshairTimeAxisView implements ITimeAxisView {
 		data.width = timeScale.width();
 
 		const value = this._valueProvider();
-		if (!value.time) {
+		if (!value.time || Number.isNaN(value.coordinate)) {
 			return;
 		}
 


### PR DESCRIPTION
The text for the timescale crosshair label could appear when even if the coordinate was NaN.

**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1255 
- `N/A` ~Includes tests~
- `N/A` ~Documentation update~

**Overview of change:**

Crosshair label won't be rendered if the coordinate is `NaN`.
