### PR TITLE
Change return type for time axis crosshair value provider

### DIFF
--- a/src/model/crosshair.ts
+++ b/src/model/crosshair.ts
@@ -26,12 +26,12 @@ export interface CrosshairPriceAndCoordinate {
 }
 
 export interface CrosshairTimeAndCoordinate {
-	time: TimePoint | null;
+	time: TimePoint;
 	coordinate: number;
 }
 
 export type PriceAndCoordinateProvider = (priceScale: PriceScale) => CrosshairPriceAndCoordinate;
-export type TimeAndCoordinateProvider = () => CrosshairTimeAndCoordinate;
+export type TimeAndCoordinateProvider = () => CrosshairTimeAndCoordinate | null;
 
 /**
  * Represents the crosshair mode.
@@ -166,9 +166,14 @@ export class Crosshair extends DataSource {
 
 		const valueTimeProvider = (rawIndexProvider: RawIndexProvider, rawCoordinateProvider: RawCoordinateProvider) => {
 			return () => {
+				const time = this._model.timeScale().indexToTime(rawIndexProvider());
+				const coordinate = rawCoordinateProvider();
+				if (!time || !Number.isFinite(coordinate)) {
+					return null;
+				}
 				return {
-					time: this._model.timeScale().indexToTime(rawIndexProvider()),
-					coordinate: rawCoordinateProvider(),
+					time,
+					coordinate,
 				};
 			};
 		};

--- a/src/views/time-axis/crosshair-time-axis-view.ts
+++ b/src/views/time-axis/crosshair-time-axis-view.ts
@@ -62,7 +62,7 @@ export class CrosshairTimeAxisView implements ITimeAxisView {
 		data.width = timeScale.width();
 
 		const value = this._valueProvider();
-		if (!value.time || !Number.isFinite(value.coordinate)) {
+		if (value === null) {
 			return;
 		}
 


### PR DESCRIPTION
**Type of PR:** bugfix, enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1255
- `N/A` ~Includes tests~
- `N/A` ~Documentation update~

Moved the runtime check logic for the validity of the values provided to the crosshair time axis. This is to increase the readability of the code.
- The reader is now immediately informed that `TimeAndCoordinateProvider` does NOT always return a valid value (so, sometimes we have nothing to draw in view),
- It is now clear that you get the whole (time, coordinate) tuple OR nothing, time or coordinate taken separately are meaningless. 

In previous version it looked like we **could** have some time, but **no** coordinate or vice-versa. This was potentially confusing.