### PR TITLE
Docs: Include version warning for mobile wrappers

### DIFF
--- a/website/docs/android.md
+++ b/website/docs/android.md
@@ -6,7 +6,7 @@ keywords:
     - android
     - canvas
     - charting library
-    - charting 
+    - charting
     - html5 charts
     - financial charting library
 sidebar_position: 7
@@ -16,6 +16,12 @@ sidebar_position: 7
 
 :::note
 You can find the source code of the Lightweight Charts Android wrapper in [this repository](https://github.com/tradingview/lightweight-charts-android).
+:::
+
+:::info
+
+This wrapper is currently still using `v3.8.0`. This will be updated to `v4.0.0` in the near future.
+
 :::
 
 You can use Lightweight Charts inside an Android application. To use Lightweight Charts in that context, you can use our Android wrapper, which will allow you to interact with lightweight charts library, which will be rendered in a web view.
@@ -42,7 +48,7 @@ In `/gradle_module/build.gradle`
 ```groovy
 dependencies {
     //...
-    implementation 'com.tradingview:lightweightcharts:4.0.0'
+    implementation 'com.tradingview:lightweightcharts:3.8.0'
 }
 ```
 

--- a/website/docs/ios.md
+++ b/website/docs/ios.md
@@ -6,7 +6,7 @@ keywords:
     - iOS
     - canvas
     - charting library
-    - charting 
+    - charting
     - html5 charts
     - financial charting library
 sidebar_position: 6
@@ -16,6 +16,12 @@ sidebar_position: 6
 
 :::note
 You can find the source code of the Lightweight Charts iOS wrapper in [this repository](https://github.com/tradingview/LightweightChartsIOS).
+:::
+
+:::info
+
+This wrapper is currently still using `v3.8.0`. This will be updated to `v4.0.0` in the near future.
+
 :::
 
 You can use Lightweight Charts inside an iOS application. To use Lightweight Charts in that context, you can use our iOS wrapper, which will allow you to interact with lightweight charts library, which will be rendered in a web view.
@@ -31,7 +37,7 @@ Requires iOS 10.0+
 [CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate LightweightCharts into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
-pod 'LightweightCharts', '~> 4.0.0'
+pod 'LightweightCharts', '~> 3.8.0'
 ```
 
 ### Swift Package Manager

--- a/website/versioned_docs/version-4.0/android.md
+++ b/website/versioned_docs/version-4.0/android.md
@@ -6,7 +6,7 @@ keywords:
     - android
     - canvas
     - charting library
-    - charting 
+    - charting
     - html5 charts
     - financial charting library
 sidebar_position: 7
@@ -16,6 +16,12 @@ sidebar_position: 7
 
 :::note
 You can find the source code of the Lightweight Charts Android wrapper in [this repository](https://github.com/tradingview/lightweight-charts-android).
+:::
+
+:::info
+
+This wrapper is currently still using `v3.8.0`. This will be updated to `v4.0.0` in the near future.
+
 :::
 
 You can use Lightweight Charts inside an Android application. To use Lightweight Charts in that context, you can use our Android wrapper, which will allow you to interact with lightweight charts library, which will be rendered in a web view.

--- a/website/versioned_docs/version-4.0/ios.md
+++ b/website/versioned_docs/version-4.0/ios.md
@@ -6,7 +6,7 @@ keywords:
     - iOS
     - canvas
     - charting library
-    - charting 
+    - charting
     - html5 charts
     - financial charting library
 sidebar_position: 6
@@ -16,6 +16,12 @@ sidebar_position: 6
 
 :::note
 You can find the source code of the Lightweight Charts iOS wrapper in [this repository](https://github.com/tradingview/LightweightChartsIOS).
+:::
+
+:::info
+
+This wrapper is currently still using `v3.8.0`. This will be updated to `v4.0.0` in the near future.
+
 :::
 
 You can use Lightweight Charts inside an iOS application. To use Lightweight Charts in that context, you can use our iOS wrapper, which will allow you to interact with lightweight charts library, which will be rendered in a web view.


### PR DESCRIPTION
**Type of PR:** update docs

Updates docs for mobile wrapper libraries to include a warning that the wrappers haven't been updated to `v4.0.0` yet.
