### PR TITLE
fix unable to add markers when autoSize chart option is enabled

### DIFF
--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -105,6 +105,7 @@ export class ChartWidget implements IDestroyable {
 			const containerRect = container.getBoundingClientRect();
 			width = width || containerRect.width;
 			height = height || containerRect.height;
+			this.resize(width, height);
 		}
 
 		// BEWARE: resize must be called BEFORE _syncGuiWithModel (in constructor only)

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -105,14 +105,11 @@ export class ChartWidget implements IDestroyable {
 			const containerRect = container.getBoundingClientRect();
 			width = width || containerRect.width;
 			height = height || containerRect.height;
-			this.resize(width, height);
 		}
 
 		// BEWARE: resize must be called BEFORE _syncGuiWithModel (in constructor only)
 		// or after but with adjustSize to properly update time scale
-		if (!usedObserver) {
-			this.resize(width, height);
-		}
+		this.resize(width, height);
 
 		this._syncGuiWithModel();
 

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -578,7 +578,7 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 
 	private _recalculateMarkers(): void {
 		const timeScale = this.model().timeScale();
-		if (timeScale.isEmpty() || this._data.size() === 0) {
+		if (timeScale.isEmpty() || this._data.isEmpty()) {
 			this._indexedMarkers = [];
 			return;
 		}

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -578,7 +578,7 @@ export class Series<T extends SeriesType = SeriesType> extends PriceDataSource i
 
 	private _recalculateMarkers(): void {
 		const timeScale = this.model().timeScale();
-		if (timeScale.isEmpty() || this._data.isEmpty()) {
+		if (!timeScale.hasPoints() || this._data.isEmpty()) {
 			this._indexedMarkers = [];
 			return;
 		}

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -321,6 +321,10 @@ export class TimeScale {
 		return this._width === 0 || this._points.length === 0 || this._baseIndexOrNull === null;
 	}
 
+	public hasPoints(): boolean {
+		return this._points.length > 0;
+	}
+
 	// strict range: integer indices of the bars in the visible range rounded in more wide direction
 	public visibleStrictRange(): RangeImpl<TimePointIndex> | null {
 		this._updateVisibleRange();

--- a/tests/e2e/graphics/test-cases/add-markers-with-autosize-enabled.js
+++ b/tests/e2e/graphics/test-cases/add-markers-with-autosize-enabled.js
@@ -1,0 +1,74 @@
+function generateCandle(i, target) {
+	const step = (i % 2) / 150;
+	const base = i / 5;
+	target.open = base * (1 - step);
+	target.high = base * (1 + 2 * step);
+	target.low = base * (1 - 2 * step);
+	target.close = base * (1 + step);
+}
+
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 50; ++i) {
+		const item = {
+			time: time.getTime() / 1000,
+		};
+		time.setUTCDate(time.getUTCDate() + 1);
+
+		if (i % 30 !== 0) {
+			generateCandle(i, item);
+		}
+		res.push(item);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, { autoSize: true });
+
+	const series = chart.addCandlestickSeries();
+
+	const data = generateData();
+	series.setData(data);
+
+	const datesForMarkers = [data[data.length - 39], data[data.length - 19]];
+	let indexOfMinPrice = 0;
+	for (let i = 1; i < datesForMarkers.length; i++) {
+		if (datesForMarkers[i].high < datesForMarkers[indexOfMinPrice].high) {
+			indexOfMinPrice = i;
+		}
+	}
+	const markers = [
+		{
+			time: data[data.length - 48].time,
+			position: 'aboveBar',
+			color: '#f68410',
+			shape: 'circle',
+			text: 'D',
+			id: 'D',
+		},
+	];
+	for (let i = 0; i < datesForMarkers.length; i++) {
+		if (i !== indexOfMinPrice) {
+			markers.push({
+				time: datesForMarkers[i].time,
+				position: 'aboveBar',
+				color: '#e91e63',
+				shape: 'arrowDown',
+				text: 'Sell @ ' + Math.floor(datesForMarkers[i].high + 2),
+				id: 'Sell',
+			});
+		} else {
+			markers.push({
+				time: datesForMarkers[i].time,
+				position: 'belowBar',
+				color: '#2196F3',
+				shape: 'arrowUp',
+				text: 'Buy @ ' + Math.floor(datesForMarkers[i].low - 2),
+				id: 'Buy',
+			});
+		}
+	}
+	series.setMarkers(markers);
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

* [x] Addresses an existing issue: fixes #1271 
* [x] Includes tests
* `N/A`  ~Documentation update~

**Overview of change:**
* The function `timeScale.isEmpty()` was returning true. This because there a condition with a `width === 0`. To resolve this [issue](https://github.com/tradingview/lightweight-charts/issues/1271), an initial size was added so that the markers could be recalculated.
* I changed the condition of `_recalculateMarkers()` to be easier to read.

**Glitch Code Sandbox link:**
https://glitch.com/edit/#!/hurricane-mahogany-output

<!-- optional -->
