### PR TITLE
Add color options for price line label

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -14,7 +14,7 @@ module.exports = [
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '46.0 KB',
+		limit: '46.05 KB',
 	},
 	{
 		name: 'Standalone',

--- a/src/api/options/price-line-options-defaults.ts
+++ b/src/api/options/price-line-options-defaults.ts
@@ -9,4 +9,6 @@ export const priceLineOptionsDefaults: PriceLineOptions = {
 	lineVisible: true,
 	axisLabelVisible: true,
 	title: '',
+	axisLabelColor: '',
+	axisLabelTextColor: '',
 };

--- a/src/model/price-line-options.ts
+++ b/src/model/price-line-options.ts
@@ -50,6 +50,19 @@ export interface PriceLineOptions {
 	 * @defaultValue `''`
 	 */
 	title: string;
+	/**
+	 * Background color for the axis label.
+	 * Will default to the price line color if unspecified.
+	 *
+	 * @defaultValue `''`
+	 */
+	axisLabelColor: string;
+	/**
+	 * Text color for the axis label.
+	 *
+	 * @defaultValue `''`
+	 */
+	axisLabelTextColor: string;
 }
 
 /**

--- a/src/views/price-axis/custom-price-line-price-axis-view.ts
+++ b/src/views/price-axis/custom-price-line-price-axis-view.ts
@@ -52,9 +52,14 @@ export class CustomPriceLinePriceAxisView extends PriceAxisView {
 		axisRendererData.text = this._formatPrice(options.price);
 		axisRendererData.visible = true;
 
-		const colors = generateContrastColors(options.color);
+		const colors = generateContrastColors(options.axisLabelColor || options.color);
 		commonData.background = colors.background;
-		commonData.color = colors.foreground;
+		// no need to set commonData.color because it will be ignored.
+
+		const textColor = options.axisLabelTextColor || colors.foreground;
+		axisRendererData.color = textColor; // price text
+		paneRendererData.color = textColor; // title text
+
 		commonData.coordinate = y;
 	}
 

--- a/tests/e2e/coverage/test-cases/series/price-line.js
+++ b/tests/e2e/coverage/test-cases/series/price-line.js
@@ -46,6 +46,8 @@ function beforeInteractions(container) {
 		color: '#f0f',
 		lineWidth: 4,
 		lineStyle: LightweightCharts.LineStyle.SparseDotted,
+		axisLabelTextColor: '#d04488',
+		axisLabelColor: '#00DDDD',
 	});
 
 	priceLine1.options();

--- a/tests/e2e/graphics/test-cases/price-line-label-colors.js
+++ b/tests/e2e/graphics/test-cases/price-line-label-colors.js
@@ -1,0 +1,54 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container));
+
+	const mainSeries = chart.addLineSeries();
+
+	mainSeries.setData(generateData());
+
+	const priceLine = {
+		price: 480,
+		color: '#be1238',
+		lineWidth: 2,
+		lineStyle: LightweightCharts.LineStyle.Dotted,
+		axisLabelVisible: true,
+		title: 'Test One',
+		axisLabelTextColor: '#d04488',
+		axisLabelColor: '#00DDDD',
+	};
+	const priceLine2 = {
+		price: 470,
+		color: '#333',
+		lineWidth: 2,
+		lineStyle: LightweightCharts.LineStyle.Dotted,
+		axisLabelVisible: true,
+		title: 'Test Two',
+		axisLabelColor: '#d04488',
+	};
+	const priceLine3 = {
+		price: 450,
+		color: '#333',
+		lineWidth: 2,
+		lineStyle: LightweightCharts.LineStyle.Dotted,
+		axisLabelVisible: true,
+		title: 'Test Three',
+		axisLabelTextColor: '#00DDDD',
+	};
+
+	mainSeries.createPriceLine(priceLine);
+	mainSeries.createPriceLine(priceLine2);
+	mainSeries.createPriceLine(priceLine3);
+}


### PR DESCRIPTION
**Type of PR:** enhancement (and bug fix)

**PR checklist:**

- [x] Addresses an existing issue: fixes #1274
- [x] Includes tests
- [x] Documentation update → JSDoc comments

**Overview of change:**
Adds the ability to specify the background color and text color for a price line's label (independently of the line color).

Additionally, fixes an issue where the label text color was always white for price lines, even if the label color was very light.