### PR TITLE
fix line rendering bug when out of visible range

### DIFF
--- a/src/renderers/walk-line.ts
+++ b/src/renderers/walk-line.ts
@@ -17,7 +17,7 @@ export function walkLine<TItem extends LinePoint, TStyle>(
 	styleGetter: (renderingScope: MediaCoordinatesRenderingScope, item: TItem) => TStyle,
 	finishStyledArea: (ctx: CanvasRenderingContext2D, style: TStyle, areaFirstItem: LinePoint, newAreaFirstItem: LinePoint) => void
 ): void {
-	if (items.length === 0 || visibleRange.from >= items.length) {
+	if (items.length === 0 || visibleRange.from >= items.length || visibleRange.to <= 0) {
 		return;
 	}
 

--- a/tests/e2e/graphics/test-cases/dont-draw-lines-when-out-of-visible-range.js
+++ b/tests/e2e/graphics/test-cases/dont-draw-lines-when-out-of-visible-range.js
@@ -1,0 +1,59 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container, {
+		height: 500,
+		width: 600,
+		crosshair: {
+			vertLine: {
+				visible: false,
+				labelVisible: false,
+			},
+			horzLine: {
+				visible: false,
+				labelVisible: false,
+			},
+		},
+	}));
+
+	const whitespaceData = generateData().map(d => ({ time: d.time }));
+	const whitespaceSeries = chart.addLineSeries();
+	whitespaceSeries.setData(whitespaceData);
+
+	const lineData = generateData().slice(-100);
+	const lineSeries = chart.addLineSeries({
+		priceLineVisible: false,
+		lastValueVisible: false,
+	});
+	lineSeries.setData(lineData);
+
+	const baselineData = generateData().slice(200, 300);
+	const baselineSeries = chart.addBaselineSeries({
+		baseValue: { type: 'price', price: baselineData[49].value },
+		priceLineVisible: false,
+		lastValueVisible: false,
+	});
+	baselineSeries.setData(baselineData);
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			chart.timeScale().fitContent();
+			requestAnimationFrame(() => {
+				chart.timeScale().setVisibleLogicalRange({ from: 0, to: 2 });
+				requestAnimationFrame(() => resolve());
+			});
+		});
+	});
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1293
- [x] Includes tests
- `N/A` ~Documentation update~

**Overview of change:**
When a line based series (line, baseline, area) is on a chart where it is possible to scroll it completely off the screen to the right.
Then if the series is scrolled off screen then it will still draw on the chart.

This change corrects the `walkLine` function so that it doesn't draw anything if the `to` value is equal to zero.