### PR TITLE
Ignore resize method if autoSize is active, and added API to check if active

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -2,6 +2,7 @@ import { ChartWidget, MouseEventParamsImpl, MouseEventParamsImplSupplier } from 
 
 import { assert, ensureDefined } from '../helpers/assertions';
 import { Delegate } from '../helpers/delegate';
+import { warn } from '../helpers/logger';
 import { clone, DeepPartial, isBoolean, merge } from '../helpers/strict-type-checks';
 
 import { ChartOptions, ChartOptionsInternal } from '../model/chart-model';
@@ -161,6 +162,12 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 	}
 
 	public resize(width: number, height: number, forceRepaint?: boolean): void {
+		if (this.autoSizeActive()) {
+			// We return early here instead of checking this within the actual _chartWidget.resize method
+			// because this should only apply to external resize requests.
+			warn(`Height and width values ignored because 'autoSize' option is enabled.`);
+			return;
+		}
 		this._chartWidget.resize(width, height, forceRepaint);
 	}
 
@@ -245,6 +252,10 @@ export class ChartApi implements IChartApi, DataUpdatesConsumer<SeriesType> {
 
 	public takeScreenshot(): HTMLCanvasElement {
 		return this._chartWidget.takeScreenshot();
+	}
+
+	public autoSizeActive(): boolean {
+		return this._chartWidget.autoSizeActive();
 	}
 
 	private _addSeriesImpl<TSeries extends SeriesType>(

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -77,6 +77,9 @@ export interface IChartApi {
 	/**
 	 * Sets fixed size of the chart. By default chart takes up 100% of its container.
 	 *
+	 * If chart has the `autoSize` option enabled, and the ResizeObserver is available then
+	 * the width and height values will be ignored.
+	 *
 	 * @param width - Target width of the chart.
 	 * @param height - Target height of the chart.
 	 * @param forceRepaint - True to initiate resize immediately. One could need this to get screenshot immediately after resize.
@@ -260,4 +263,12 @@ export interface IChartApi {
 	 * @returns A canvas with the chart drawn on. Any `Canvas` methods like `toDataURL()` or `toBlob()` can be used to serialize the result.
 	 */
 	takeScreenshot(): HTMLCanvasElement;
+
+	/**
+	 * Returns the active state of the `autoSize` option. This can be used to check
+	 * whether the chart is handling resizing automatically with a `ResizeObserver`.
+	 *
+	 * @returns Whether the `autoSize` option is enabled and the active.
+	 */
+	autoSizeActive(): boolean;
 }

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -277,6 +277,10 @@ export class ChartWidget implements IDestroyable {
 		return ensureNotNull(priceAxisWidget).getWidth();
 	}
 
+	public autoSizeActive(): boolean {
+		return this._options.autoSize && this._observer !== null;
+	}
+
 	// eslint-disable-next-line complexity
 	private _applyAutoSizeOptions(options: DeepPartial<ChartOptionsInternal>): void {
 		if (options.autoSize === undefined && this._observer && (options.width !== undefined || options.height !== undefined)) {

--- a/tests/e2e/graphics/test-cases/api/ignore-resize-if-autosize-active.js
+++ b/tests/e2e/graphics/test-cases/api/ignore-resize-if-autosize-active.js
@@ -1,0 +1,30 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 1000; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container, {
+		autoSize: true,
+	}));
+	const series = chart.addLineSeries();
+	series.setData(generateData());
+
+	return new Promise(resolve => {
+		setTimeout(() => {
+			chart.resize(400, 350);
+			requestAnimationFrame(() => {
+				resolve();
+			});
+		}, 500);
+	});
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue
- [x] Includes tests
- [x] Documentation update

**Overview of change:**
When `autoSize` chart option is enabled then we should ignore any requests to change the `height` and `width` via the `resize` method. 

Added a `autoSizeActive` method to the Chart API for checking if the setting is enabled and the ResizeObserver was successfully created.