### PR TITLE
new docusaurus tsconfig breaks website building

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -4,6 +4,7 @@
 		"strict": true,
 		"resolveJsonModule": true,
 		"jsx": "react",
+		"moduleResolution": "node",
 	},
 	"include": [
 		"./**/*.ts",


### PR DESCRIPTION
**Type of PR:** hot fix

**Overview of change:**
The new `tsconfig` for docusaurus (`v1.0.7` instead of `v1.0.6`) breaks our documentation site build because they added:
```
"moduleResolution": "Node16",
```

This breaks our `../../../../..` import within the documentation site build. See [import-lightweight-charts-version.ts](https://github.com/tradingview/lightweight-charts/blob/master/website/plugins/enhanced-codeblock/theme/CodeBlock/import-lightweight-charts-version.ts)

- https://www.npmjs.com/package/@tsconfig/docusaurus/v/1.0.6
- https://www.npmjs.com/package/@tsconfig/docusaurus/v/1.0.7