### PR TITLE
fix auto contrast text color for crosshair labels

### DIFF
--- a/src/renderers/iprice-axis-view-renderer.ts
+++ b/src/renderers/iprice-axis-view-renderer.ts
@@ -7,7 +7,6 @@ import { LineWidth } from './draw-line';
 export interface PriceAxisViewRendererCommonData {
 	activeBackground?: string;
 	background: string;
-	color: string;
 	coordinate: number;
 	fixedCoordinate?: number;
 	additionalPaddingTop: number;

--- a/src/renderers/price-axis-view-renderer.ts
+++ b/src/renderers/price-axis-view-renderer.ts
@@ -70,7 +70,7 @@ export class PriceAxisViewRenderer implements IPriceAxisViewRenderer {
 			return;
 		}
 
-		const textColor = this._data.color || this._commonData.color;
+		const textColor = this._data.color;
 		const backgroundColor = this._commonData.background;
 
 		const geometry = target.useBitmapCoordinateSpace((scope: BitmapCoordinatesRenderingScope) => {

--- a/src/views/price-axis/crosshair-price-axis-view.ts
+++ b/src/views/price-axis/crosshair-price-axis-view.ts
@@ -38,7 +38,7 @@ export class CrosshairPriceAxisView extends PriceAxisView {
 
 		const colors = generateContrastColors(options.labelBackgroundColor);
 		commonRendererData.background = colors.background;
-		commonRendererData.color = colors.foreground;
+		axisRendererData.color = colors.foreground;
 
 		const additionalPadding = 2 / 12 * this._priceScale.fontSize();
 

--- a/src/views/price-axis/custom-price-line-price-axis-view.ts
+++ b/src/views/price-axis/custom-price-line-price-axis-view.ts
@@ -54,7 +54,6 @@ export class CustomPriceLinePriceAxisView extends PriceAxisView {
 
 		const colors = generateContrastColors(options.axisLabelColor || options.color);
 		commonData.background = colors.background;
-		// no need to set commonData.color because it will be ignored.
 
 		const textColor = options.axisLabelTextColor || colors.foreground;
 		axisRendererData.color = textColor; // price text

--- a/src/views/price-axis/price-axis-view.ts
+++ b/src/views/price-axis/price-axis-view.ts
@@ -13,7 +13,6 @@ import { IPriceAxisView } from './iprice-axis-view';
 export abstract class PriceAxisView implements IPriceAxisView {
 	private readonly _commonRendererData: PriceAxisViewRendererCommonData = {
 		coordinate: 0,
-		color: '#FFF',
 		background: '#000',
 		additionalPaddingBottom: 0,
 		additionalPaddingTop: 0,

--- a/src/views/price-axis/series-price-axis-view.ts
+++ b/src/views/price-axis/series-price-axis-view.ts
@@ -53,12 +53,11 @@ export class SeriesPriceAxisView extends PriceAxisView {
 		const colors = generateContrastColors(lastValueColor);
 
 		commonRendererData.background = colors.background;
-		commonRendererData.color = colors.foreground;
 		commonRendererData.coordinate = lastValueData.coordinate;
 		paneRendererData.borderColor = source.model().backgroundColorAtYPercentFromTop(lastValueData.coordinate / source.priceScale().height());
 		axisRendererData.borderColor = lastValueColor;
-		axisRendererData.color = commonRendererData.color;
-		paneRendererData.color = commonRendererData.color;
+		axisRendererData.color = colors.foreground;
+		paneRendererData.color = colors.foreground;
 	}
 
 	protected _paneText(

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-black.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-black.js
@@ -1,0 +1,30 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, {
+		crosshair: {
+			vertLine: {
+				labelBackgroundColor: '#000000',
+			},
+			horzLine: {
+				labelBackgroundColor: '#000000',
+			},
+		},
+	});
+
+	const mainSeries = chart.addAreaSeries();
+
+	mainSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-greys.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-greys.js
@@ -16,10 +16,10 @@ function runTestCase(container) {
 	const chart = window.chart = LightweightCharts.createChart(container, {
 		crosshair: {
 			vertLine: {
-				labelBackgroundColor: '#ffffff',
+				labelBackgroundColor: '#222222',
 			},
 			horzLine: {
-				labelBackgroundColor: '#000000',
+				labelBackgroundColor: '#DDDDDD',
 			},
 		},
 	});

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-named.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-named.js
@@ -1,0 +1,30 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, {
+		crosshair: {
+			vertLine: {
+				labelBackgroundColor: 'orangered',
+			},
+			horzLine: {
+				labelBackgroundColor: 'hotpink',
+			},
+		},
+	});
+
+	const mainSeries = chart.addAreaSeries();
+
+	mainSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-white.js
+++ b/tests/e2e/graphics/test-cases/initial-options/crosshair-label-color-white.js
@@ -1,0 +1,30 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, {
+		crosshair: {
+			vertLine: {
+				labelBackgroundColor: '#ffffff',
+			},
+			horzLine: {
+				labelBackgroundColor: '#ffffff',
+			},
+		},
+	});
+
+	const mainSeries = chart.addAreaSeries();
+
+	mainSeries.setData(generateData());
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1309
- [x] Includes tests
- `N/A` ~Documentation update~

**Overview of change:**
The automatic text color (calculated for contrast) for crosshair labels has been fixed. Previously, the calculated value was ignored because we `axisRendererData` had a default text color of white which was always taking precedence in the renderer.

Added a few tests for different label colors. It is expected that the following graphics tests will fail on the CI:
- `crosshair-label-color-greys`
- `crosshair-label-color-white`
