### PR TITLE
fix re-enabling of autoSize after disabling it

### DIFF
--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -802,6 +802,7 @@ export class ChartWidget implements IDestroyable {
 		if (this._observer !== null) {
 			this._observer.disconnect();
 		}
+		this._observer = null;
 	}
 }
 

--- a/tests/e2e/graphics/test-cases/applying-options/re-enable-autosize.js
+++ b/tests/e2e/graphics/test-cases/applying-options/re-enable-autosize.js
@@ -1,0 +1,45 @@
+window.ignoreMouseMove = true;
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+function runTestCase(container) {
+	const box = document.createElement('div');
+	box.style.position = 'absolute';
+	box.style.top = 0;
+	box.style.left = 0;
+	box.style.width = '200px';
+	box.style.height = '200px';
+	container.appendChild(box);
+
+	const chart = LightweightCharts.createChart(box, { autoSize: true, height: 200, width: 200 });
+	const mainSeries = chart.addAreaSeries();
+
+	mainSeries.setData(generateData());
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			// remove autoSize
+			chart.applyOptions({ autoSize: false });
+			box.style.height = '225px';
+			requestAnimationFrame(() => {
+				// enable autoSize again.
+				// This test case is checking that you can have autoSize enabled, then removed, and then re-added again
+				chart.applyOptions({ autoSize: true });
+				box.style.height = '250px';
+				setTimeout(resolve, 300);
+			});
+		});
+	});
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- `N/A` Addresses an existing issue
- [x] Includes tests
- `N/A` Documentation update

**Overview of change:**
When `autoSize` is enabled, and then removed (via `applyOptions`), and then later re-added (via `applyOptions`) then the new observer isn't created. This results in `autoSize` not working.
