### PR TITLE
fix candlestick width at smaller bar spacing

### DIFF
--- a/src/renderers/optimal-bar-width.ts
+++ b/src/renderers/optimal-bar-width.ts
@@ -3,9 +3,11 @@ export function optimalBarWidth(barSpacing: number, pixelRatio: number): number 
 }
 
 export function optimalCandlestickWidth(barSpacing: number, pixelRatio: number): number {
+	const barSpacingSpecialCaseFrom = 2.5;
 	const barSpacingSpecialCaseTo = 4;
-	if (barSpacing < barSpacingSpecialCaseTo) {
-		return Math.max(Math.floor(barSpacing * pixelRatio), 1);
+	const barSpacingSpecialCaseCoeff = 3;
+	if (barSpacing >= barSpacingSpecialCaseFrom && barSpacing <= barSpacingSpecialCaseTo) {
+		return Math.floor(barSpacingSpecialCaseCoeff * pixelRatio);
 	}
 	// coeff should be 1 on small barspacing and go to 0.8 while bar spacing grows
 	const barSpacingReducingCoeff = 0.2;

--- a/src/renderers/optimal-bar-width.ts
+++ b/src/renderers/optimal-bar-width.ts
@@ -3,13 +3,11 @@ export function optimalBarWidth(barSpacing: number, pixelRatio: number): number 
 }
 
 export function optimalCandlestickWidth(barSpacing: number, pixelRatio: number): number {
-	const barSpacingSpecialCaseFrom = 2.5;
 	const barSpacingSpecialCaseTo = 4;
-	const barSpacingSpecialCaseCoeff = 3;
-	if (barSpacing >= barSpacingSpecialCaseFrom && barSpacing <= barSpacingSpecialCaseTo) {
-		return Math.floor(barSpacingSpecialCaseCoeff * pixelRatio);
+	if (barSpacing < barSpacingSpecialCaseTo) {
+		return Math.max(Math.floor(barSpacing * pixelRatio), 1);
 	}
-	// coeff should be 1 on small barspacing and go to 0.8 while groing bar spacing
+	// coeff should be 1 on small barspacing and go to 0.8 while bar spacing grows
 	const barSpacingReducingCoeff = 0.2;
 	const coeff = 1 - barSpacingReducingCoeff * Math.atan(Math.max(barSpacingSpecialCaseTo, barSpacing) - barSpacingSpecialCaseTo) / (Math.PI * 0.5);
 	const res = Math.floor(barSpacing * coeff * pixelRatio);

--- a/tests/e2e/graphics/test-cases/series/candlesticks-small-barspacing.js
+++ b/tests/e2e/graphics/test-cases/series/candlesticks-small-barspacing.js
@@ -1,0 +1,72 @@
+const sampleDataSection = [
+	{
+		open: 10,
+		high: 11,
+		low: 10,
+		close: 11,
+	},
+	{
+		open: 10.5,
+		high: 10.5,
+		low: 9.5,
+		close: 9.5,
+	},
+];
+
+function sampleData() {
+	const res = [];
+	const time = new Date(Date.UTC(2023, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 100; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			...sampleDataSection[0],
+		});
+		time.setUTCDate(time.getUTCDate() + 1);
+		res.push({
+			time: time.getTime() / 1000,
+			...sampleDataSection[1],
+		});
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+window.ignoreMouseMove = true;
+
+function runTestCase(container) {
+	container.style.display = 'flex';
+	container.style.flexWrap = 'wrap';
+
+	const barSpacings = [2.4, 2.5, 2.6, 2.75, 2.9, 3.0, 3.1, 3.9, 4.0];
+
+	barSpacings.forEach((barSpacing, index) => {
+		const element = document.createElement('div');
+		element.style = 'width: 200px; height: 200px;';
+		container.append(element);
+		const chart = LightweightCharts.createChart(element, {
+			rightPriceScale: {
+				visible: false,
+			},
+			handleScale: false,
+			layout: {
+				background: {
+					type: 'solid',
+					color: index % 2 ? '#FFFFFF' : '#F8F8F8',
+				},
+			},
+		});
+
+		const mainSeries = chart.addCandlestickSeries({
+			upColor: 'rgba(0, 255, 0, 0.5)',
+			downColor: 'rgba(255, 0, 0, 0.5)',
+			borderVisible: false,
+		});
+		mainSeries.setData(sampleData());
+
+		chart.timeScale().applyOptions({
+			barSpacing,
+			visible: false,
+		});
+	});
+}


### PR DESCRIPTION
**Type of PR:** bugfix / enhancement

**PR checklist:**

- `N/A` Addresses an existing issue
- [x] Includes tests
- `N/A` Documentation update

**Overview of change:**
~Changes the calculation for the width of candlesticks at smaller bar spacing values.~
Adds a test case for the candlestick widths at smaller bar spacing values.

Decided that the existing behaviour is better for chart readability (instead of preventing slight overlapping). So the changes to the width calculation have been reverted.

---
 
~**Problem:**
Previously, there were cases where the candlestick width would be larger than the bar spacing therefore candlesticks could overlap. Preview of issue: https://codesandbox.io/p/sandbox/lightweight-charts-js-starter-forked-fnycf7?file=%2Fsrc%2Fmain.js%3A19%2C1
![dpr-1](https://github.com/tradingview/lightweight-charts/assets/3482679/22032688-6f1d-4dfa-9809-7e34630d88bb)~

~**Solution:**
Adjusted the `optimalCandlestickWidth` function such that the calculated width (in bitmap pixels) should never exceed the barSpacing gap (in bitmap pixels) until the width reaches a single pixel.~

~Plot of the new function results: https://jsfiddle.net/msilverwood/jx0zLo6f/~
```
Blue - candle width (pixels)
Red - bar spacing (pixels)
Green - bar spacing (media size)
```