### PR TITLE
Fix percentage mode and zero first value

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '46.96 KB',
+		limit: '46.97 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '46.89 KB',
+		limit: '46.90 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '48.58 KB',
+		limit: '48.59 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '48.63 KB',
+		limit: '48.64 KB',
 	},
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '46.94 KB',
+		limit: '46.96 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '46.86 KB',
+		limit: '46.89 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '48.56 KB',
+		limit: '48.58 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '48.61 KB',
+		limit: '48.63 KB',
 	},
 ];

--- a/src/model/price-range-impl.ts
+++ b/src/model/price-range-impl.ts
@@ -2,6 +2,15 @@ import { isNumber } from '../helpers/strict-type-checks';
 
 import { PriceRange } from './series-options';
 
+function computeFiniteResult(
+	values: number[],
+	method: (...values: number[]) => number,
+	fallback: number
+): number {
+	const result = method(...values.filter(Number.isFinite));
+	return Number.isFinite(result) ? result : fallback;
+}
+
 export class PriceRangeImpl {
 	private _minValue: number;
 	private _maxValue!: number;
@@ -43,8 +52,8 @@ export class PriceRangeImpl {
 			return this;
 		}
 		return new PriceRangeImpl(
-			Math.min(this.minValue(), anotherRange.minValue()),
-			Math.max(this.maxValue(), anotherRange.maxValue())
+			computeFiniteResult([this.minValue(), anotherRange.minValue()], Math.min, -Infinity),
+			computeFiniteResult([this.maxValue(), anotherRange.maxValue()], Math.max, Infinity)
 		);
 	}
 

--- a/src/model/price-range-impl.ts
+++ b/src/model/price-range-impl.ts
@@ -2,13 +2,22 @@ import { isNumber } from '../helpers/strict-type-checks';
 
 import { PriceRange } from './series-options';
 
+function ensureFiniteWithFallback(value: number, fallback: number): number {
+	return Number.isFinite(value) ? value : fallback;
+}
+
 function computeFiniteResult(
-	values: number[],
 	method: (...values: number[]) => number,
+	valueOne: number,
+	valueTwo: number,
 	fallback: number
 ): number {
-	const result = method(...values.filter(Number.isFinite));
-	return Number.isFinite(result) ? result : fallback;
+	const firstFinite = Number.isFinite(valueOne);
+	return firstFinite && Number.isFinite(valueTwo)
+		? ensureFiniteWithFallback(method(valueOne, valueTwo), fallback)
+		: firstFinite
+		? valueOne
+		: valueTwo;
 }
 
 export class PriceRangeImpl {
@@ -52,8 +61,8 @@ export class PriceRangeImpl {
 			return this;
 		}
 		return new PriceRangeImpl(
-			computeFiniteResult([this.minValue(), anotherRange.minValue()], Math.min, -Infinity),
-			computeFiniteResult([this.maxValue(), anotherRange.maxValue()], Math.max, Infinity)
+			computeFiniteResult(Math.min, this.minValue(), anotherRange.minValue(), -Infinity),
+			computeFiniteResult(Math.max, this.maxValue(), anotherRange.maxValue(), Infinity)
 		);
 	}
 

--- a/src/model/price-range-impl.ts
+++ b/src/model/price-range-impl.ts
@@ -2,10 +2,6 @@ import { isNumber } from '../helpers/strict-type-checks';
 
 import { PriceRange } from './series-options';
 
-function ensureFiniteWithFallback(value: number, fallback: number): number {
-	return Number.isFinite(value) ? value : fallback;
-}
-
 function computeFiniteResult(
 	method: (...values: number[]) => number,
 	valueOne: number,
@@ -13,11 +9,13 @@ function computeFiniteResult(
 	fallback: number
 ): number {
 	const firstFinite = Number.isFinite(valueOne);
-	return firstFinite && Number.isFinite(valueTwo)
-		? method(valueOne, valueTwo)
-		: firstFinite
-		? valueOne
-		: ensureFiniteWithFallback(valueTwo, fallback);
+	const secondFinite = Number.isFinite(valueTwo);
+
+	if (firstFinite && secondFinite) {
+		return method(valueOne, valueTwo);
+	}
+
+	return !firstFinite && !secondFinite ? fallback : (firstFinite ? valueOne : valueTwo);
 }
 
 export class PriceRangeImpl {

--- a/src/model/price-range-impl.ts
+++ b/src/model/price-range-impl.ts
@@ -14,10 +14,10 @@ function computeFiniteResult(
 ): number {
 	const firstFinite = Number.isFinite(valueOne);
 	return firstFinite && Number.isFinite(valueTwo)
-		? ensureFiniteWithFallback(method(valueOne, valueTwo), fallback)
+		? method(valueOne, valueTwo)
 		: firstFinite
 		? valueOne
-		: valueTwo;
+		: ensureFiniteWithFallback(valueTwo, fallback);
 }
 
 export class PriceRangeImpl {

--- a/tests/e2e/graphics/test-cases/price-scale/percentage-first-value-invisible-series.js
+++ b/tests/e2e/graphics/test-cases/price-scale/percentage-first-value-invisible-series.js
@@ -1,0 +1,39 @@
+function runTestCase(container) {
+	const chartOptions = {
+		rightPriceScale: {
+			borderVisible: false,
+			mode: 2,
+		},
+		layout: {
+			textColor: 'black',
+			background: { type: 'solid', color: 'white' },
+		},
+	};
+	const chart = (window.chart = LightweightCharts.createChart(
+		container,
+		chartOptions
+	));
+
+	/*
+	 * We expect the blue series to NOT be visible
+	 * and the red series to BE visible
+	 */
+
+	const series1 = chart.addLineSeries({
+		color: '#2962FF',
+	});
+	series1.setData([
+		{ time: 1522033200, value: 0 },
+		{ time: 1529895600, value: -3 },
+		{ time: 1537758000, value: 3 },
+	]);
+	const series2 = chart.addLineSeries({
+		color: '#FF2962',
+	});
+	series2.setData([
+		{ time: 1522033200, value: 1 },
+		{ time: 1529895600, value: -1 },
+		{ time: 1537758000, value: 2 },
+	]);
+	chart.timeScale().fitContent();
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1386
- [x] Includes tests
- `N/A` ~Documentation update~

**Overview of change:**

When merging price ranges for the price scale, infinite values would always be used if one of the values was infinite (which is the case with percentage mode and zero first value). The code change prevents Infinite values from always winning, but fallback to Infinite if required.