### PR TITLE
Use label length when building marks

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,24 +1,28 @@
 // eslint-env node
 
+// We should set these values as 0.01 higher than the number we get when running the size check.
+// The reason is that the size can change very slightly on each build because we include the build date as a comment in the output.
+// This seems to affect the compressed size (some dates are more compressible than others).
+
 module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '47.68 KB',
+		limit: '47.69 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '47.63 KB',
+		limit: '47.64 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.36 KB',
+		limit: '49.37 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.40 KB',
+		limit: '49.41 KB',
 	},
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '47.62 KB',
+		limit: '47.68 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '47.56 KB',
+		limit: '47.63 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.29 KB',
+		limit: '49.36 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.33 KB',
+		limit: '49.40 KB',
 	},
 ];

--- a/src/model/tick-marks.ts
+++ b/src/model/tick-marks.ts
@@ -76,6 +76,9 @@ export class TickMarks<HorzScaleItem> {
 	public build(spacing: number, fontSize: number): TickMarkBuildResult {
 		const maxLabelWidth = (fontSize + 4) * 5;
 		const widthPerCharacterEstimate = maxLabelWidth / 8;
+		// If we do not round then even very small changes in the spacing will cause the marks to be rebuilt.
+		// Limiting this to increments of 0.1 seems to be an acceptable compromise but probably there is a cleverer way to handle this.
+
 		// "default" because we will adjust the value based on actual label widths
 		const defaultMaxIndexesPerMark = roundToOneDecimalPlace(maxLabelWidth / spacing);
 


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [x] Addresses an existing issue: fixes #1396 
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Use the label length when building tick marks.

These changes stop overlapping labels, but it is a breaking change as it does not preserve the existing time scale behaviour.


**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
