### PR TITLE
DOCS: landing page css fixes

### DIFF
--- a/website/src/components/landing-page/CTAButton/ctabutton.module.css
+++ b/website/src/components/landing-page/CTAButton/ctabutton.module.css
@@ -36,6 +36,7 @@
 
 .SquareButton[data-primary]:hover {
 	background-color: var(--cta-button-primary-background-hover);
+	color: #ffffff;
 }
 
 .SquareButton[data-primary]:active {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -223,9 +223,8 @@
 		Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 	display: flex;
 	flex-direction: column;
-	margin: 0;
+	margin: 0px;
 	max-width: 1920px;
-	margin-inline: auto;
 
 	/* Don't use this because we want to have the chart reach the viewport edge for certain breakpoints */
 	/* padding-inline: var(--container-padding); */
@@ -233,4 +232,11 @@
 	/* padding-block: var(--vertical-container-padding); */
 	/* ! Fix for older versions of Safari which had a bug with css variables being used for -inline / -block */
 	padding: var(--vertical-container-padding) 0px;
+}
+
+@media (min-width: 1920px) {
+	.RootContainer {
+		margin-left: auto;
+		margin-right: auto;
+	}
 }


### PR DESCRIPTION
**Type of PR:** css fix for documentation landing page

**Overview of change:**
- Fixes a rendering issue on the landing page for the breakpoint between 1280 and 1440 where the chart should extend to the edge of the screen.
- CTA css issue which only occurs on minified builds.
