### PR TITLE
don't shift chart when new data replaces existing whitespace

### DIFF
--- a/src/api/options/time-scale-options-defaults.ts
+++ b/src/api/options/time-scale-options-defaults.ts
@@ -14,6 +14,7 @@ export const timeScaleOptionsDefaults: HorzScaleOptions = {
 	timeVisible: false,
 	secondsVisible: true,
 	shiftVisibleRangeOnNewBar: true,
+	dontShiftVisibleRangeWhenNewBarReplacesWhitespace: false,
 	ticksVisible: false,
 	uniformDistribution: false,
 	minimumHeight: 0,

--- a/src/api/options/time-scale-options-defaults.ts
+++ b/src/api/options/time-scale-options-defaults.ts
@@ -14,7 +14,6 @@ export const timeScaleOptionsDefaults: HorzScaleOptions = {
 	timeVisible: false,
 	secondsVisible: true,
 	shiftVisibleRangeOnNewBar: true,
-	shiftVisibleRangeWhenNewBarReplacesWhitespace: true,
 	ticksVisible: false,
 	uniformDistribution: false,
 	minimumHeight: 0,

--- a/src/api/options/time-scale-options-defaults.ts
+++ b/src/api/options/time-scale-options-defaults.ts
@@ -14,7 +14,7 @@ export const timeScaleOptionsDefaults: HorzScaleOptions = {
 	timeVisible: false,
 	secondsVisible: true,
 	shiftVisibleRangeOnNewBar: true,
-	dontShiftVisibleRangeWhenNewBarReplacesWhitespace: false,
+	shiftVisibleRangeWhenNewBarReplacesWhitespace: true,
 	ticksVisible: false,
 	uniformDistribution: false,
 	minimumHeight: 0,

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -803,9 +803,9 @@ export class ChartModel<HorzScaleItem> implements IDestroyable, IChartModelBase 
 			// This can happen when you have a whitespace series which extends past
 			// the baseIndex, and now you are adding a new data point at one of those
 			// whitespace locations. In this case we would not want the chart to
-			// shift the visible range when `shiftVisibleRangeWhenNewBarReplacesWhitespace` is `false`. #1201
+			// shift the visible range. #1201
 			const lastIndex = this._timeScale.lastIndex();
-			const replacedExistingWhitespace = lastIndex === oldLastIndex && !this._timeScale.options().shiftVisibleRangeWhenNewBarReplacesWhitespace;
+			const replacedExistingWhitespace = lastIndex === oldLastIndex;
 
 			const needShiftVisibleRangeOnNewBar = isLastSeriesBarVisible && !replacedExistingWhitespace && this._timeScale.options().shiftVisibleRangeOnNewBar;
 			if (isSeriesPointsAddedToRight && !needShiftVisibleRangeOnNewBar) {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -803,9 +803,9 @@ export class ChartModel<HorzScaleItem> implements IDestroyable, IChartModelBase 
 			// This can happen when you have a whitespace series which extends past
 			// the baseIndex, and now you are adding a new data point at one of those
 			// whitespace locations. In this case we would not want the chart to
-			// shift the visible range. #1201
+			// shift the visible range when `shiftVisibleRangeWhenNewBarReplacesWhitespace` is `false`. #1201
 			const lastIndex = this._timeScale.lastIndex();
-			const replacedExistingWhitespace = lastIndex === oldLastIndex && this._timeScale.options().dontShiftVisibleRangeWhenNewBarReplacesWhitespace;
+			const replacedExistingWhitespace = lastIndex === oldLastIndex && !this._timeScale.options().shiftVisibleRangeWhenNewBarReplacesWhitespace;
 
 			const needShiftVisibleRangeOnNewBar = isLastSeriesBarVisible && !replacedExistingWhitespace && this._timeScale.options().shiftVisibleRangeOnNewBar;
 			if (isSeriesPointsAddedToRight && !needShiftVisibleRangeOnNewBar) {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -805,7 +805,7 @@ export class ChartModel<HorzScaleItem> implements IDestroyable, IChartModelBase 
 			// whitespace locations. In this case we would not want the chart to
 			// shift the visible range. #1201
 			const lastIndex = this._timeScale.lastIndex();
-			const replacedExistingWhitespace = lastIndex === oldLastIndex;
+			const replacedExistingWhitespace = lastIndex === oldLastIndex && this._timeScale.options().dontShiftVisibleRangeWhenNewBarReplacesWhitespace;
 
 			const needShiftVisibleRangeOnNewBar = isLastSeriesBarVisible && !replacedExistingWhitespace && this._timeScale.options().shiftVisibleRangeOnNewBar;
 			if (isSeriesPointsAddedToRight && !needShiftVisibleRangeOnNewBar) {

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -147,12 +147,21 @@ export interface HorzScaleOptions {
 	/**
 	 * Shift the visible range to the right (into the future) by the number of new bars when new data is added.
 	 *
-	 * Note that this only applies when the last bar is visible, and the new data point is not being placed
-	 * at the same time value as an existing whitespace data point (on a different series).
+	 * Note that this only applies when the last bar is visible.
 	 *
 	 * @defaultValue `true`
 	 */
 	shiftVisibleRangeOnNewBar: boolean;
+
+	/**
+	 * Don't shift the visible range to the right (into the future) by the number of new bars when new data is added IF
+	 * that data is placed on existing whitespace data points (times).
+	 *
+	 * {@link shiftVisibleRangeOnNewBar} needs to be enabled for this to have any effect.
+	 *
+	 * @defaultValue `false`
+	 */
+	dontShiftVisibleRangeWhenNewBarReplacesWhitespace: boolean;
 
 	/**
 	 * Draw small vertical line on time axis labels.

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -147,7 +147,8 @@ export interface HorzScaleOptions {
 	/**
 	 * Shift the visible range to the right (into the future) by the number of new bars when new data is added.
 	 *
-	 * Note that this only applies when the last bar is visible.
+	 * Note that this only applies when the last bar is visible, and the new data point is not being placed
+	 * at the same time value as an existing whitespace data point (on a different series).
 	 *
 	 * @defaultValue `true`
 	 */
@@ -360,7 +361,7 @@ export class TimeScale<HorzScaleItem> implements ITimeScale {
 		const to = Math.round(range.to);
 
 		const firstIndex = ensureNotNull(this._firstIndex());
-		const lastIndex = ensureNotNull(this._lastIndex());
+		const lastIndex = ensureNotNull(this.lastIndex());
 
 		return {
 			from: ensureNotNull(this.indexToTimeScalePoint(Math.max(firstIndex, from) as TimePointIndex)),
@@ -506,7 +507,7 @@ export class TimeScale<HorzScaleItem> implements ITimeScale {
 		const earliestIndexOfSecondLabel = (this._firstIndex() as number) + indexPerLabel;
 
 		// according to indexPerLabel value this value means "earliest index which _might be_ used as the second last label on time scale"
-		const indexOfSecondLastLabel = (this._lastIndex() as number) - indexPerLabel;
+		const indexOfSecondLastLabel = (this.lastIndex() as number) - indexPerLabel;
 
 		const isAllScalingAndScrollingDisabled = this._isAllScalingAndScrollingDisabled();
 		const isLeftEdgeFixed = this._options.fixLeftEdge || isAllScalingAndScrollingDisabled;
@@ -734,7 +735,7 @@ export class TimeScale<HorzScaleItem> implements ITimeScale {
 
 	public fitContent(): void {
 		const first = this._firstIndex();
-		const last = this._lastIndex();
+		const last = this.lastIndex();
 		if (first === null || last === null) {
 			return;
 		}
@@ -758,6 +759,10 @@ export class TimeScale<HorzScaleItem> implements ITimeScale {
 		return this._horzScaleBehavior.formatHorzItem(timeScalePoint.time);
 	}
 
+	public lastIndex(): TimePointIndex | null {
+		return this._points.length === 0 ? null : (this._points.length - 1) as TimePointIndex;
+	}
+
 	private _isAllScalingAndScrollingDisabled(): boolean {
 		const { handleScroll, handleScale } = this._model.options();
 		return !handleScroll.horzTouchDrag
@@ -772,10 +777,6 @@ export class TimeScale<HorzScaleItem> implements ITimeScale {
 
 	private _firstIndex(): TimePointIndex | null {
 		return this._points.length === 0 ? null : 0 as TimePointIndex;
-	}
-
-	private _lastIndex(): TimePointIndex | null {
-		return this._points.length === 0 ? null : (this._points.length - 1) as TimePointIndex;
 	}
 
 	private _rightOffsetForCoordinate(x: Coordinate): number {

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -154,14 +154,14 @@ export interface HorzScaleOptions {
 	shiftVisibleRangeOnNewBar: boolean;
 
 	/**
-	 * Don't shift the visible range to the right (into the future) by the number of new bars when new data is added IF
+	 * Should shift the visible range to the right (into the future) by the number of new bars when new data is added IF
 	 * that data is placed on existing whitespace data points (times).
 	 *
 	 * {@link shiftVisibleRangeOnNewBar} needs to be enabled for this to have any effect.
 	 *
-	 * @defaultValue `false`
+	 * @defaultValue `true`
 	 */
-	dontShiftVisibleRangeWhenNewBarReplacesWhitespace: boolean;
+	shiftVisibleRangeWhenNewBarReplacesWhitespace: boolean;
 
 	/**
 	 * Draw small vertical line on time axis labels.

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -154,16 +154,6 @@ export interface HorzScaleOptions {
 	shiftVisibleRangeOnNewBar: boolean;
 
 	/**
-	 * Should shift the visible range to the right (into the future) by the number of new bars when new data is added IF
-	 * that data is placed on existing whitespace data points (times).
-	 *
-	 * {@link shiftVisibleRangeOnNewBar} needs to be enabled for this to have any effect.
-	 *
-	 * @defaultValue `true`
-	 */
-	shiftVisibleRangeWhenNewBarReplacesWhitespace: boolean;
-
-	/**
 	 * Draw small vertical line on time axis labels.
 	 *
 	 * @defaultValue `false`

--- a/tests/e2e/graphics/test-cases/series/histogram-add-new-color-on-update.js
+++ b/tests/e2e/graphics/test-cases/series/histogram-add-new-color-on-update.js
@@ -1,3 +1,7 @@
+/*
+	End result should have a purple histogram bar (value of 499) as
+	the last visible bar.
+*/
 function generateData() {
 	const colors = [
 		'#013370',
@@ -23,7 +27,6 @@ function runTestCase(container) {
 	const chart = window.chart = LightweightCharts.createChart(container);
 
 	const mainSeries = chart.addHistogramSeries({
-		lineWidth: 1,
 		color: '#ff0000',
 	});
 

--- a/tests/e2e/graphics/test-cases/series/whitespace-updates.js
+++ b/tests/e2e/graphics/test-cases/series/whitespace-updates.js
@@ -1,3 +1,6 @@
+/*
+	End result should be 4 visible bars, 1 whitespace, and finally 1 visible bar.
+*/
 function runTestCase(container) {
 	const chart = window.chart = LightweightCharts.createChart(container);
 

--- a/tests/e2e/graphics/test-cases/time-scale/do-not-shift-range-when-replacing-whitespace.js
+++ b/tests/e2e/graphics/test-cases/time-scale/do-not-shift-range-when-replacing-whitespace.js
@@ -1,0 +1,44 @@
+const seriesOneData = [
+	{ time: '2019-04-11', value: 80.01 },
+	{ time: '2019-04-12', value: 96.63 },
+	{ time: '2019-04-13', value: 76.64 },
+	{ time: '2019-04-14', value: 81.89 },
+	{ time: '2019-04-15', value: 74.43 },
+	{ time: '2019-04-16', value: 80.01 },
+];
+
+const seriesTwoWhitespaceData = [
+	{ time: '2019-04-17' },
+	{ time: '2019-04-18' },
+	{ time: '2019-04-19' },
+	{ time: '2019-04-20' },
+];
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, {
+		timeScale: {
+			barSpacing: 30,
+			rightOffset: 10,
+			shiftVisibleRangeOnNewBar: true,
+			dontShiftVisibleRangeWhenNewBarReplacesWhitespace: true,
+		},
+	});
+
+	const s1 = chart.addLineSeries({
+		color: 'red',
+	});
+	s1.setData(seriesOneData);
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			const s2 = chart.addLineSeries({
+				color: 'blue',
+			});
+			s2.setData(seriesTwoWhitespaceData);
+			requestAnimationFrame(() => {
+				s1.update({ time: '2019-04-17', value: 84.43 });
+				requestAnimationFrame(resolve);
+			});
+		});
+	});
+}

--- a/tests/e2e/graphics/test-cases/time-scale/do-not-shift-range-when-replacing-whitespace.js
+++ b/tests/e2e/graphics/test-cases/time-scale/do-not-shift-range-when-replacing-whitespace.js
@@ -20,7 +20,7 @@ function runTestCase(container) {
 			barSpacing: 30,
 			rightOffset: 10,
 			shiftVisibleRangeOnNewBar: true,
-			dontShiftVisibleRangeWhenNewBarReplacesWhitespace: true,
+			shiftVisibleRangeWhenNewBarReplacesWhitespace: false,
 		},
 	});
 


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1201
- [x] Includes tests
- [x] Documentation update

**Overview of change:**
When a realtime update is for a time point which already exists on the time scale then we won't shift the visible range of the chart anymore.


**Pipeline Checks:**
- Changes to DTS are expected. ✅
- Changes to Graphics Tests are expected (new test `do-not-shift-range-when-replacing-whitespace` was added). ✅
- It is expected that the `histogram-add-new-color-on-update` and `whitespace-updates` tests will fail. They have been manually checked and the old behaviour was incorrect. ✅
