### PR TITLE
Add setCrosshairPosition API

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -320,6 +320,16 @@ export class ChartApi<HorzScaleItem> implements IChartApiBase<HorzScaleItem>, Da
 		};
 	}
 
+	public setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem): void {
+		const paneIndex = 0;
+		const pane = this._chartWidget.paneWidgets()[paneIndex];
+		this._chartWidget.model().setAndSaveSyntheticPosition(price, horizontalPosition, pane.state());
+	}
+
+	public clearCrosshairPosition(): void {
+		this._chartWidget.model().clearCurrentPosition(true);
+	}
+
 	private _addSeriesImpl<
 		TSeries extends SeriesType,
 		TData extends WhitespaceData<HorzScaleItem> = SeriesDataItemTypeMap<HorzScaleItem>[TSeries],

--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -320,10 +320,20 @@ export class ChartApi<HorzScaleItem> implements IChartApiBase<HorzScaleItem>, Da
 		};
 	}
 
-	public setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem): void {
-		const paneIndex = 0;
-		const pane = this._chartWidget.paneWidgets()[paneIndex];
-		this._chartWidget.model().setAndSaveSyntheticPosition(price, horizontalPosition, pane.state());
+	public setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem, seriesApi: ISeriesApi<SeriesType, HorzScaleItem>): void {
+		const series = this._seriesMap.get(seriesApi as SeriesApi<SeriesType, HorzScaleItem>);
+
+		if (series === undefined) {
+			return;
+		}
+
+		const pane = this._chartWidget.model().paneForSource(series);
+
+		if (pane === null) {
+			return;
+		}
+
+		this._chartWidget.model().setAndSaveSyntheticPosition(price, horizontalPosition, pane);
 	}
 
 	public clearCrosshairPosition(): void {

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -347,6 +347,16 @@ export interface IChartApiBase<HorzScaleItem = Time> {
 	chartElement(): HTMLDivElement;
 
 	/**
+	 * TODO: set crosshair position
+	 */
+	setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem): void;
+
+	/**
+	 * TODO: clear crosshair position
+	 */
+	clearCrosshairPosition(): void;
+
+	/**
 	 * Returns the dimensions of the chart pane (the plot surface which excludes time and price scales).
 	 * This would typically only be useful for plugin development.
 	 *

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -347,12 +347,19 @@ export interface IChartApiBase<HorzScaleItem = Time> {
 	chartElement(): HTMLDivElement;
 
 	/**
-	 * TODO: set crosshair position
+	 * Set the crosshair position within the chart.
+	 *
+	 * Usually the crosshair position is set automatically by the user's actions. However in some cases you may want to set it explicitly.
+	 *
+	 * For example if you want to synchronise the crosshairs of two separate charts.
+	 *
+	 * @param price - The price (vertical coordinate) of the new crosshair position.
+	 * @param horizontalPosition - The horizontal coordinate (time by default) of the new crosshair position.
 	 */
 	setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem): void;
 
 	/**
-	 * TODO: clear crosshair position
+	 * Clear the crosshair position within the chart.
 	 */
 	clearCrosshairPosition(): void;
 

--- a/src/api/ichart-api.ts
+++ b/src/api/ichart-api.ts
@@ -356,7 +356,7 @@ export interface IChartApiBase<HorzScaleItem = Time> {
 	 * @param price - The price (vertical coordinate) of the new crosshair position.
 	 * @param horizontalPosition - The horizontal coordinate (time by default) of the new crosshair position.
 	 */
-	setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem): void;
+	setCrosshairPosition(price: number, horizontalPosition: HorzScaleItem, seriesApi: ISeriesApi<SeriesType, HorzScaleItem>): void;
 
 	/**
 	 * Clear the crosshair position within the chart.

--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -351,8 +351,8 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 
 		this._mouseTouchDownEvent();
 
-		if (this._startTrackPoint !== null) {
-			const crosshair = this._model().crosshairSource();
+		const crosshair = this._model().crosshairSource();
+		if (this._startTrackPoint !== null && crosshair.visible()) {
 			this._initCrosshairPosition = { x: crosshair.appliedX(), y: crosshair.appliedY() };
 			this._startTrackPoint = { x: event.localX, y: event.localY };
 		}

--- a/tests/e2e/graphics/test-cases/set-crosshair-position.js
+++ b/tests/e2e/graphics/test-cases/set-crosshair-position.js
@@ -1,0 +1,25 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2023, 0, 1, 0, 0, 0, 0));
+
+	for (let i = 0; i < 12; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCMonth(time.getUTCMonth() + 1);
+	}
+
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container);
+
+	const series = chart.addLineSeries();
+	series.setData(generateData());
+	chart.timeScale().fitContent();
+
+	chart.setCrosshairPosition(Date.UTC(2023, 2, 1, 0, 0, 0, 0) / 1000, 10, series);
+}

--- a/website/plugins/enhanced-codeblock/theme/CodeBlock/chart.tsx
+++ b/website/plugins/enhanced-codeblock/theme/CodeBlock/chart.tsx
@@ -8,6 +8,7 @@ import styles from './styles.module.css';
 
 interface ChartProps {
 	script: string;
+	iframeStyle?: React.CSSProperties;
 }
 
 type IFrameWindow<TVersion extends keyof LightweightChartsApiTypeMap> = Window & {
@@ -37,7 +38,7 @@ function getSrcDocWithScript(script: string): string {
 }
 
 export function Chart<TVersion extends keyof LightweightChartsApiTypeMap>(props: ChartProps): React.JSX.Element {
-	const { script } = props;
+	const { script, iframeStyle } = props;
 	const { preferredVersion } = useDocsPreferredVersion() as { preferredVersion: (PropVersionMetadata & { name: string }) | null };
 	const currentVersion = versions && versions.length > 0 ? versions[0] : '';
 	const version = (preferredVersion?.name ?? currentVersion ?? 'current') as TVersion;
@@ -89,6 +90,7 @@ export function Chart<TVersion extends keyof LightweightChartsApiTypeMap>(props:
 			ref={ref}
 			srcDoc={srcDoc}
 			className={styles.iframe}
+			style={iframeStyle}
 		/>
 	);
 }

--- a/website/plugins/enhanced-codeblock/theme/CodeBlock/index.jsx
+++ b/website/plugins/enhanced-codeblock/theme/CodeBlock/index.jsx
@@ -29,7 +29,7 @@ export function removeUnwantedLines(originalString) {
 }
 
 const EnhancedCodeBlock = props => {
-	const { chart, replaceThemeConstants, hideableCode, chartOnly, ...rest } = props;
+	const { chart, replaceThemeConstants, hideableCode, chartOnly, iframeStyle, ...rest } = props;
 	let { children } = props;
 	const { colorMode } = useColorMode();
 	const isDarkTheme = colorMode === 'dark';
@@ -51,7 +51,7 @@ const EnhancedCodeBlock = props => {
 					/>
 					<label className="toggle-label" htmlFor={uniqueId}>Show all code</label></>}
 				{!chartOnly && <CodeBlock {...rest}>{children}</CodeBlock>}
-				{chart && <BrowserOnly fallback={<div className={styles.iframe}>&nbsp;</div>}>{() => <Chart script={children} />}</BrowserOnly>}
+				{chart && <BrowserOnly fallback={<div className={styles.iframe}>&nbsp;</div>}>{() => <Chart script={children} iframeStyle={iframeStyle} />}</BrowserOnly>}
 			</>
 		);
 	}

--- a/website/src/components/MinimumVersionWrapper/index.tsx
+++ b/website/src/components/MinimumVersionWrapper/index.tsx
@@ -1,0 +1,24 @@
+import { type PropVersionMetadata } from '@docusaurus/plugin-content-docs';
+import { useDocsPreferredVersion } from '@docusaurus/theme-common';
+import * as React from 'react';
+
+import versions from '../../../versions.json';
+
+interface MinimumVersionWrapperProps {
+	version: number;
+	fallback: React.FunctionComponent;
+}
+
+export default function MinimumVersionWrapper(props: React.PropsWithChildren<MinimumVersionWrapperProps>): ReturnType<React.FunctionComponent> {
+	const { preferredVersion } = useDocsPreferredVersion() as { preferredVersion: (PropVersionMetadata & { name: string }) | null };
+	const currentVersion = versions && versions.length > 0 ? versions[0] : '';
+	const version = (preferredVersion?.name ?? currentVersion ?? 'current');
+
+	const canShowExamples = version === 'current' || parseFloat(version) > props.version;
+
+	if (canShowExamples) {
+		return props.children as React.ReactElement;
+	} else {
+		return props.fallback({});
+	}
+}

--- a/website/tutorials/how_to/set-crosshair-position-syncing.js
+++ b/website/tutorials/how_to/set-crosshair-position-syncing.js
@@ -76,7 +76,7 @@ function syncCrosshair(chart, series, param) {
 	}
 	const dataPoint = param.seriesData.get(series);
 	if (dataPoint) {
-		chart.setCrosshairPosition(dataPoint.value, dataPoint.time);
+		chart.setCrosshairPosition(dataPoint.value, dataPoint.time, series);
 		return;
 	}
 	chart.clearCrosshairPosition();

--- a/website/tutorials/how_to/set-crosshair-position-syncing.js
+++ b/website/tutorials/how_to/set-crosshair-position-syncing.js
@@ -1,6 +1,7 @@
 // remove-start
 // Lightweight Charts™ Example: Crosshair syncing
 // https://tradingview.github.io/lightweight-charts/tutorials/how_to/set-crosshair-position
+// remove-end
 
 // hide-start
 function generateData(startValue, startDate) {
@@ -59,6 +60,7 @@ const mainSeries2 = chart2.addLineSeries({
 });
 
 mainSeries2.setData(generateData(100));
+// hide-end
 
 chart1.timeScale().subscribeVisibleLogicalRangeChange(timeRange => {
 	chart2.timeScale().setVisibleLogicalRange(timeRange);
@@ -67,25 +69,27 @@ chart1.timeScale().subscribeVisibleLogicalRangeChange(timeRange => {
 chart2.timeScale().subscribeVisibleLogicalRangeChange(timeRange => {
 	chart1.timeScale().setVisibleLogicalRange(timeRange);
 });
-// hide-end
 
-function syncCrosshair(chart, series, param) {
+function getCrosshairDataPoint(series, param) {
 	if (!param.time) {
-		chart.clearCrosshairPosition();
-		return;
+		return null;
 	}
 	const dataPoint = param.seriesData.get(series);
+	return dataPoint || null;
+}
+
+function syncCrosshair(chart, series, dataPoint) {
 	if (dataPoint) {
 		chart.setCrosshairPosition(dataPoint.value, dataPoint.time, series);
 		return;
 	}
 	chart.clearCrosshairPosition();
 }
-
 chart1.subscribeCrosshairMove(param => {
-	syncCrosshair(chart2, mainSeries1, param);
+	const dataPoint = getCrosshairDataPoint(mainSeries1, param);
+	syncCrosshair(chart2, mainSeries2, dataPoint);
 });
-
 chart2.subscribeCrosshairMove(param => {
-	syncCrosshair(chart1, mainSeries2, param);
+	const dataPoint = getCrosshairDataPoint(mainSeries2, param);
+	syncCrosshair(chart1, mainSeries1, dataPoint);
 });

--- a/website/tutorials/how_to/set-crosshair-position-syncing.js
+++ b/website/tutorials/how_to/set-crosshair-position-syncing.js
@@ -1,0 +1,91 @@
+// remove-start
+// Lightweight Charts™ Example: Crosshair syncing
+// https://tradingview.github.io/lightweight-charts/tutorials/how_to/set-crosshair-position
+
+// hide-start
+function generateData(startValue, startDate) {
+	const res = [];
+	const time = startDate ?? (new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0)));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i + startValue,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+const chart1 = createChart(
+	document.getElementById('container'),
+	{
+		height: 250,
+		crosshair: {
+			mode: 0,
+		},
+		timeScale: {
+			visible: false,
+		},
+		layout: {
+			background: {
+				type: 'solid',
+				color: '#FFF5F5',
+			},
+		},
+	}
+);
+const mainSeries1 = chart1.addLineSeries({
+	color: 'red',
+});
+
+mainSeries1.setData(generateData(0));
+
+const chart2 = createChart(
+	document.getElementById('container'),
+	{
+		height: 250,
+		layout: {
+			background: {
+				type: 'solid',
+				color: '#F5F5FF',
+			},
+		},
+	}
+);
+const mainSeries2 = chart2.addLineSeries({
+	color: 'blue',
+});
+
+mainSeries2.setData(generateData(100));
+
+chart1.timeScale().subscribeVisibleLogicalRangeChange(timeRange => {
+	chart2.timeScale().setVisibleLogicalRange(timeRange);
+});
+
+chart2.timeScale().subscribeVisibleLogicalRangeChange(timeRange => {
+	chart1.timeScale().setVisibleLogicalRange(timeRange);
+});
+// hide-end
+
+function syncCrosshair(chart, series, param) {
+	if (!param.time) {
+		chart.clearCrosshairPosition();
+		return;
+	}
+	const dataPoint = param.seriesData.get(series);
+	if (dataPoint) {
+		chart.setCrosshairPosition(dataPoint.value, dataPoint.time);
+		return;
+	}
+	chart.clearCrosshairPosition();
+}
+
+chart1.subscribeCrosshairMove(param => {
+	syncCrosshair(chart2, mainSeries1, param);
+});
+
+chart2.subscribeCrosshairMove(param => {
+	syncCrosshair(chart1, mainSeries2, param);
+});

--- a/website/tutorials/how_to/set-crosshair-position-tracking.js
+++ b/website/tutorials/how_to/set-crosshair-position-tracking.js
@@ -1,0 +1,54 @@
+// remove-start
+// Lightweight Charts™ Example: Crosshair syncing
+// https://tradingview.github.io/lightweight-charts/tutorials/how_to/set-crosshair-position
+
+// hide-start
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+
+	return res;
+}
+
+const chart = createChart(
+	document.getElementById('container'),
+	{
+		handleScale: false,
+		handleScroll: false,
+	}
+);
+
+const mainSeries = chart.addLineSeries({
+	priceFormat: {
+		minMove: 1,
+		precision: 0,
+	},
+});
+
+mainSeries.setData(generateData());
+
+chart.timeScale().fitContent();
+// hide-end
+
+document.getElementById('container').addEventListener('touchmove', e => {
+	const bcr = document.getElementById('container').getBoundingClientRect();
+	const x = bcr.left + e.touches[0].clientX;
+	const y = bcr.top + e.touches[0].clientY;
+
+	const price = mainSeries.coordinateToPrice(y);
+	const time = chart.timeScale().coordinateToTime(x);
+
+	if (!Number.isFinite(price) || !Number.isFinite(time)) {
+		return;
+	}
+
+	chart.setCrosshairPosition(price, time);
+});

--- a/website/tutorials/how_to/set-crosshair-position-tracking.js
+++ b/website/tutorials/how_to/set-crosshair-position-tracking.js
@@ -50,5 +50,9 @@ document.getElementById('container').addEventListener('touchmove', e => {
 		return;
 	}
 
-	chart.setCrosshairPosition(price, time);
+	chart.setCrosshairPosition(price, time, mainSeries);
+});
+
+document.getElementById('container').addEventListener('touchend', () => {
+	chart.clearCrosshairPosition();
 });

--- a/website/tutorials/how_to/set-crosshair-position-tracking.js
+++ b/website/tutorials/how_to/set-crosshair-position-tracking.js
@@ -1,6 +1,7 @@
 // remove-start
 // Lightweight Charts™ Example: Crosshair syncing
 // https://tradingview.github.io/lightweight-charts/tutorials/how_to/set-crosshair-position
+// remove-end
 
 // hide-start
 function generateData() {

--- a/website/tutorials/how_to/set-crosshair-position.mdx
+++ b/website/tutorials/how_to/set-crosshair-position.mdx
@@ -1,0 +1,50 @@
+---
+title: Set crosshair position
+sidebar_label: Set crosshair position
+description: Examples of how to add a programatically set the crosshair position.
+pagination_prev: null
+pagination_next: null
+keywords:
+  - crosshair
+  - tracking
+  - example
+---
+
+import CodeBlock from "@theme/CodeBlock";
+
+import MinimumVersionWrapper from "../../src/components/MinimumVersionWrapper";
+
+Lightweight Charts™ allows the crosshair position to be set programatically using the [`setCrosshairPosition`](/api/interfaces/IChartApi#setCrosshairPosition), and cleared using [`clearCrosshairPosition`](/api/interfaces/IChartApi#clearCrosshairPosition).
+
+Usually the crosshair position is set automatically by the user's actions. However in some cases you may want to set it explicitly. For example if you want to synchronise the crosshairs of two separate charts.
+
+import syncingCode from "!!raw-loader!./set-crosshair-position-syncing.js";
+import trackingCode from "!!raw-loader!./set-crosshair-position-tracking.js";
+import VersionWarningAdmonition from "@site/src/components/VersionWarningAdmonition";
+
+<!-- Show warning when not on the required version  -->
+<!-- Tutorials section isn't versioned yet, hence the need for the warning message -->
+
+<MinimumVersionWrapper version={4.1} fallback={() => {
+  return (<VersionWarningAdmonition
+    notCurrent="These tutorials are for version 4.1 (or greater) of Lightweight&nbsp;Charts™."
+    type="caution"
+    displayVersionMessage
+  />);
+}}>
+
+  ## Syncing two charts
+
+  <CodeBlock replaceThemeConstants chart className="language-js" hideableCode iframeStyle={{ height: '500px' }}>
+    {syncingCode}
+  </CodeBlock>
+
+  ## Automatic tracking mode (on mobile)
+
+  If scrolling and scaling is disabled, then the API can be used to enable a kind of tracking mode without the user having to long-press the screen.
+
+  <CodeBlock replaceThemeConstants chart className="language-js" hideableCode>
+    {trackingCode}
+  </CodeBlock>
+
+</MinimumVersionWrapper>

--- a/website/tutorials/how_to/set-crosshair-position.mdx
+++ b/website/tutorials/how_to/set-crosshair-position.mdx
@@ -14,7 +14,7 @@ import CodeBlock from "@theme/CodeBlock";
 
 import MinimumVersionWrapper from "../../src/components/MinimumVersionWrapper";
 
-Lightweight Charts™ allows the crosshair position to be set programatically using the [`setCrosshairPosition`](/api/interfaces/IChartApi#setCrosshairPosition), and cleared using [`clearCrosshairPosition`](/api/interfaces/IChartApi#clearCrosshairPosition).
+Lightweight Charts™ allows the crosshair position to be set programatically using the [`setCrosshairPosition`](/docs/api/interfaces/IChartApi#setcrosshairposition), and cleared using [`clearCrosshairPosition`](/docs/api/interfaces/IChartApi#clearcrosshairposition).
 
 Usually the crosshair position is set automatically by the user's actions. However in some cases you may want to set it explicitly. For example if you want to synchronise the crosshairs of two separate charts.
 
@@ -39,7 +39,7 @@ import VersionWarningAdmonition from "@site/src/components/VersionWarningAdmonit
     {syncingCode}
   </CodeBlock>
 
-  ## Automatic tracking mode (on mobile)
+  ## Tracking without long-press (on mobile)
 
   If scrolling and scaling is disabled, then the API can be used to enable a kind of tracking mode without the user having to long-press the screen.
 


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [x] Addresses an existing issue: fixes #1198 #1163 #438
- [x] Includes tests
- [x] Documentation update

**Overview of change:**

Allow the crosshair position to be set programatically.

This should enabled a kind of tracking mode on mobile without needing to long-press, and also enable syncing the crosshair of two different chart instances.

