### PR TITLE
feat: Add findNearest second arg to TimeScale#timeToCoordinate()

### DIFF
--- a/src/api/time-scale-api.ts
+++ b/src/api/time-scale-api.ts
@@ -136,13 +136,12 @@ export class TimeScaleApi<HorzScaleItem> implements ITimeScaleApi<HorzScaleItem>
 		}
 	}
 
-	public timeToCoordinate(time: HorzScaleItem): Coordinate | null {
+	public timeToCoordinate(time: HorzScaleItem, findNearest = false): Coordinate | null {
 		const timePoint = this._horzScaleBehavior.convertHorzItemToInternal(time);
-		const timePointIndex = this._timeScale.timeToIndex(timePoint, false);
+		const timePointIndex = this._timeScale.timeToIndex(timePoint, findNearest);
 		if (timePointIndex === null) {
 			return null;
 		}
-
 		return this._timeScale.indexToCoordinate(timePointIndex);
 	}
 


### PR DESCRIPTION
**Type of PR:** Bugfix/Feature

**PR checklist:**

- [x] Addresses an existing issue: fixes #
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

There's currently a pretty major limitation with `TimeScale#timeToCoordinate()`

If you have data that's of a smaller interval than the timescale, `timeToCoordinate()` always returns null even though internally it still performs the binary search and finds the correct closest index.

I think in this scenario it'd be much better to return the closest bar than it is to return nothing at all. Or, at the very least allow the user the option of choosing by adding a second argument to `timeToCoordinate()`.

Personally, I'd be ok with defaulting `findNearest`  to `true` instead of `false`, since I doubt anyone would be surprised if it returns the _containing_ bar/index instead of `null`, but at least with an argument the user has the option.

**Additional context**

My simple use case: I am writing custom pane views to show order markers. Even if the main series is set to daily bars or higher I'd still like to be able to show the orders. 

