### PR TITLE
Improved error messages for price scale margins

### DIFF
--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -273,7 +273,7 @@ export class PriceScale {
 				throw new Error(`Invalid top margin - expect value between 0 and 1, given=${top}`);
 			}
 
-			if (bottom < 0 || bottom > 1 || top + bottom > 1) {
+			if (bottom < 0 || bottom > 1) {
 				throw new Error(`Invalid bottom margin - expect value between 0 and 1, given=${bottom}`);
 			}
 


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1484
- `N/A` Includes tests
- `N/A` Documentation update

**Overview of change:**

Improved the error message presented to the developer when the sum of the scale margins is greater than 1.

The message was already there, but check was duplicated in an earlier check so it wasn't possible for it to be reported.

