### PR TITLE
fix series crosshair marker x positioning #1504

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '47.87 KB',
+		limit: '47.97 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '47.81 KB',
+		limit: '47.91 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.54 KB',
+		limit: '49.62 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.58 KB',
+		limit: '49.67 KB',
 	},
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '47.97 KB',
+		limit: '47.96 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '47.91 KB',
+		limit: '47.89 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.62 KB',
+		limit: '49.60 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.67 KB',
+		limit: '49.64 KB',
 	},
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -9,16 +9,16 @@ module.exports = [
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '47.8 KB',
+		limit: '47.81 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.52 KB',
+		limit: '49.54 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.57 KB',
+		limit: '49.58 KB',
 	},
 ];

--- a/src/renderers/marks-renderer.ts
+++ b/src/renderers/marks-renderer.ts
@@ -1,9 +1,9 @@
-import { MediaCoordinatesRenderingScope } from 'fancy-canvas';
+import { BitmapCoordinatesRenderingScope } from 'fancy-canvas';
 
 import { SeriesItemsIndexesRange } from '../model/time-data';
 
+import { BitmapCoordinatesPaneRenderer } from './bitmap-coordinates-pane-renderer';
 import { LineItemBase } from './line-renderer-base';
-import { MediaCoordinatesPaneRenderer } from './media-coordinates-pane-renderer';
 
 export interface MarksRendererData {
 	items: LineItemBase[];
@@ -14,14 +14,14 @@ export interface MarksRendererData {
 	visibleRange: SeriesItemsIndexesRange | null;
 }
 
-export class PaneRendererMarks extends MediaCoordinatesPaneRenderer {
+export class PaneRendererMarks extends BitmapCoordinatesPaneRenderer {
 	protected _data: MarksRendererData | null = null;
 
 	public setData(data: MarksRendererData): void {
 		this._data = data;
 	}
 
-	protected _drawImpl({ context: ctx }: MediaCoordinatesRenderingScope): void {
+	protected _drawImpl({ context: ctx, horizontalPixelRatio, verticalPixelRatio }: BitmapCoordinatesRenderingScope): void {
 		if (this._data === null || this._data.visibleRange === null) {
 			return;
 		}
@@ -29,13 +29,19 @@ export class PaneRendererMarks extends MediaCoordinatesPaneRenderer {
 		const visibleRange = this._data.visibleRange;
 		const data = this._data;
 
-		const draw = (radius: number) => {
+		const tickWidth = Math.max(1, Math.floor(horizontalPixelRatio));
+		const correction = (tickWidth % 2) / 2;
+
+		const draw = (radiusMedia: number) => {
 			ctx.beginPath();
 
 			for (let i = visibleRange.to - 1; i >= visibleRange.from; --i) {
 				const point = data.items[i];
-				ctx.moveTo(point.x, point.y);
-				ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+				const centerX = Math.round(point.x * horizontalPixelRatio) + correction; // correct x coordinate only
+				const centerY = point.y * verticalPixelRatio;
+				const radius = radiusMedia * verticalPixelRatio + correction;
+				ctx.moveTo(centerX, centerY);
+				ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
 			}
 
 			ctx.fill();

--- a/src/renderers/series-markers-arrow.ts
+++ b/src/renderers/series-markers-arrow.ts
@@ -3,37 +3,36 @@ import { ceiledOdd } from '../helpers/mathex';
 import { Coordinate } from '../model/coordinate';
 
 import { hitTestSquare } from './series-markers-square';
-import { shapeSize } from './series-markers-utils';
+import { BitmapShapeItemCoordinates, shapeSize } from './series-markers-utils';
 
 export function drawArrow(
 	up: boolean,
 	ctx: CanvasRenderingContext2D,
-	centerX: Coordinate,
-	centerY: Coordinate,
+	coords: BitmapShapeItemCoordinates,
 	size: number
 ): void {
 	const arrowSize = shapeSize('arrowUp', size);
-	const halfArrowSize = (arrowSize - 1) / 2;
+	const halfArrowSize = ((arrowSize - 1) / 2) * coords.pixelRatio;
 	const baseSize = ceiledOdd(size / 2);
-	const halfBaseSize = (baseSize - 1) / 2;
+	const halfBaseSize = ((baseSize - 1) / 2) * coords.pixelRatio;
 
 	ctx.beginPath();
 	if (up) {
-		ctx.moveTo(centerX - halfArrowSize, centerY);
-		ctx.lineTo(centerX, centerY - halfArrowSize);
-		ctx.lineTo(centerX + halfArrowSize, centerY);
-		ctx.lineTo(centerX + halfBaseSize, centerY);
-		ctx.lineTo(centerX + halfBaseSize, centerY + halfArrowSize);
-		ctx.lineTo(centerX - halfBaseSize, centerY + halfArrowSize);
-		ctx.lineTo(centerX - halfBaseSize, centerY);
+		ctx.moveTo(coords.x - halfArrowSize, coords.y);
+		ctx.lineTo(coords.x, coords.y - halfArrowSize);
+		ctx.lineTo(coords.x + halfArrowSize, coords.y);
+		ctx.lineTo(coords.x + halfBaseSize, coords.y);
+		ctx.lineTo(coords.x + halfBaseSize, coords.y + halfArrowSize);
+		ctx.lineTo(coords.x - halfBaseSize, coords.y + halfArrowSize);
+		ctx.lineTo(coords.x - halfBaseSize, coords.y);
 	} else {
-		ctx.moveTo(centerX - halfArrowSize, centerY);
-		ctx.lineTo(centerX, centerY + halfArrowSize);
-		ctx.lineTo(centerX + halfArrowSize, centerY);
-		ctx.lineTo(centerX + halfBaseSize, centerY);
-		ctx.lineTo(centerX + halfBaseSize, centerY - halfArrowSize);
-		ctx.lineTo(centerX - halfBaseSize, centerY - halfArrowSize);
-		ctx.lineTo(centerX - halfBaseSize, centerY);
+		ctx.moveTo(coords.x - halfArrowSize, coords.y);
+		ctx.lineTo(coords.x, coords.y + halfArrowSize);
+		ctx.lineTo(coords.x + halfArrowSize, coords.y);
+		ctx.lineTo(coords.x + halfBaseSize, coords.y);
+		ctx.lineTo(coords.x + halfBaseSize, coords.y - halfArrowSize);
+		ctx.lineTo(coords.x - halfBaseSize, coords.y - halfArrowSize);
+		ctx.lineTo(coords.x - halfBaseSize, coords.y);
 	}
 
 	ctx.fill();

--- a/src/renderers/series-markers-circle.ts
+++ b/src/renderers/series-markers-circle.ts
@@ -1,18 +1,17 @@
 import { Coordinate } from '../model/coordinate';
 
-import { shapeSize } from './series-markers-utils';
+import { BitmapShapeItemCoordinates, shapeSize } from './series-markers-utils';
 
 export function drawCircle(
 	ctx: CanvasRenderingContext2D,
-	centerX: Coordinate,
-	centerY: Coordinate,
+	coords: BitmapShapeItemCoordinates,
 	size: number
 ): void {
 	const circleSize = shapeSize('circle', size);
 	const halfSize = (circleSize - 1) / 2;
 
 	ctx.beginPath();
-	ctx.arc(centerX, centerY, halfSize, 0, 2 * Math.PI, false);
+	ctx.arc(coords.x, coords.y, halfSize * coords.pixelRatio, 0, 2 * Math.PI, false);
 
 	ctx.fill();
 }

--- a/src/renderers/series-markers-renderer.ts
+++ b/src/renderers/series-markers-renderer.ts
@@ -54,7 +54,7 @@ export class SeriesMarkersRenderer extends BitmapCoordinatesPaneRenderer {
 		if (this._fontSize !== fontSize || this._fontFamily !== fontFamily) {
 			this._fontSize = fontSize;
 			this._fontFamily = fontFamily;
-			this._font = makeFont(this._fontSize, this._fontFamily);
+			this._font = makeFont(fontSize, fontFamily);
 			this._textWidthCache.reset();
 		}
 	}

--- a/src/renderers/series-markers-renderer.ts
+++ b/src/renderers/series-markers-renderer.ts
@@ -45,7 +45,6 @@ export class SeriesMarkersRenderer extends BitmapCoordinatesPaneRenderer {
 	private _fontSize: number = -1;
 	private _fontFamily: string = '';
 	private _font: string = '';
-	private _fontPixelRatio: number = 1;
 
 	public setData(data: SeriesMarkerRendererData): void {
 		this._data = data;
@@ -55,7 +54,8 @@ export class SeriesMarkersRenderer extends BitmapCoordinatesPaneRenderer {
 		if (this._fontSize !== fontSize || this._fontFamily !== fontFamily) {
 			this._fontSize = fontSize;
 			this._fontFamily = fontFamily;
-			this._buildFont();
+			this._font = makeFont(this._fontSize, this._fontFamily);
+			this._textWidthCache.reset();
 		}
 	}
 
@@ -81,10 +81,6 @@ export class SeriesMarkersRenderer extends BitmapCoordinatesPaneRenderer {
 		if (this._data === null || this._data.visibleRange === null) {
 			return;
 		}
-		if (this._fontPixelRatio !== horizontalPixelRatio) {
-			this._fontPixelRatio = horizontalPixelRatio;
-			this._buildFont();
-		}
 
 		ctx.textBaseline = 'middle';
 		ctx.font = this._font;
@@ -92,17 +88,12 @@ export class SeriesMarkersRenderer extends BitmapCoordinatesPaneRenderer {
 		for (let i = this._data.visibleRange.from; i < this._data.visibleRange.to; i++) {
 			const item = this._data.items[i];
 			if (item.text !== undefined) {
-				item.text.width = this._textWidthCache.measureText(ctx, item.text.content) / horizontalPixelRatio;
+				item.text.width = this._textWidthCache.measureText(ctx, item.text.content);
 				item.text.height = this._fontSize;
 				item.text.x = item.x - item.text.width / 2 as Coordinate;
 			}
 			drawItem(item, ctx, horizontalPixelRatio, verticalPixelRatio);
 		}
-	}
-
-	private _buildFont(): void {
-		this._font = makeFont(this._fontSize * this._fontPixelRatio, this._fontFamily);
-		this._textWidthCache.reset();
 	}
 }
 
@@ -120,7 +111,7 @@ function drawItem(item: SeriesMarkerRendererDataItem, ctx: CanvasRenderingContex
 	ctx.fillStyle = item.color;
 
 	if (item.text !== undefined) {
-		drawText(ctx, item.text.content, item.text.x * horizontalPixelRatio, item.text.y * verticalPixelRatio);
+		drawText(ctx, item.text.content, item.text.x, item.text.y, horizontalPixelRatio, verticalPixelRatio);
 	}
 
 	drawShape(item, ctx, bitmapShapeItemCoordinates(item, horizontalPixelRatio, verticalPixelRatio));

--- a/src/renderers/series-markers-square.ts
+++ b/src/renderers/series-markers-square.ts
@@ -1,19 +1,18 @@
 import { Coordinate } from '../model/coordinate';
 
-import { shapeSize } from './series-markers-utils';
+import { BitmapShapeItemCoordinates, shapeSize } from './series-markers-utils';
 
 export function drawSquare(
 	ctx: CanvasRenderingContext2D,
-	centerX: Coordinate,
-	centerY: Coordinate,
+	coords: BitmapShapeItemCoordinates,
 	size: number
 ): void {
 	const squareSize = shapeSize('square', size);
-	const halfSize = (squareSize - 1) / 2;
-	const left = centerX - halfSize;
-	const top = centerY - halfSize;
+	const halfSize = ((squareSize - 1) * coords.pixelRatio) / 2;
+	const left = coords.x - halfSize;
+	const top = coords.y - halfSize;
 
-	ctx.fillRect(left, top, squareSize, squareSize);
+	ctx.fillRect(left, top, squareSize * coords.pixelRatio, squareSize * coords.pixelRatio);
 }
 
 export function hitTestSquare(

--- a/src/renderers/series-markers-text.ts
+++ b/src/renderers/series-markers-text.ts
@@ -4,9 +4,14 @@ export function drawText(
 	ctx: CanvasRenderingContext2D,
 	text: string,
 	x: number,
-	y: number
+	y: number,
+	horizontalPixelRatio: number,
+	verticalPixelRatio: number
 ): void {
+	ctx.save();
+	ctx.scale(horizontalPixelRatio, verticalPixelRatio);
 	ctx.fillText(text, x, y);
+	ctx.restore();
 }
 
 export function hitTestText(

--- a/src/renderers/series-markers-utils.ts
+++ b/src/renderers/series-markers-utils.ts
@@ -32,3 +32,9 @@ export function calculateShapeHeight(barSpacing: number): number {
 export function shapeMargin(barSpacing: number): number {
 	return Math.max(size(barSpacing, 0.1), Constants.MinShapeMargin);
 }
+
+export interface BitmapShapeItemCoordinates {
+	x: number;
+	y: number;
+	pixelRatio: number;
+}

--- a/tests/e2e/graphics/helpers/screenshoter.ts
+++ b/tests/e2e/graphics/helpers/screenshoter.ts
@@ -73,8 +73,14 @@ export class Screenshoter {
 				return (window as unknown as TestCaseWindow).testCaseReady;
 			});
 
-			// move mouse to top-left corner
-			await page.mouse.move(0, 0);
+			const shouldIgnoreMouseMove = await page.evaluate(() => {
+				return Boolean((window as unknown as TestCaseWindow).ignoreMouseMove);
+			});
+
+			if (!shouldIgnoreMouseMove) {
+				// move mouse to top-left corner
+				await page.mouse.move(0, 0);
+			}
 
 			const waitForMouseMove = page.evaluate(() => {
 				if ((window as unknown as TestCaseWindow).ignoreMouseMove) { return Promise.resolve(); }
@@ -93,10 +99,11 @@ export class Screenshoter {
 				});
 			});
 
-			// to avoid random cursor position
-			await page.mouse.move(viewportWidth / 2, viewportHeight / 2);
-
-			await waitForMouseMove;
+			if (!shouldIgnoreMouseMove) {
+				// to avoid random cursor position
+				await page.mouse.move(viewportWidth / 2, viewportHeight / 2);
+				await waitForMouseMove;
+			}
 
 			// let's wait until the next af to make sure that everything is repainted
 			await page.evaluate(() => {

--- a/tests/e2e/graphics/test-cases/crosshair-marker-position.js
+++ b/tests/e2e/graphics/test-cases/crosshair-marker-position.js
@@ -30,14 +30,15 @@ function runTestCase(container) {
 
 	chart.timeScale().applyOptions({ barSpacing: 27.701, fixRightEdge: true, rightOffset: 0 });
 	return new Promise(resolve => {
-		setTimeout(() => {
-			chart.setCrosshairPosition(
-				200,
-				{ year: 2024, month: 1, day: 2 },
-				mainSeries
-			);
-
-			resolve();
-		}, 10);
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => {
+				chart.setCrosshairPosition(
+					200,
+					{ year: 2024, month: 1, day: 2 },
+					mainSeries
+				);
+				resolve();
+			});
+		});
 	});
 }

--- a/tests/e2e/graphics/test-cases/crosshair-marker-position.js
+++ b/tests/e2e/graphics/test-cases/crosshair-marker-position.js
@@ -1,0 +1,43 @@
+// Ignore the mouse movement because we are using setCrosshairPosition
+window.ignoreMouseMove = true;
+
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container));
+
+	const mainSeries = chart.addLineSeries({
+		pointMarkersVisible: true,
+		pointMarkersRadius: 8,
+	});
+
+	mainSeries.setData([
+		{
+			time: '2024-01-01',
+			value: 100,
+		},
+		{
+			time: '2024-01-02',
+			value: 200,
+		},
+		{
+			time: '2024-01-03',
+			value: 150,
+		},
+		{
+			time: '2024-01-04',
+			value: 170,
+		},
+	]);
+
+	chart.timeScale().applyOptions({ barSpacing: 27.701, fixRightEdge: true, rightOffset: 0 });
+	return new Promise(resolve => {
+		setTimeout(() => {
+			chart.setCrosshairPosition(
+				200,
+				{ year: 2024, month: 1, day: 2 },
+				mainSeries
+			);
+
+			resolve();
+		}, 10);
+	});
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1504
- [x] Includes tests
- `N/A` ~Documentation update~

**Overview of change:**
The alignment of the crosshair marker for the series didn't match the alignment of the Line series point markers. It appears that the series markers were being drawn correctly, and rather that the crosshair marker position was incorrect. The code was using MediaCoordinates without any corrections.

**Tests:**
Since the code change is to the crosshair marker, it is expected that the number of failing tests will be large for the strange DPRs like 1.25 and 1.5.

The added test `crosshair-marker-position` will only test the issue properly on the lower DPRs (`1`, `1.25`, `1.5`).