### PR TITLE
fix possible ReDoS

### DIFF
--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -195,16 +195,14 @@ function normalizeRgbComponent<T extends RedComponent | GreenComponent | BlueCom
 }
 
 function normalizeAlphaComponent(component: AlphaComponent): AlphaComponent {
-	return Number.isNaN(component)
-		? (1 as AlphaComponent)
-		: ((!(component <= 0) && !(component > 0)
-			? (0 as AlphaComponent)
-			: component < 0
-				? (0 as AlphaComponent)
-				: component > 1
-					? (1 as AlphaComponent)
-					: // limit the precision of all numbers to at most 4 digits in fractional part
-					Math.round(component * 10000) / 10000) as AlphaComponent);
+	if (Number.isNaN(component)) {
+		return 1 as AlphaComponent;
+	}
+	if (component <= 0 || component > 1) {
+		return (component < 0 ? 0 : 1) as AlphaComponent;
+	}
+	// limit the precision of all numbers to at most 4 digits in fractional part
+	return Math.round(component * 10000) / 10000 as AlphaComponent;
 }
 
 /**

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -196,7 +196,7 @@ function normalizeRgbComponent<T extends RedComponent | GreenComponent | BlueCom
 
 function normalizeAlphaComponent(component: AlphaComponent): AlphaComponent {
 	if (component <= 0 || component > 1) {
-		Math.min(Math.max(component, 0), 1) as AlphaComponent;
+		return Math.min(Math.max(component, 0), 1) as AlphaComponent;
 	}
 	// limit the precision of all numbers to at most 4 digits in fractional part
 	return Math.round(component * 10000) / 10000 as AlphaComponent;

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -196,15 +196,15 @@ function normalizeRgbComponent<T extends RedComponent | GreenComponent | BlueCom
 
 function normalizeAlphaComponent(component: AlphaComponent): AlphaComponent {
 	return Number.isNaN(component)
-	? (1 as AlphaComponent)
-	: ((!(component <= 0) && !(component > 0)
-	? (0 as AlphaComponent)
-	: component < 0
-	? (0 as AlphaComponent)
-	: component > 1
-	? (1 as AlphaComponent)
-	: // limit the precision of all numbers to at most 4 digits in fractional part
-	Math.round(component * 10000) / 10000) as AlphaComponent);
+		? (1 as AlphaComponent)
+		: ((!(component <= 0) && !(component > 0)
+			? (0 as AlphaComponent)
+			: component < 0
+				? (0 as AlphaComponent)
+				: component > 1
+					? (1 as AlphaComponent)
+					: // limit the precision of all numbers to at most 4 digits in fractional part
+					Math.round(component * 10000) / 10000) as AlphaComponent);
 }
 
 /**

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -195,11 +195,16 @@ function normalizeRgbComponent<T extends RedComponent | GreenComponent | BlueCom
 }
 
 function normalizeAlphaComponent(component: AlphaComponent): AlphaComponent {
-	return (!(component <= 0) && !(component > 0) ? 0 as AlphaComponent :
-		component < 0 ? 0 as AlphaComponent :
-			component > 1 ? 1 as AlphaComponent :
-				// limit the precision of all numbers to at most 4 digits in fractional part
-				Math.round(component * 10000) / 10000) as AlphaComponent;
+	return Number.isNaN(component)
+	? (1 as AlphaComponent)
+	: ((!(component <= 0) && !(component > 0)
+	? (0 as AlphaComponent)
+	: component < 0
+	? (0 as AlphaComponent)
+	: component > 1
+	? (1 as AlphaComponent)
+	: // limit the precision of all numbers to at most 4 digits in fractional part
+	Math.round(component * 10000) / 10000) as AlphaComponent);
 }
 
 /**
@@ -236,7 +241,7 @@ const rgbRe = /^rgb\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*\)$
  * @example
  * rgba(255,234,245,0.1)
  */
-const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?[\d]{0,10}(?:\.\d+)?)\s*\)$/;
+const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(\S+)\s*\)$/;
 
 function colorStringToRgba(colorString: string): Rgba {
 	colorString = colorString.toLowerCase();
@@ -253,7 +258,7 @@ function colorStringToRgba(colorString: string): Rgba {
 				normalizeRgbComponent<RedComponent>(parseInt(matches[1], 10)),
 				normalizeRgbComponent<GreenComponent>(parseInt(matches[2], 10)),
 				normalizeRgbComponent<BlueComponent>(parseInt(matches[3], 10)),
-				normalizeAlphaComponent((matches.length < 5 ? 1 : parseFloat(matches[4])) as AlphaComponent),
+				normalizeAlphaComponent((matches.length < 4 ? 1 : parseFloat(matches[4])) as AlphaComponent),
 			];
 		}
 	}

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -195,11 +195,8 @@ function normalizeRgbComponent<T extends RedComponent | GreenComponent | BlueCom
 }
 
 function normalizeAlphaComponent(component: AlphaComponent): AlphaComponent {
-	if (Number.isNaN(component)) {
-		return 1 as AlphaComponent;
-	}
 	if (component <= 0 || component > 1) {
-		return (component < 0 ? 0 : 1) as AlphaComponent;
+		Math.min(Math.max(component, 0), 1) as AlphaComponent;
 	}
 	// limit the precision of all numbers to at most 4 digits in fractional part
 	return Math.round(component * 10000) / 10000 as AlphaComponent;
@@ -239,8 +236,8 @@ const rgbRe = /^rgb\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*\)$
  * @example
  * rgba(255,234,245,0.1)
  */
-const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(\S+)\s*\)$/;
 
+const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d*\.?\d+)\s*\)$/i;
 function colorStringToRgba(colorString: string): Rgba {
 	colorString = colorString.toLowerCase();
 
@@ -256,7 +253,7 @@ function colorStringToRgba(colorString: string): Rgba {
 				normalizeRgbComponent<RedComponent>(parseInt(matches[1], 10)),
 				normalizeRgbComponent<GreenComponent>(parseInt(matches[2], 10)),
 				normalizeRgbComponent<BlueComponent>(parseInt(matches[3], 10)),
-				normalizeAlphaComponent((matches.length < 4 ? 1 : parseFloat(matches[4])) as AlphaComponent),
+				normalizeAlphaComponent((matches.length < 5 ? 1 : parseFloat(matches[4])) as AlphaComponent),
 			];
 		}
 	}

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -237,7 +237,7 @@ const rgbRe = /^rgb\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*\)$
  * rgba(255,234,245,0.1)
  */
 
-const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d*\.?\d+)\s*\)$/i;
+const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d*\.?\d+)\s*\)$/;
 function colorStringToRgba(colorString: string): Rgba {
 	colorString = colorString.toLowerCase();
 


### PR DESCRIPTION
**Type of PR:**  bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes [CLL-263]

**Overview of change:**
color regex  `const rgbaRe = /^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?[\d]{0,10}(?:\.\d+)?)\s*\)$/;` contains possible weakness, for cases like `'rgba(0,0,0,' + '\t'.repeat(54773) + '\x00'` . Changed regex to `/^rgba\(\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d{1,10})\s*,\s*(-?\d*\.?\d+)\s*\)$/` 

