### PR TITLE
Fix puppeteer installation on CI

### DIFF
--- a/.puppeteerrc.js
+++ b/.puppeteerrc.js
@@ -9,6 +9,7 @@ module.exports = {
 	 * can reliably find the installed chrome binary
 	 */
 	cacheDirectory: join(__dirname, 'node_modules', '.cache', 'puppeteer'),
+	downloadBaseUrl: 'https://storage.googleapis.com/chrome-for-testing-public',
 	experiments: {
 		/**
 		 * This can also be configured / overridden with the


### PR DESCRIPTION
Fixes the CI pipeline which is currently freezing on the chromium download (`install-deps` step).

See: https://github.com/puppeteer/puppeteer/issues/12094#issuecomment-1999345951