### PR TITLE
fix showLabels option on trend-line plugin example

### DIFF
--- a/plugin-examples/src/plugins/trend-line/trend-line.ts
+++ b/plugin-examples/src/plugins/trend-line/trend-line.ts
@@ -48,8 +48,10 @@ class TrendLinePaneRenderer implements ISeriesPrimitivePaneRenderer {
 			ctx.moveTo(x1Scaled, y1Scaled);
 			ctx.lineTo(x2Scaled, y2Scaled);
 			ctx.stroke();
-			this._drawTextLabel(scope, this._text1, x1Scaled, y1Scaled, true);
-			this._drawTextLabel(scope, this._text2, x2Scaled, y2Scaled, false);
+			if (this._options.showLabels) {
+				this._drawTextLabel(scope, this._text1, x1Scaled, y1Scaled, true);
+				this._drawTextLabel(scope, this._text2, x2Scaled, y2Scaled, false);
+			}
 		});
 	}
 


### PR DESCRIPTION
**Type of PR:** bugfix (plugin example_

**PR checklist:**

- [x] Addresses an existing issue: fixes #1549

**Overview of change:**
`showLabels` option was ignored by the plugin and the labels would always been shown even if the option was set to false.
