### PR TITLE
fix throws "Value is undefined" when hovering mouse over the chart

### DIFF
--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -826,9 +826,9 @@ export class ChartWidget<HorzScaleItem> implements IDestroyable, IChartWidgetBas
 	): void {
 		try {
 			this._crosshairMoved.fire(() => this._getMouseEventParamsImpl(time, point, event));
-		} catch (e: any) {
-			if (e !instanceof ValueIsUndefinedError) {
-				throw e;
+		} catch (error) {
+			if (!(error instanceof ValueIsUndefinedError)) {
+				throw error;
 			}
 		}
 	}

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -1,6 +1,6 @@
 import { Size, size } from 'fancy-canvas';
 
-import { ensureDefined, ensureNotNull } from '../helpers/assertions';
+import { ensureDefined, ensureNotNull, ValueIsUndefinedError } from '../helpers/assertions';
 import { isChromiumBased, isWindows } from '../helpers/browsers';
 import { Delegate } from '../helpers/delegate';
 import { IDestroyable } from '../helpers/idestroyable';
@@ -824,7 +824,13 @@ export class ChartWidget<HorzScaleItem> implements IDestroyable, IChartWidgetBas
 		point: Point | null,
 		event: TouchMouseEventData | null
 	): void {
-		this._crosshairMoved.fire(() => this._getMouseEventParamsImpl(time, point, event));
+		try {
+			this._crosshairMoved.fire(() => this._getMouseEventParamsImpl(time, point, event));
+		} catch (e: any) {
+			if (e !instanceof ValueIsUndefinedError) {
+				throw e;
+			}
+		}
 	}
 
 	private _updateTimeAxisVisibility(): void {

--- a/src/helpers/assertions.ts
+++ b/src/helpers/assertions.ts
@@ -11,6 +11,20 @@ export function assert(condition: boolean, message?: string): asserts condition 
 }
 
 /**
+ * Custom Value is undefined error for useful handling.
+ *
+ * @message value - error message.
+ * @returns Custom error
+ */
+export class ValueIsUndefinedError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = "ValueIsUndefinedError";
+  }
+}
+
+/**
  * Ensures that value is defined.
  * Throws if the value is undefined, returns the original value otherwise.
  *
@@ -21,7 +35,7 @@ export function ensureDefined(value: undefined): never;
 export function ensureDefined<T>(value: T | undefined): T;
 export function ensureDefined<T>(value: T | undefined): T {
 	if (value === undefined) {
-		throw new Error('Value is undefined');
+		throw new ValueIsUndefinedError('Value is undefined');
 	}
 
 	return value;

--- a/src/helpers/assertions.ts
+++ b/src/helpers/assertions.ts
@@ -12,16 +12,17 @@ export function assert(condition: boolean, message?: string): asserts condition 
 
 /**
  * Custom Value is undefined error for useful handling.
- *
- * @message value - error message.
- * @returns Custom error
  */
 export class ValueIsUndefinedError extends Error {
-  constructor(message: string) {
-    super(message);
-
-    this.name = "ValueIsUndefinedError";
-  }
+	/**
+	 * Creates an instance of ValueIsUndefinedError.
+	 *
+	 * @param message - Error message
+	 */
+	public constructor(message: string) {
+		super(message);
+		this.name = 'ValueIsUndefinedError';
+	}
 }
 
 /**


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [+] Addresses an existing issue: fixes #1499 

**Overview of change:**
This fix ignores the bug because the events are asynchronous and when a series is deleted, we can't know about it. We probably need to fix the Click/DblClick events as well, but simultaneous deletion of a series and a click is very rare.
