### PR TITLE
Allow primitives to draw above the last price animation

### DIFF
--- a/plugin-examples/src/plugins/user-price-alerts/example/example.ts
+++ b/plugin-examples/src/plugins/user-price-alerts/example/example.ts
@@ -1,4 +1,4 @@
-import { LineStyle, createChart } from 'lightweight-charts';
+import { LastPriceAnimationMode, LineStyle, createChart } from 'lightweight-charts';
 import { generateLineData } from '../../../sample-data';
 import { UserAlertInfo } from '../state';
 import { UserPriceAlerts } from '../user-price-alerts';
@@ -41,6 +41,7 @@ const areaSeries = chart.addAreaSeries({
 	topColor: 'rgba(4,153,129, 0.4)',
 	bottomColor: 'rgba(4,153,129, 0)',
 	priceLineVisible: false,
+	lastPriceAnimation: LastPriceAnimationMode.Continuous,
 });
 const data = generateLineData();
 areaSeries.setData(data);

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -411,7 +411,7 @@ export class Series<T extends SeriesType> extends PriceDataSource implements IDe
 		}
 
 		animationPaneView.invalidateStage();
-		res.push(animationPaneView);
+		res.unshift(animationPaneView);
 		return res;
 	}
 


### PR DESCRIPTION
**Type of PR:** bugfix

**Overview of change:**

The last price animation currently draws above all primitives with a `zOrder` of `top`. This PR places the primitives above the animation.

Before:
https://github.com/tradingview/lightweight-charts/assets/3482679/30f62296-d5c7-4693-a25d-a8b17b3aee67

After:
https://github.com/tradingview/lightweight-charts/assets/3482679/496f3797-da11-4f9a-89c4-9d8afb9e1e50
