### PR TITLE
fix rendering glitch with drawRoundRectWithInnerBorder

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '48.15 KB',
+		limit: '48.16 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '48.11 KB',
+		limit: '48.09 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.8 KB',
+		limit: '49.79 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.85 KB',
+		limit: '49.83 KB',
 	},
 ];

--- a/src/renderers/price-axis-view-renderer.ts
+++ b/src/renderers/price-axis-view-renderer.ts
@@ -1,6 +1,6 @@
 import { BitmapCoordinatesRenderingScope, CanvasRenderingTarget2D, MediaCoordinatesRenderingScope } from 'fancy-canvas';
 
-import { drawRoundRectWithInnerBorder } from '../helpers/canvas-helpers';
+import { drawRoundRectWithBorder } from '../helpers/canvas-helpers';
 
 import { TextWidthCache } from '../model/text-width-cache';
 
@@ -80,8 +80,12 @@ export class PriceAxisViewRenderer implements IPriceAxisViewRenderer {
 			const gb = geom.bitmap;
 
 			const drawLabelBody = (labelBackgroundColor: string, labelBorderColor?: string): void => {
+				/*
+				 labelBackgroundColor (and labelBorderColor) will always be a solid color (no alpha) [see generateContrastColors in color.ts].
+				 Therefore we can draw the rounded label using simplified code (drawRoundRectWithBorder) that doesn't need to ensure the background and the border don't overlap.
+				*/
 				if (geom.alignRight) {
-					drawRoundRectWithInnerBorder(
+					drawRoundRectWithBorder(
 						ctx,
 						gb.xOutside,
 						gb.yTop,
@@ -93,7 +97,7 @@ export class PriceAxisViewRenderer implements IPriceAxisViewRenderer {
 						labelBorderColor
 					);
 				} else {
-					drawRoundRectWithInnerBorder(
+					drawRoundRectWithBorder(
 						ctx,
 						gb.xInside,
 						gb.yTop,


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1584

**Overview of change:**

The code within the old `drawRoundRectWithInnerBorder` is technically correct but the browsers are rendering the labels drawn with this method with a slight artefact.

Since the labels are always a solid color (see `generateContrastColors` in `color.ts`), we can use a simplified method of drawing these labels which doesn't have this rendering issue.
