### PR TITLE
replace day mark with month if month didn't fit

### DIFF
--- a/src/model/tick-marks.ts
+++ b/src/model/tick-marks.ts
@@ -1,6 +1,7 @@
 import { lowerBound } from '../helpers/algorithms';
 import { ensureDefined } from '../helpers/assertions';
 
+import { TickMarkWeight } from './horz-scale-behavior-time/types';
 import { InternalHorzScaleItem } from './ihorz-scale-behavior';
 import { TickMarkWeightValue, TimePointIndex, TimeScalePoint } from './time-data';
 
@@ -131,8 +132,26 @@ export class TickMarks<HorzScaleItem> {
 				}
 
 				if (rightIndex - currentIndex >= maxIndexesPerMark && currentIndex - leftIndex >= maxIndexesPerMark) {
-					// TickMark fits. Place it into new array
-					marks.push(mark);
+					// Check if we need to add month mark
+					if (weight === TickMarkWeight.Day && typeof mark.originalTime === 'number') {
+						const startOfTheMonth = new Date(mark.originalTime * 1000);
+						startOfTheMonth.setDate(1);
+						startOfTheMonth.setHours(0);
+						startOfTheMonth.setMinutes(0);
+						startOfTheMonth.setSeconds(0);
+						const startOfTheMonthUtcSeconds = Math.floor(startOfTheMonth.getTime() / 1000);
+						const monthMark = marks.find((m: TickMark) => {
+							return m.weight === TickMarkWeight.Month && (m.originalTime as number) >= startOfTheMonthUtcSeconds;
+						});
+						// If there is no month mark, but current day mark first, promote current mark to month mark
+						if (!monthMark) {
+							mark.weight = TickMarkWeight.Month as TickMarkWeightValue;
+						}
+						marks.push(mark);
+					} else {
+						// TickMark fits. Place it into new array
+						marks.push(mark);
+					}
 					leftIndex = currentIndex;
 				} else {
 					if (this._uniformDistribution) {

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -237,7 +237,7 @@ export class TimeScale<HorzScaleItem> implements ITimeScale {
 	private _barSpacing: number;
 	private _scrollStartPoint: Coordinate | null = null;
 	private _scaleStartPoint: Coordinate | null = null;
-	private readonly _tickMarks: TickMarks<HorzScaleItem> = new TickMarks();
+	private readonly _tickMarks: TickMarks<HorzScaleItem> = new TickMarks<HorzScaleItem>();
 	private _formattedByWeight: Map<number, FormattedLabelsCache<HorzScaleItem>> = new Map();
 
 	private _visibleRange: TimeScaleVisibleRange = TimeScaleVisibleRange.invalid();


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1588
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**
In some cases the month mark can't be placed on the timescale, but some day marks of the current month fit and we have strange behavior when we have on timescale `Jan Feb 21 Apr`. as a fix I've added a check for this specific case and change the weight of the mark before placing it into timescale