### PR TITLE
Fix for chrome 124 till 126 for blank canvas issue

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '48.38 KB',
+		limit: '48.31 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '48.30 KB',
+		limit: '48.23 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '50.01 KB',
+		limit: '49.95 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '50.06 KB',
+		limit: '49.99 KB',
 	},
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '48.17 KB',
+		limit: '48.38 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '48.10 KB',
+		limit: '48.30 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '49.80 KB',
+		limit: '50.01 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '49.84 KB',
+		limit: '50.06 KB',
 	},
 ];

--- a/src/gui/canvas-utils.ts
+++ b/src/gui/canvas-utils.ts
@@ -34,3 +34,24 @@ export function releaseCanvas(canvas: HTMLCanvasElement): void {
 	canvas.height = 1;
 	canvas.getContext('2d')?.clearRect(0, 0, 1, 1);
 }
+
+/**
+ * Chrome 124 - 126 have a bug where the canvas will become blank
+ * if the user view different tabs and then returns to the tab containing
+ * the chart.
+ * It is enough to just draw a single transparent pixel on the canvas to 'revive' it.
+ * https://issues.chromium.org/issues/328755781
+ */
+export function reviveCanvas(canvas: HTMLCanvasElement): void {
+	const ctx = canvas.getContext('2d');
+	if (!ctx) {
+		// Probably, this canvas is used for webgl
+		return;
+	}
+	ctx.save();
+	// Fully transparent
+	ctx.fillStyle = '#0000';
+	// Draw something
+	ctx.fillRect(1, 1, 1, 1);
+	ctx.restore();
+}

--- a/src/gui/canvas-utils.ts
+++ b/src/gui/canvas-utils.ts
@@ -34,24 +34,3 @@ export function releaseCanvas(canvas: HTMLCanvasElement): void {
 	canvas.height = 1;
 	canvas.getContext('2d')?.clearRect(0, 0, 1, 1);
 }
-
-/**
- * Chrome 124 - 126 have a bug where the canvas will become blank
- * if the user view different tabs and then returns to the tab containing
- * the chart.
- * It is enough to just draw a single transparent pixel on the canvas to 'revive' it.
- * https://issues.chromium.org/issues/328755781
- */
-export function reviveCanvas(canvas: HTMLCanvasElement): void {
-	const ctx = canvas.getContext('2d');
-	if (!ctx) {
-		// Probably, this canvas is used for webgl
-		return;
-	}
-	ctx.save();
-	// Fully transparent
-	ctx.fillStyle = '#0000';
-	// Draw something
-	ctx.fillRect(1, 1, 1, 1);
-	ctx.restore();
-}

--- a/src/helpers/browsers.ts
+++ b/src/helpers/browsers.ts
@@ -37,13 +37,16 @@ export function isWindows(): boolean {
 }
 
 // Determine whether the browser is Chromium based.
-export function isChromiumBased(): boolean {
+export function isChromiumBased(specificVersionsOnly?: string[]): boolean {
 	if (!isRunningOnClientSide) {
 		return false;
 	}
 	if (!navigator.userAgentData) { return false; }
 	return navigator.userAgentData.brands.some(
 		(brand: UADataBrand) => {
+			if (specificVersionsOnly && !specificVersionsOnly.includes(brand.version)) {
+				return false;
+			}
 			return brand.brand.includes('Chromium');
 		}
 	);


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1598
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**
This is a browser bug on Chromium based browsers for Chromium version 124 until 126 (should be fixed in v127). The bug sometimes results in the canvas elements on a page being blank when the returning to the tab.

Chrome issue: https://issues.chromium.org/issues/328755781