### PR TITLE
Prepare v4 branch for v5 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,13 @@ aliases:
 
 
 executors:
-  node16-executor:
+  node-executor:
     docker:
-      - image: cimg/node:16.16
+      - image: cimg/node:18.19
 
-  node16-browsers-executor:
+  node-browsers-executor:
     docker:
-      - image: cimg/node:16.16-browsers
+      - image: cimg/node:18.19-browsers
 
 commands:
   checkout-with-deps:
@@ -87,21 +87,21 @@ commands:
 
 jobs:
   install-deps:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: npm install
       - save_cache: *save-node-modules-cache
 
   install-deps-website:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: cd website && npm install
       - save_cache: *save-node-modules-cache-website
 
   build:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: npm run build:prod
@@ -115,19 +115,19 @@ jobs:
             - dist
 
   no-crlf:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout
       - run: scripts/no-crlf.sh
 
   trailing-lf:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout
       - run: scripts/trailing-newlines.sh
 
   lint-eslint:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - attach_workspace:
@@ -135,7 +135,7 @@ jobs:
       - run: npm run lint:eslint
 
   lint-dts:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - attach_workspace:
@@ -144,13 +144,13 @@ jobs:
       - run: npm run check-dts-docs
 
   lint-markdown:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: npm run lint:md
 
   usable-in-nodejs:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - attach_workspace:
@@ -171,7 +171,7 @@ jobs:
           command: node -e "import 'lightweight-charts'" --input-type=module
 
   unittests:
-    executor: node16-executor
+    executor: node-executor
     environment:
       TESTS_REPORT_FILE: "test-results/unittests/results.xml"
     steps:
@@ -181,14 +181,14 @@ jobs:
           path: test-results/
 
   type-tests:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: npm run tsc-verify
       - run: npm run type-tests
 
   dts-changes:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: scripts/check-dts-changes.sh ./dts-changes $(git merge-base origin/master HEAD) $(git rev-parse HEAD)
@@ -197,31 +197,31 @@ jobs:
           when: on_fail
 
   graphics-tests-dpr1_0:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     steps:
       - run-graphics-tests:
           devicePixelRatio: "1.0"
 
   graphics-tests-dpr1_25:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     steps:
       - run-graphics-tests:
           devicePixelRatio: "1.25"
 
   graphics-tests-dpr1_5:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     steps:
       - run-graphics-tests:
           devicePixelRatio: "1.5"
 
   graphics-tests-dpr2_0:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     steps:
       - run-graphics-tests:
           devicePixelRatio: "2.0"
 
   graphics-tests-dpr2_0-prod:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     steps:
       - run-graphics-tests:
           devicePixelRatio: "2.0"
@@ -229,7 +229,7 @@ jobs:
 
 
   memleaks-tests:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     environment:
       NO_SANDBOX: "true"
       TESTS_REPORT_FILE: "test-results/memleaks/results.xml"
@@ -249,7 +249,7 @@ jobs:
           path: tests/e2e/memleaks/.logs/
 
   coverage:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     environment:
       NO_SANDBOX: "true"
       TESTS_REPORT_FILE: "test-results/coverage/results.xml"
@@ -262,7 +262,7 @@ jobs:
           path: test-results/
 
   interactions:
-    executor: node16-browsers-executor
+    executor: node-browsers-executor
     environment:
       NO_SANDBOX: "true"
       TESTS_REPORT_FILE: "test-results/interactions/results.xml"
@@ -275,7 +275,7 @@ jobs:
           path: test-results/
 
   size-limit:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - attach_workspace:
@@ -286,7 +286,7 @@ jobs:
       - run: npm run size-limit
 
   build-docusaurus-website:
-    executor: node16-executor
+    executor: node-executor
     steps:
       - checkout-with-deps
       - run: npm run build:prod

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -793,8 +793,6 @@ module.exports = {
 		}],
 
 		'jsdoc/check-indentation': 'error',
-		'jsdoc/newline-after-description': 'error',
-
 		'import/no-default-export': 'error',
 
 		'prefer-arrow/prefer-arrow-functions': [

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint": "~7.32.0",
     "eslint-plugin-deprecation": "~1.3.3",
     "eslint-plugin-import": "~2.27.5",
-    "eslint-plugin-jsdoc": "~39.8.0",
+    "eslint-plugin-jsdoc": "~48.5.0",
     "eslint-plugin-markdown": "~3.0.0",
     "eslint-plugin-mdx": "~1.17.0",
     "eslint-plugin-prefer-arrow": "~1.2.3",


### PR DESCRIPTION
Updated the version for the `eslint-plugin-jsdoc` dependency so that future v5 branches can be tested correctly on the CI.
The `v5` branches are using a newer version of node, but part of the CI checks is to checkout master and build the current golden release. The dependency blocks this since it not listing 22 as a supported node version.
