### PR TITLE
Fix deploy workflow Node version error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,12 +20,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install library dependencies
         run: npm install
@@ -48,7 +48,7 @@ jobs:
         run: npm run build:examples:site
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

Fixes deploy error caused by using unsupported Node 16: https://github.com/tradingview/lightweight-charts/actions/runs/9855529550

**Overview of change:**

Update the GitHub actions to their latest versions and change `node-version` to 18.

