### PR TITLE
fix: calc timeDiff if prevTime not null

### DIFF
--- a/src/model/horz-scale-behavior-time/time-scale-point-weight-generator.ts
+++ b/src/model/horz-scale-behavior-time/time-scale-point-weight-generator.ts
@@ -70,9 +70,10 @@ export function fillWeightsForPoints(sortedTimePoints: readonly Mutable<TimeScal
 
 		if (prevDate !== null) {
 			currentPoint.timeWeight = weightByTime(currentDate, prevDate) as TickMarkWeightValue;
-		}
 
-		totalTimeDiff += cast(currentPoint.time).timestamp - (prevTime || cast(currentPoint.time).timestamp);
+			// Calculate the time difference only if prevTime is not null
+			totalTimeDiff += cast(currentPoint.time).timestamp - (prevTime || cast(currentPoint.time).timestamp);
+		}
 
 		prevTime = cast(currentPoint.time).timestamp;
 		prevDate = currentDate;


### PR DESCRIPTION
This commit addresses an issue in the fillWeightsForPoints function where the time difference calculation could be incorrect if prevTime was null. Previously, the code used a fallback mechanism that could result in totalTimeDiff being zero for the first point, leading to an inaccurate averageTimeDiff and incorrect weight assignment.

To fix this, we introduced a conditional check to ensure that the time difference is only calculated when prevTime is not null. This change ensures that totalTimeDiff accurately reflects the true time intervals, leading to correct weight assignments for all time points.

**I acknowledge that this might not be a complete solution; my goal is to highlight the issue. The screenshot clearly demonstrates that when the first label's weight is estimated, the totalTimeDiff is calculated based on an incorrect assumption. This can cause the label to appear in an arbitrary position, potentially leading to unintended behavior in certain scenarios. My solution causes the first label to now always be displayed as a year. This may not be the correct approach for every case, but I hope it can contribute towards finding a solution.**

![03-09-2024_11-22-22](https://github.com/user-attachments/assets/f481816d-a2d7-4110-bb56-c82215f329fa)

And here how it look with my fix:

![03-09-2024_11-52-08](https://github.com/user-attachments/assets/aa6d843c-e439-4498-9a6e-2840d854cbb2)

