### PR TITLE
Fix the issue of labels in centre will overlap when alignLabels switc…

### DIFF
--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -639,6 +639,11 @@ export class PriceAxisWidget implements IDestroyable {
 		}
 
 		recalculateOverlapping(top, 1, this._size.height, rendererOptions);
+		// move the last top to the first bottom to prevent overlapping between the items in top and bottom
+		if (top.length && bottom.length) {
+			bottom.splice(0, 0, top.splice(0, 1)[0]);
+		}
+
 		recalculateOverlapping(bottom, -1, this._size.height, rendererOptions);
 	}
 

--- a/tests/e2e/graphics/test-cases/price-scale/fix-labels-overlapping-when-align-labels-on.js
+++ b/tests/e2e/graphics/test-cases/price-scale/fix-labels-overlapping-when-align-labels-on.js
@@ -1,0 +1,85 @@
+function runTestCase(container) {
+	const chartOptions = {
+		height: 500,
+		width: 600,
+		rightPriceScale: {
+			scaleMargins: {
+				top: 0,
+				bottom: 0,
+			},
+			entireTextOnly: true,
+			alignLabels: true,
+		},
+		layout: { attributionLogo: false },
+	};
+
+	const chart = (window.chart = LightweightCharts.createChart(
+		container,
+		chartOptions
+	));
+
+	const levels = [
+		7.9,
+		5.44,
+		4.23,
+		4.08,
+		3.42,
+		3.09,
+		2.78,
+		2.24,
+		2.14,
+		2.13,
+		2.12,
+		2.05,
+		2.04,
+		1.92,
+		1.69,
+		1.67,
+		1.47,
+		1.32,
+		1.11,
+		0.90712,
+		0.63113,
+		0.40527,
+		0.20527,
+		0.10527,
+		0.00527,
+		0.00027,
+		0.00007,
+		0.00001,
+	].map(price => ({ price }));
+
+	const colorByIndex = index => {
+		const r = index & 0b10000 >> 4;
+		const g = index & 0b01100 >> 2;
+		const b = index & 0b00011;
+		return `rgb(${Math.floor(r * 255)}, ${Math.floor(g * 255 / 4)}, ${Math.floor(b * 255 / 4)})`;
+	};
+
+	for (let i = 0; i < levels.length; i++) {
+		const s = chart.addLineSeries({
+			color: colorByIndex(i),
+		});
+		s.setData([
+			{ time: 10000, value: levels[i].price },
+			{ time: 20000, value: levels[i].price },
+		]);
+		levels[i].series = s;
+	}
+
+	for (let i = 0; i < 4; i++) {
+		chart.removeSeries(levels[i].series);
+		delete levels[i].series;
+	}
+
+	for (let i = 3; i >= 2; i--) {
+		const s = chart.addLineSeries({
+			color: colorByIndex(i),
+		});
+		s.setData([
+			{ time: 10000, value: levels[i].price },
+			{ time: 20000, value: levels[i].price },
+		]);
+		levels[i].series = s;
+	}
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [X] Includes tests
- [ ] Documentation update

**Overview of change:**
In the library, it splits all the labels into top and bottom parts (based on the center coordinate), then recalculates the fixed coordinates for both parts. The issue occurs when calculating the bottom part, as it doesn't consider the coordinate of the last label from the top part, which causes some of the first items in the bottom part to overlap with the last items in the top part.

What has been changed in this PR is that the last item from the top part is moved to the bottom part. This way, when calculating the coordinates for the first item in the bottom part, it checks the last top item and adds the label's height if there is an overlap.



**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
