### PR TITLE
add relative gradient option to the baseline series

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -79,7 +79,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ BaselineSeries }',
 		ignore: ['fancy-canvas'],
-		limit: '3.3 KB',
+		limit: '4.00 KB',
 		brotli: true,
 	},
 	{
@@ -87,7 +87,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ AreaSeries }',
 		ignore: ['fancy-canvas'],
-		limit: '3.2 KB',
+		limit: '4.00 KB',
 		brotli: true,
 	},
 	{

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -79,7 +79,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ BaselineSeries }',
 		ignore: ['fancy-canvas'],
-		limit: '3.2 KB',
+		limit: '3.3 KB',
 		brotli: true,
 	},
 	{

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -252,6 +252,14 @@ export interface AreaStyleOptions {
 	bottomColor: string;
 
 	/**
+	 * Gradient is relative to the base value and the currently visible range.
+	 * If it is false, the gradient is relative to the top and bottom of the chart.
+	 *
+	 * @defaultValue `false`
+	 */
+	relativeGradient: boolean;
+
+	/**
 	 * Invert the filled area. Fills the area above the line if set to true.
 	 *
 	 * @defaultValue `false`

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -375,7 +375,13 @@ export interface BaselineStyleOptions {
 	 * @defaultValue `{ type: 'price', price: 0 }`
 	 */
 	baseValue: BaseValueType;
-
+	/**
+	 * Gradient is relative to the base value and the currently visible range.
+	 * If it is false, the gradient is relative to the top and bottom of the chart.
+	 *
+	 * @defaultValue `false`
+	 */
+	relativeGradient: boolean;
 	/**
 	 * The first color of the top area.
 	 *

--- a/src/model/series/area-pane-view.ts
+++ b/src/model/series/area-pane-view.ts
@@ -28,13 +28,28 @@ export class SeriesAreaPaneView extends LinePaneViewBase<'Area', AreaFillItem & 
 
 	protected _prepareRendererData(): void {
 		const options = this._series.options();
+		if (this._itemsVisibleRange === null || this._items.length === 0) {
+			return;
+		}
+		let topCoordinate;
 
+		if (options.relativeGradient) {
+			topCoordinate = this._items[this._itemsVisibleRange.from].y;
+
+			for (let i = this._itemsVisibleRange.from; i < this._itemsVisibleRange.to; i++) {
+				const item = this._items[i];
+				if (item.y < topCoordinate) {
+					topCoordinate = item.y;
+				}
+			}
+		}
 		this._areaRenderer.setData({
 			lineType: options.lineType,
 			items: this._items,
 			lineStyle: options.lineStyle,
 			lineWidth: options.lineWidth,
 			baseLevelCoordinate: null,
+			topCoordinate,
 			invertFilledArea: options.invertFilledArea,
 			visibleRange: this._itemsVisibleRange,
 			barWidth: this._model.timeScale().barSpacing(),

--- a/src/model/series/area-series.ts
+++ b/src/model/series/area-series.ts
@@ -11,6 +11,7 @@ export const areaStyleDefaults: AreaStyleOptions = {
 	topColor: 'rgba( 46, 220, 135, 0.4)',
 	bottomColor: 'rgba( 40, 221, 100, 0)',
 	invertFilledArea: false,
+	relativeGradient: false,
 	lineColor: '#33D778',
 	lineStyle: LineStyle.Solid,
 	lineWidth: 3,

--- a/src/model/series/baseline-pane-view.ts
+++ b/src/model/series/baseline-pane-view.ts
@@ -33,34 +33,52 @@ export class SeriesBaselinePaneView extends LinePaneViewBase<'Baseline', Baselin
 		}
 
 		const options = this._series.options();
-
 		const baseLevelCoordinate = this._series.priceScale().priceToCoordinate(options.baseValue.price, firstValue.value);
 		const barWidth = this._model.timeScale().barSpacing();
 
+		if (this._itemsVisibleRange === null || this._items.length === 0) {
+			return;
+		}
+		let topCoordinate;
+		let bottomCoordinate;
+
+		if (options.relativeGradient) {
+			topCoordinate = this._items[this._itemsVisibleRange.from].y;
+			bottomCoordinate = this._items[this._itemsVisibleRange.from].y;
+
+			for (let i = this._itemsVisibleRange.from; i < this._itemsVisibleRange.to; i++) {
+				const item = this._items[i];
+				if (item.y < topCoordinate) {
+					topCoordinate = item.y;
+				}
+				if (item.y > bottomCoordinate) {
+					bottomCoordinate = item.y;
+				}
+			}
+		}
+
 		this._baselineAreaRenderer.setData({
 			items: this._items,
-
 			lineWidth: options.lineWidth,
 			lineStyle: options.lineStyle,
 			lineType: options.lineType,
-
 			baseLevelCoordinate,
+			topCoordinate,
+			bottomCoordinate,
 			invertFilledArea: false,
-
 			visibleRange: this._itemsVisibleRange,
 			barWidth,
 		});
 
 		this._baselineLineRenderer.setData({
 			items: this._items,
-
 			lineWidth: options.lineWidth,
 			lineStyle: options.lineStyle,
 			lineType: options.lineVisible ? options.lineType : undefined,
 			pointMarkersRadius: options.pointMarkersVisible ? (options.pointMarkersRadius || options.lineWidth / 2 + 2) : undefined,
-
 			baseLevelCoordinate,
-
+			topCoordinate,
+			bottomCoordinate,
 			visibleRange: this._itemsVisibleRange,
 			barWidth,
 		});

--- a/src/model/series/baseline-series.ts
+++ b/src/model/series/baseline-series.ts
@@ -12,7 +12,7 @@ export const baselineStyleDefaults: BaselineStyleOptions = {
 		type: 'price',
 		price: 0,
 	},
-
+	relativeGradient: false,
 	topFillColor1: 'rgba(38, 166, 154, 0.28)',
 	topFillColor2: 'rgba(38, 166, 154, 0.05)',
 	topLineColor: 'rgba(38, 166, 154, 1)',

--- a/src/renderers/area-renderer.ts
+++ b/src/renderers/area-renderer.ts
@@ -21,7 +21,8 @@ export class PaneRendererArea extends PaneRendererAreaBase<PaneRendererAreaData>
 				topColor2: '',
 				bottomColor1: '',
 				bottomColor2: item.bottomColor,
-				bottom: renderingScope.bitmapSize.height as Coordinate,
+				topCoordinate: 0 as Coordinate,
+				bottomCoordinate: renderingScope.bitmapSize.height as Coordinate,
 			}
 		);
 	}

--- a/src/renderers/area-renderer.ts
+++ b/src/renderers/area-renderer.ts
@@ -8,6 +8,7 @@ import { GradientStyleCache } from './gradient-style-cache';
 
 export type AreaFillItem = AreaFillItemBase & AreaFillColorerStyle;
 export interface PaneRendererAreaData extends PaneRendererAreaDataBase<AreaFillItem> {
+	topCoordinate?: Coordinate;
 }
 
 export class PaneRendererArea extends PaneRendererAreaBase<PaneRendererAreaData> {
@@ -21,7 +22,7 @@ export class PaneRendererArea extends PaneRendererAreaBase<PaneRendererAreaData>
 				topColor2: '',
 				bottomColor1: '',
 				bottomColor2: item.bottomColor,
-				topCoordinate: 0 as Coordinate,
+				topCoordinate: this._data?.topCoordinate ?? 0 as Coordinate,
 				bottomCoordinate: renderingScope.bitmapSize.height as Coordinate,
 			}
 		);

--- a/src/renderers/baseline-renderer-area.ts
+++ b/src/renderers/baseline-renderer-area.ts
@@ -8,6 +8,8 @@ import { GradientStyleCache } from './gradient-style-cache';
 
 export type BaselineFillItem = AreaFillItemBase & BaselineFillColorerStyle;
 export interface PaneRendererBaselineData extends PaneRendererAreaDataBase<BaselineFillItem> {
+	topCoordinate?: Coordinate;
+	bottomCoordinate?: Coordinate;
 }
 export class PaneRendererBaselineArea extends PaneRendererAreaBase<PaneRendererBaselineData> {
 	private readonly _fillCache: GradientStyleCache = new GradientStyleCache();
@@ -23,8 +25,9 @@ export class PaneRendererBaselineArea extends PaneRendererAreaBase<PaneRendererB
 				topColor2: item.topFillColor2,
 				bottomColor1: item.bottomFillColor1,
 				bottomColor2: item.bottomFillColor2,
-				bottom: renderingScope.bitmapSize.height as Coordinate,
 				baseLevelCoordinate: data.baseLevelCoordinate,
+				topCoordinate: data.topCoordinate ?? 0 as Coordinate,
+				bottomCoordinate: data.bottomCoordinate ?? renderingScope.bitmapSize.height as Coordinate,
 			}
 		);
 	}

--- a/src/renderers/baseline-renderer-line.ts
+++ b/src/renderers/baseline-renderer-line.ts
@@ -9,6 +9,8 @@ import { LineItemBase as LineStrokeItemBase, PaneRendererLineBase, PaneRendererL
 export type BaselineStrokeItem = LineStrokeItemBase & BaselineStrokeColorerStyle;
 export interface PaneRendererBaselineLineData extends PaneRendererLineDataBase<BaselineStrokeItem> {
 	baseLevelCoordinate: Coordinate;
+	topCoordinate?: Coordinate;
+	bottomCoordinate?: Coordinate;
 }
 
 export class PaneRendererBaselineLine extends PaneRendererLineBase<PaneRendererBaselineLineData> {
@@ -25,8 +27,9 @@ export class PaneRendererBaselineLine extends PaneRendererLineBase<PaneRendererB
 				topColor2: item.topLineColor,
 				bottomColor1: item.bottomLineColor,
 				bottomColor2: item.bottomLineColor,
-				bottom: renderingScope.bitmapSize.height as Coordinate,
 				baseLevelCoordinate: data.baseLevelCoordinate,
+				topCoordinate: data.topCoordinate ?? 0 as Coordinate,
+				bottomCoordinate: data.bottomCoordinate ?? renderingScope.bitmapSize.height as Coordinate,
 			}
 		);
 	}

--- a/src/renderers/gradient-style-cache.ts
+++ b/src/renderers/gradient-style-cache.ts
@@ -18,6 +18,7 @@ export class GradientStyleCache {
 	private _params?: GradientCacheParams;
 	private _cachedValue?: CanvasGradient;
 
+	// eslint-disable-next-line complexity
 	public get(scope: BitmapCoordinatesRenderingScope, params: GradientCacheParams): CanvasGradient {
 		const cachedParams = this._params;
 		const {
@@ -37,9 +38,10 @@ export class GradientStyleCache {
 			cachedParams.bottomCoordinate !== bottomCoordinate
 		) {
 			const { verticalPixelRatio } = scope;
-			const top = (topCoordinate) * verticalPixelRatio;
-			const bottom = (bottomCoordinate) * verticalPixelRatio;
-			const baseline = (baseLevelCoordinate ?? 0) * verticalPixelRatio;
+			const multiplier = baseLevelCoordinate || topCoordinate > 0 ? verticalPixelRatio : 1;
+			const top = topCoordinate * multiplier;
+			const bottom = bottomCoordinate === scope.bitmapSize.height ? bottomCoordinate : bottomCoordinate * multiplier;
+			const baseline = (baseLevelCoordinate ?? 0) * multiplier;
 			const gradient = scope.context.createLinearGradient(0, top, 0, bottom);
 
 			gradient.addColorStop(0, topColor1);

--- a/tests/e2e/graphics/helpers/compare-screenshots.ts
+++ b/tests/e2e/graphics/helpers/compare-screenshots.ts
@@ -24,7 +24,7 @@ export function compareScreenshots(leftImg: PNG, rightImg: PNG): CompareResult {
 		leftImg.data, rightImg.data,
 		diffImg.data,
 		leftImg.width, leftImg.height,
-		{ threshold: 0.03 }
+		{ threshold: 0.1 }
 	);
 
 	return { diffPixelsCount, diffImg };

--- a/tests/e2e/graphics/helpers/compare-screenshots.ts
+++ b/tests/e2e/graphics/helpers/compare-screenshots.ts
@@ -24,7 +24,7 @@ export function compareScreenshots(leftImg: PNG, rightImg: PNG): CompareResult {
 		leftImg.data, rightImg.data,
 		diffImg.data,
 		leftImg.width, leftImg.height,
-		{ threshold: 0.1 }
+		{ threshold: 0.01 }
 	);
 
 	return { diffPixelsCount, diffImg };

--- a/tests/e2e/graphics/helpers/compare-screenshots.ts
+++ b/tests/e2e/graphics/helpers/compare-screenshots.ts
@@ -24,7 +24,7 @@ export function compareScreenshots(leftImg: PNG, rightImg: PNG): CompareResult {
 		leftImg.data, rightImg.data,
 		diffImg.data,
 		leftImg.width, leftImg.height,
-		{ threshold: 0.01 }
+		{ threshold: 0.1 }
 	);
 
 	return { diffPixelsCount, diffImg };

--- a/tests/e2e/graphics/helpers/compare-screenshots.ts
+++ b/tests/e2e/graphics/helpers/compare-screenshots.ts
@@ -24,7 +24,7 @@ export function compareScreenshots(leftImg: PNG, rightImg: PNG): CompareResult {
 		leftImg.data, rightImg.data,
 		diffImg.data,
 		leftImg.width, leftImg.height,
-		{ threshold: 0.1 }
+		{ threshold: 0.03 }
 	);
 
 	return { diffPixelsCount, diffImg };

--- a/tests/e2e/graphics/test-cases/series/area-relative-gradient-inverted.js
+++ b/tests/e2e/graphics/test-cases/series/area-relative-gradient-inverted.js
@@ -1,0 +1,24 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, { layout: { attributionLogo: false } });
+
+	const mainSeries = chart.addSeries(LightweightCharts.AreaSeries, {
+		relativeGradient: true,
+		invertFilledArea: true,
+	});
+
+	mainSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/series/area-relative-gradient.js
+++ b/tests/e2e/graphics/test-cases/series/area-relative-gradient.js
@@ -1,0 +1,23 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, { layout: { attributionLogo: false } });
+
+	const mainSeries = chart.addSeries(LightweightCharts.AreaSeries, {
+		relativeGradient: true,
+	});
+
+	mainSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/series/baseline-relative-gradient.js
+++ b/tests/e2e/graphics/test-cases/series/baseline-relative-gradient.js
@@ -1,0 +1,43 @@
+function generateBar(i, target) {
+	const step = (i % 20) / 5000;
+	const base = i / 5;
+	target.value = base * (1 - step);
+
+	if ((i % 10) > 4) {
+		target.topFillColor1 = 'red';
+		target.topFillColor2 = 'rgba(255, 0, 0, 0)';
+	}
+
+	if ((i % 10) > 6) {
+		target.bottomFillColor1 = 'yellow';
+		target.bottomFillColor2 = 'rgba(255, 255, 0, 0)';
+	}
+
+	if ((i % 10) > 5) {
+		target.topLineColor = 'blue';
+		target.bottomLineColor = 'green';
+	}
+}
+
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		const item = {
+			time: time.getTime() / 1000,
+		};
+		time.setUTCDate(time.getUTCDate() + 1);
+
+		generateBar(i, item);
+		res.push(item);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, { layout: { attributionLogo: false } });
+
+	const mainSeries = chart.addSeries(LightweightCharts.BaselineSeries, { baseValue: { type: 'price', price: 88 }, relativeGradient: true });
+
+	mainSeries.setData(generateData());
+}

--- a/website/package.json
+++ b/website/package.json
@@ -35,6 +35,6 @@
     "vue": "^3.4.29"
   },
   "devDependencies": {
-    "typedoc-plugin-frontmatter": "^1.0.0"
+    "typedoc-plugin-frontmatter": "1.0.0"
   }
 }


### PR DESCRIPTION
**Type of PR:**  enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1005
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**
Added a new option to the baseline series where we calculate gradient from the visible points range and not from the top and bottom of the chart.
Example with two series with the same settings. Top and bottom colors are different without option enabled
without option:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/63d35e78-3b01-456a-a963-1316e75f6146">


with the option enabled:
<img width="813" alt="image" src="https://github.com/user-attachments/assets/ed9317e9-aca0-484e-8ac2-3732e10fed63">


<!-- optional -->
