### PR TITLE
Fix priceLine rendering when having LastPriceAnimation indicator

### DIFF
--- a/src/gui/pane-widget.ts
+++ b/src/gui/pane-widget.ts
@@ -506,6 +506,7 @@ export class PaneWidget implements IDestroyable, MouseEventHandlers {
 			});
 			this._drawCrosshair(topTarget);
 			this._drawSources(topTarget, sourceTopPaneViews);
+			this._drawSources(topTarget, sourceLabelPaneViews);
 		}
 	}
 


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1711

Note:
- Not adding an e2e graphics test case because it is unreliable to test the Last Price Animation during it the timing of the screenshot within the animation effect.
