### PR TITLE
CLL-310: Do not allocate space for crosshair label is crosshair is di…

### DIFF
--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -16,6 +16,7 @@ import { makeFont } from '../helpers/make-font';
 
 import { ChartOptionsInternalBase } from '../model/chart-model';
 import { Coordinate } from '../model/coordinate';
+import { CrosshairMode } from '../model/crosshair';
 import { IDataSource } from '../model/idata-source';
 import { InvalidationLevel } from '../model/invalidate-mask';
 import { IPriceDataSource } from '../model/iprice-data-source';
@@ -272,7 +273,7 @@ export class PriceAxisWidget implements IDestroyable {
 		}
 
 		const firstValue = this._priceScale.firstValue();
-		if (firstValue !== null && this._size !== null) {
+		if (firstValue !== null && this._size !== null && this._options.crosshair.mode !== CrosshairMode.Hidden) {
 			const topValue = this._priceScale.coordinateToPrice(1 as Coordinate, firstValue);
 			const bottomValue = this._priceScale.coordinateToPrice(this._size.height - 2 as Coordinate, firstValue);
 

--- a/tests/e2e/graphics/test-cases/price-scale/price-scale-width-without-crosshair.js
+++ b/tests/e2e/graphics/test-cases/price-scale/price-scale-width-without-crosshair.js
@@ -1,0 +1,34 @@
+function runTestCase(container) {
+	const chartOptions = {
+		height: 400,
+		width: 600,
+		rightPriceScale: {
+			scaleMargins: {
+				top: 0,
+				bottom: 0,
+			},
+			entireTextOnly: true,
+			alignLabels: true,
+		},
+		crosshair: {
+			mode: 2,
+		},
+	};
+
+	const chart = (window.chart = LightweightCharts.createChart(
+		container,
+		chartOptions
+	));
+
+	const data1 = Array.from({ length: 10 }).map((_, index) => ({ time: index * 10000, value: 1000000 * (100 - index), color: index % 2 ? '#ff0000' : '#0000ff' }));
+
+	const series1 = chart.addLineSeries({
+		priceFormat: {
+			type: 'volume',
+			precision: 3,
+		},
+	});
+	series1.setData(data1);
+
+	chart.timeScale().fitContent();
+}


### PR DESCRIPTION
Improve price scale width calculation

**Type of PR:** bugfix / enhancement
**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**
If crosshair is disabled by options, we do not need to preallocate space for all the possible crosshair labels within the price scales

