### PR TITLE
improve check for crosshair label visibility on the price scale

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -4,21 +4,21 @@ module.exports = [
 	{
 		name: 'CJS',
 		path: 'dist/lightweight-charts.production.cjs',
-		limit: '49.29 KB',
+		limit: '49.32 KB',
 	},
 	{
 		name: 'ESM',
 		path: 'dist/lightweight-charts.production.mjs',
-		limit: '49.22 KB',
+		limit: '49.25 KB',
 	},
 	{
 		name: 'Standalone-ESM',
 		path: 'dist/lightweight-charts.standalone.production.mjs',
-		limit: '50.94 KB',
+		limit: '50.97 KB',
 	},
 	{
 		name: 'Standalone',
 		path: 'dist/lightweight-charts.standalone.production.js',
-		limit: '50.98 KB',
+		limit: '51.00 KB',
 	},
 ];

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -16,7 +16,7 @@ import { makeFont } from '../helpers/make-font';
 
 import { ChartOptionsInternalBase } from '../model/chart-model';
 import { Coordinate } from '../model/coordinate';
-import { CrosshairMode } from '../model/crosshair';
+import { CrosshairMode, CrosshairOptions } from '../model/crosshair';
 import { IDataSource } from '../model/idata-source';
 import { InvalidationLevel } from '../model/invalidate-mask';
 import { IPriceDataSource } from '../model/iprice-data-source';
@@ -117,6 +117,10 @@ function recalculateOverlapping(
 				: coordinate - (prevFixedCoordinate + height);
 		}
 	}
+}
+
+function priceScaleCrosshairLabelVisible(crosshair: CrosshairOptions): boolean {
+	return crosshair.mode !== CrosshairMode.Hidden && crosshair.horzLine.visible && crosshair.horzLine.labelVisible;
 }
 
 export class PriceAxisWidget implements IDestroyable {
@@ -273,7 +277,11 @@ export class PriceAxisWidget implements IDestroyable {
 		}
 
 		const firstValue = this._priceScale.firstValue();
-		if (firstValue !== null && this._size !== null && this._options.crosshair.mode !== CrosshairMode.Hidden) {
+		if (
+			firstValue !== null &&
+			this._size !== null &&
+			priceScaleCrosshairLabelVisible(this._options.crosshair)
+		) {
 			const topValue = this._priceScale.coordinateToPrice(1 as Coordinate, firstValue);
 			const bottomValue = this._priceScale.coordinateToPrice(this._size.height - 2 as Coordinate, firstValue);
 


### PR DESCRIPTION
**Type of PR:** enhancement

**Overview of change:**
This improves upon previous work (#1743) by reducing the allocated space for the crosshair when it is enabled, but the label is disabled. It enhances the granularity of the check.

