### PR TITLE
CLL-303: Assert that open, close, high, low, value can safely represe…

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -79,7 +79,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ createSeriesMarkers }',
 		ignore: ['fancy-canvas'],
-		limit: '4.123 KB',
+		limit: '4.5 KB',
 		brotli: true,
 	},
 	{
@@ -119,7 +119,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ CandlestickSeries }',
 		ignore: ['fancy-canvas'],
-		limit: '2.54 KB',
+		limit: '3.00 KB',
 		brotli: true,
 	},
 	{

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -79,7 +79,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ createSeriesMarkers }',
 		ignore: ['fancy-canvas'],
-		limit: '4.08 KB',
+		limit: '4.123 KB',
 		brotli: true,
 	},
 	{
@@ -119,7 +119,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ CandlestickSeries }',
 		ignore: ['fancy-canvas'],
-		limit: '2.5 KB',
+		limit: '2.54 KB',
 		brotli: true,
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "build:release": "cross-env BUILD_TAG=release npm run build:prod",
     "prepare-release": "npm-run-all clean build:release && npm run prepare-package-json-for-release",
     "prepare-package-json-for-release": "node ./scripts/clean-package-json.js",
-    "size-limit": "test ./dist/lightweight-charts.production.mjs -nt ./.git/HEAD || npm run build:prod; size-limit --highlight-less",
+    "size-limit": "size-limit",
     "verify": "npm-run-all clean -p build:prod check-markdown-links -p lint check-dts-docs tsc-verify test size-limit -p type-tests",
     "test": "esno --import ./tests/unittests/setup.units.mjs --test './tests/unittests/**/*.spec.ts'",
     "type-tests": "tsc -b ./src/tsconfig.composite.json && tsc -p ./tests/type-checks/tsconfig.composite.json --noEmit",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "build:release": "cross-env BUILD_TAG=release npm run build:prod",
     "prepare-release": "npm-run-all clean build:release && npm run prepare-package-json-for-release",
     "prepare-package-json-for-release": "node ./scripts/clean-package-json.js",
-    "size-limit": "size-limit",
+    "size-limit": "test ./dist/lightweight-charts.production.mjs -nt ./.git/HEAD || npm run build:prod; size-limit --highlight-less",
     "verify": "npm-run-all clean -p build:prod check-markdown-links -p lint check-dts-docs tsc-verify test size-limit -p type-tests",
     "test": "esno --import ./tests/unittests/setup.units.mjs --test './tests/unittests/**/*.spec.ts'",
     "type-tests": "tsc -b ./src/tsconfig.composite.json && tsc -p ./tests/type-checks/tsconfig.composite.json --noEmit",

--- a/src/model/data-validators.ts
+++ b/src/model/data-validators.ts
@@ -115,8 +115,8 @@ function checkCustomItem(
 	return;
 }
 
-const MIN_SAVE_VALUE = Number.MIN_SAFE_INTEGER / 100;
-const MAX_SAVE_VALUE = Number.MAX_SAFE_INTEGER / 100;
+const MIN_SAFE_VALUE = Number.MIN_SAFE_INTEGER / 100;
+const MAX_SAFE_VALUE = Number.MAX_SAFE_INTEGER / 100;
 
 function isSafeValue(value: number): boolean {
 	return value >= MIN_SAVE_VALUE && value <= MAX_SAVE_VALUE;

--- a/src/model/data-validators.ts
+++ b/src/model/data-validators.ts
@@ -77,7 +77,7 @@ function checkBarItem<HorzScaleItem>(
 
 		assert(
 			isSafeValue(barItem[key]),
-			`${type} series item data value of ${key} must be between ${MIN_SAVE_VALUE.toPrecision(16)} and ${MAX_SAVE_VALUE.toPrecision(16)}, got=${typeof barItem[key]}, value=${
+			`${type} series item data value of ${key} must be between ${MIN_SAFE_VALUE.toPrecision(16)} and ${MAX_SAFE_VALUE.toPrecision(16)}, got=${typeof barItem[key]}, value=${
 				barItem[key]
 			}`
 		);
@@ -101,7 +101,7 @@ function checkLineItem<HorzScaleItem>(
 
 	assert(
 		isSafeValue(lineItem.value),
-		`${type} series item data value must be between ${MIN_SAVE_VALUE.toPrecision(16)} and ${MAX_SAVE_VALUE.toPrecision(16)}, got=${typeof lineItem.value}, value=${
+		`${type} series item data value must be between ${MIN_SAFE_VALUE.toPrecision(16)} and ${MAX_SAFE_VALUE.toPrecision(16)}, got=${typeof lineItem.value}, value=${
 			lineItem.value
 		}`
 	);
@@ -119,5 +119,5 @@ const MIN_SAFE_VALUE = Number.MIN_SAFE_INTEGER / 100;
 const MAX_SAFE_VALUE = Number.MAX_SAFE_INTEGER / 100;
 
 function isSafeValue(value: number): boolean {
-	return value >= MIN_SAVE_VALUE && value <= MAX_SAVE_VALUE;
+	return value >= MIN_SAFE_VALUE && value <= MAX_SAFE_VALUE;
 }

--- a/src/model/data-validators.ts
+++ b/src/model/data-validators.ts
@@ -77,7 +77,7 @@ function checkBarItem<HorzScaleItem>(
 
 		assert(
 			isSafeValue(barItem[key]),
-			`${type} series item data value of ${key} must be between ${VALUE_SAFE_RANGE}, got=${typeof barItem[key]}, value=${
+			`${type} series item data value of ${key} must be between ${MIN_SAVE_VALUE.toPrecision(16)} and ${MAX_SAVE_VALUE.toPrecision(16)}, got=${typeof barItem[key]}, value=${
 				barItem[key]
 			}`
 		);
@@ -101,7 +101,7 @@ function checkLineItem<HorzScaleItem>(
 
 	assert(
 		isSafeValue(lineItem.value),
-		`${type} series item data value must be between ${VALUE_SAFE_RANGE}, got=${typeof lineItem.value}, value=${
+		`${type} series item data value must be between ${MIN_SAVE_VALUE.toPrecision(16)} and ${MAX_SAVE_VALUE.toPrecision(16)}, got=${typeof lineItem.value}, value=${
 			lineItem.value
 		}`
 	);
@@ -117,7 +117,6 @@ function checkCustomItem(
 
 const MIN_SAVE_VALUE = Number.MIN_SAFE_INTEGER / 100;
 const MAX_SAVE_VALUE = Number.MAX_SAFE_INTEGER / 100;
-const VALUE_SAFE_RANGE = `${MIN_SAVE_VALUE.toPrecision(16)} and ${MAX_SAVE_VALUE.toPrecision(16)}`;
 
 function isSafeValue(value: number): boolean {
 	return value >= MIN_SAVE_VALUE && value <= MAX_SAVE_VALUE;

--- a/src/model/data-validators.ts
+++ b/src/model/data-validators.ts
@@ -2,7 +2,7 @@
 
 import { assert } from '../helpers/assertions';
 
-import { isFulfilledData, SeriesDataItemTypeMap } from './data-consumer';
+import { isFulfilledData, OhlcData, SeriesDataItemTypeMap } from './data-consumer';
 import { IHorzScaleBehavior } from './ihorz-scale-behavior';
 import { CreatePriceLineOptions } from './price-line-options';
 import { SeriesType } from './series-options';
@@ -67,31 +67,21 @@ function checkBarItem<HorzScaleItem>(
 	if (!isFulfilledData(barItem)) {
 		return;
 	}
+	(['open', 'high', 'low', 'close'] as (keyof OhlcData)[]).forEach((key: keyof OhlcData) => {
+		assert(
+			typeof barItem[key] === 'number',
+			`${type} series item data value of ${key} must be a number, got=${typeof barItem[key]}, value=${
+				barItem[key]
+			}`
+		);
 
-	assert(
-		typeof barItem.open === 'number',
-		`${type} series item data value of open must be a number, got=${typeof barItem.open}, value=${
-			barItem.open
-		}`
-	);
-	assert(
-		typeof barItem.high === 'number',
-		`${type} series item data value of high must be a number, got=${typeof barItem.high}, value=${
-			barItem.high
-		}`
-	);
-	assert(
-		typeof barItem.low === 'number',
-		`${type} series item data value of low must be a number, got=${typeof barItem.low}, value=${
-			barItem.low
-		}`
-	);
-	assert(
-		typeof barItem.close === 'number',
-		`${type} series item data value of close must be a number, got=${typeof barItem.close}, value=${
-			barItem.close
-		}`
-	);
+		assert(
+			isSafeValue(barItem[key]),
+			`${type} series item data value of ${key} must be between ${VALUE_SAFE_RANGE}, got=${typeof barItem[key]}, value=${
+				barItem[key]
+			}`
+		);
+	});
 }
 
 function checkLineItem<HorzScaleItem>(
@@ -108,6 +98,13 @@ function checkLineItem<HorzScaleItem>(
 			lineItem.value
 		}`
 	);
+
+	assert(
+		isSafeValue(lineItem.value),
+		`${type} series item data value must be between ${VALUE_SAFE_RANGE}, got=${typeof lineItem.value}, value=${
+			lineItem.value
+		}`
+	);
 }
 
 function checkCustomItem(
@@ -116,4 +113,12 @@ function checkCustomItem(
 ): void {
 	// Nothing to check yet...
 	return;
+}
+
+const MIN_SAVE_VALUE = Number.MIN_SAFE_INTEGER / 100;
+const MAX_SAVE_VALUE = Number.MAX_SAFE_INTEGER / 100;
+const VALUE_SAFE_RANGE = `${MIN_SAVE_VALUE.toPrecision(16)} and ${MAX_SAVE_VALUE.toPrecision(16)}`;
+
+function isSafeValue(value: number): boolean {
+	return value >= MIN_SAVE_VALUE && value <= MAX_SAVE_VALUE;
 }


### PR DESCRIPTION
**Type of PR:** Fixes #1500 

**Overview of change:**

This PR adds validation for values in time series to prevent issue with browser freezing.
Browser freezing happens when price value cannot be safely represented as decimal with 2 digits after the dot.