### PR TITLE
don't draw crosshair lines after mouse leaves chart pane

### DIFF
--- a/src/model/crosshair.ts
+++ b/src/model/crosshair.ts
@@ -255,6 +255,7 @@ export class Crosshair extends DataSource {
 		this._pane = null;
 
 		this.clearOriginCoord();
+		this.updateAllViews();
 	}
 
 	public paneViews(pane: Pane): readonly IPaneView[] {

--- a/tests/e2e/graphics/helpers/screenshoter.ts
+++ b/tests/e2e/graphics/helpers/screenshoter.ts
@@ -9,6 +9,8 @@ import puppeteer, {
 	Page,
 } from 'puppeteer';
 
+import { runInteractionsOnPage } from '../../helpers/perform-interactions';
+
 import { MouseEventParams } from '../../../../src/api/ichart-api';
 import { TestCaseWindow } from './testcase-window-type';
 
@@ -107,6 +109,8 @@ export class Screenshoter {
 				await page.mouse.move(viewportWidth / 2, viewportHeight / 2);
 				await waitForMouseMove;
 			}
+
+			await runInteractionsOnPage(page);
 
 			// let's wait until the next af to make sure that everything is repainted
 			await page.evaluate(() => {

--- a/tests/e2e/graphics/test-cases/.eslintrc.cjs
+++ b/tests/e2e/graphics/test-cases/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
 		node: false,
 	},
 	rules: {
-		'no-unused-vars': ['error', { varsIgnorePattern: '^runTestCase$', args: 'none' }],
+		'no-unused-vars': ['error', { varsIgnorePattern: '^(runTestCase|beforeInteractions|after(Initial|Final)Interactions|(initial|final)InteractionsToPerform)$', args: 'none' }],
 	},
 	globals: {
 		LightweightCharts: false,

--- a/tests/e2e/graphics/test-cases/dont-draw-crosshair-lines-when-mouse-leave.js
+++ b/tests/e2e/graphics/test-cases/dont-draw-crosshair-lines-when-mouse-leave.js
@@ -1,0 +1,56 @@
+/*
+	When the mouse leaves the chart pane then the crosshair line should not be drawn
+*/
+
+window.ignoreMouseMove = true;
+
+function initialInteractionsToPerform() {
+	return [{ action: 'moveMouseCenter', target: 'container' }];
+}
+
+function finalInteractionsToPerform() {
+	return [{ action: 'moveMouseBottomRight', target: 'container' }];
+}
+
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2023, 0, 1, 0, 0, 0, 0));
+
+	for (let i = 0; i < 12; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCMonth(time.getUTCMonth() + 1);
+	}
+
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(
+		container,
+		{
+			layout: { attributionLogo: false },
+			height: 450,
+			width: 450,
+			crosshair: {
+				vertLine: {
+					color: 'red',
+					width: 4,
+					style: 0,
+				},
+				horzLine: {
+					color: 'red',
+					width: 4,
+					style: 0,
+				},
+			},
+		}
+	);
+
+	const series = chart.addSeries(LightweightCharts.LineSeries);
+	series.setData(generateData());
+	chart.timeScale().fitContent();
+}

--- a/tests/e2e/interactions/interactions-test-cases.ts
+++ b/tests/e2e/interactions/interactions-test-cases.ts
@@ -11,10 +11,7 @@ import puppeteer, {
 } from 'puppeteer';
 
 import { TestCase } from '../helpers/get-test-cases';
-import {
-	Interaction,
-	performInteractions,
-} from '../helpers/perform-interactions';
+import { Interaction, runInteractionsOnPage } from '../helpers/perform-interactions';
 import { retryTest } from '../helpers/retry-tests';
 
 import { getTestCases } from './helpers/get-interaction-test-cases';
@@ -101,47 +98,7 @@ void describe('Interactions tests', () => {
 					return (window as unknown as InternalWindow).finishedSetup;
 				});
 
-				const initialInteractionsToPerform = await page.evaluate(() => {
-					if (!(window as unknown as InternalWindow).initialInteractionsToPerform) {
-						return [];
-					}
-					return (window as unknown as InternalWindow).initialInteractionsToPerform();
-				});
-
-				await performInteractions(page, initialInteractionsToPerform);
-
-				await page.evaluate(() => {
-					if ((window as unknown as InternalWindow).afterInitialInteractions) {
-						return (
-							window as unknown as InternalWindow
-						).afterInitialInteractions?.();
-					}
-					return new Promise<void>((resolve: () => void) => {
-						window.requestAnimationFrame(() => {
-							setTimeout(resolve, 50);
-						});
-					});
-				});
-
-				const finalInteractionsToPerform = await page.evaluate(() => {
-					if (!(window as unknown as InternalWindow).finalInteractionsToPerform) {
-						return [];
-					}
-					return (window as unknown as InternalWindow).finalInteractionsToPerform();
-				});
-
-				if (finalInteractionsToPerform && finalInteractionsToPerform.length > 0) {
-					await performInteractions(page, finalInteractionsToPerform);
-				}
-
-				await page.evaluate(() => {
-					return new Promise<void>((resolve: () => void) => {
-						(window as unknown as InternalWindow).afterFinalInteractions();
-						window.requestAnimationFrame(() => {
-							setTimeout(resolve, 50);
-						});
-					});
-				});
+				await runInteractionsOnPage(page);
 
 				await page.close();
 


### PR DESCRIPTION
**Type of PR:** bugfix (regression added during v4 to v5 changes)

**PR checklist:**

- [ ] Addresses an existing issue: (no issue created)
- [x] Includes tests
- `N/A` Documentation update

**Overview of change:**
When the mouse (pointer) leaves the chart pane then it is expected that the chart should stop drawing the crosshair.

A one-line code change to trigger a `updateAllViews` was all that was required to fix the issue.