### PR TITLE
Fix: fix puppeteer installation

### DIFF
--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -9,7 +9,6 @@ module.exports = {
 	 * can reliably find the installed chrome binary
 	 */
 	cacheDirectory: join(__dirname, 'node_modules', '.cache', 'puppeteer'),
-	downloadBaseUrl: 'https://storage.googleapis.com/chrome-for-testing-public',
 	experiments: {
 		/**
 		 * This can also be configured / overridden with the


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1769
- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**

Was removed specific url for puppeteer source, that have returned error on download request