### PR TITLE
ensure resize observer uses last entry

### DIFF
--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -880,8 +880,13 @@ export class ChartWidget<HorzScaleItem> implements IDestroyable, IChartWidgetBas
 			return false;
 		} else {
 			this._observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
-				const containerEntry = entries.find((entry: ResizeObserverEntry) => entry.target === this._container);
+				// There is no need to check if entry.target === this._container since there is only
+				// a single element being observed.
+				// and we want to use the last entry (if multiple) because it would be most up to date
+				// (since the browser may batch multiple updates).
+				const containerEntry = entries[entries.length - 1];
 				if (!containerEntry) {
+					// this may be undefined if the entries array was empty.
 					return;
 				}
 				this.resize(containerEntry.contentRect.width, containerEntry.contentRect.height);


### PR DESCRIPTION
**Type of PR:** bugfix / enhancement

**Overview of change:**
The issue with using ⁠`find()` instead of the last entry is that `ResizeObserver` may batch multiple resize notifications for the same element in a single callback. The last entry in the array represents the most recent size change, making it more accurate for the current state. Using `⁠find()` could potentially return an outdated intermediate size value.

Additionally, since this usage of `ResizeObserver` is configured to observe only one element (`this._container`), there's no need to search for the matching entry - the callback will only receive entries for that element, making ⁠`entries[entries.length - 1]` the most efficient approach.