### PR TITLE
suppress ResizeObserver error overlay in dev mode

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -406,6 +406,7 @@ const getConfig = async () => {
 			],
 			...versions.map(typedocPluginForVersion),
 			'./plugins/enhanced-codeblock',
+			'./plugins/suppress-resize-observer-error',
 		],
 	};
 

--- a/website/plugins/suppress-resize-observer-error/index.js
+++ b/website/plugins/suppress-resize-observer-error/index.js
@@ -1,0 +1,32 @@
+/*
+	This suppresses the 'ResizeObserver loop completed with undelivered notification'
+	error which can appear when viewing the website in developer mode. This only
+	prevents the error appearing on the overlay. It will still be visible in the console.
+*/
+module.exports = function suppressResizeObserverError() {
+	return {
+		name: 'suppress-resize-observer-error',
+		configureWebpack(_config, isServer, _utils) {
+			if (!isServer) {
+				return {
+					devServer: {
+						client: {
+							overlay: {
+								runtimeErrors: error => {
+									if (
+										error.message.includes('ResizeObserver') &&
+										error.message.includes('undelivered notification')
+									) {
+										return false;
+									}
+									return true;
+								},
+							},
+						},
+					},
+				};
+			}
+			return {};
+		},
+	};
+};


### PR DESCRIPTION
**Note: This doesn't affect the library code, or built version of the documentation. Purely for development mode of the website.**

Suppresses the "ResizeObserver loop completed with undelivered notification" error overlay that appears during development. This is a harmless error that occurs during React development mode and doesn't affect production builds.

The error will still be logged to the console but won't disrupt development by showing the error overlay.
