### PR TITLE
Performance Optimization for Charts with Markers and Large Datasets

### DIFF
--- a/src/plugins/series-markers/primitive.ts
+++ b/src/plugins/series-markers/primitive.ts
@@ -31,6 +31,7 @@ export class SeriesMarkersPrimitive<HorzScaleItem> implements ISeriesPrimitive<H
 	private _autoScaleMargins: AutoScaleMargins | null = null;
 	private _markersPositions: MarkerPositions | null = null;
 	private _cachedBarSpacing: number | null = null;
+	private _recalculationRequired: boolean = true;
 
 	public attached(param: SeriesAttachedParameter<HorzScaleItem>): void {
 		this._recalculateMarkers();
@@ -39,6 +40,7 @@ export class SeriesMarkersPrimitive<HorzScaleItem> implements ISeriesPrimitive<H
 		this._paneView = new SeriesMarkersPaneView(this._series, ensureNotNull(this._chart));
 		this._requestUpdate = param.requestUpdate;
 		this._series.subscribeDataChanged((scope: DataChangedScope) => this._onDataChanged(scope));
+		this._recalculationRequired = true;
 		this.requestUpdate();
 	}
 
@@ -59,6 +61,7 @@ export class SeriesMarkersPrimitive<HorzScaleItem> implements ISeriesPrimitive<H
 	}
 
 	public setMarkers(markers: SeriesMarker<HorzScaleItem>[]): void {
+		this._recalculationRequired = true;
 		this._markers = markers;
 		this._recalculateMarkers();
 		this._autoScaleMarginsInvalidated = true;
@@ -142,7 +145,7 @@ export class SeriesMarkersPrimitive<HorzScaleItem> implements ISeriesPrimitive<H
 	}
 
 	private _recalculateMarkers(): void {
-		if (!this._chart || !this._series) {
+		if (!this._recalculationRequired || !this._chart || !this._series) {
 			return;
 		}
 		const timeScale = this._chart.timeScale();
@@ -172,6 +175,7 @@ export class SeriesMarkersPrimitive<HorzScaleItem> implements ISeriesPrimitive<H
 				originalTime: marker.time,
 			};
 		});
+		this._recalculationRequired = false;
 	}
 
 	private _updateAllViews(updateType?: UpdateType): void {
@@ -183,6 +187,7 @@ export class SeriesMarkersPrimitive<HorzScaleItem> implements ISeriesPrimitive<H
 	}
 
 	private _onDataChanged(scope: DataChangedScope): void {
+		this._recalculationRequired = true;
 		this.requestUpdate();
 	}
 }

--- a/website/docs/release-notes.md
+++ b/website/docs/release-notes.md
@@ -16,6 +16,18 @@ toc_max_heading_level: 2
 
 <!-- markdownlint-disable no-emphasis-as-heading -->
 <!-- ^ using emphasis as headings so we don't have duplicate headers -->
+<!--
+
+Unreleased
+
+## 5.0.4
+
+**Improvements**
+
+- Fixed performance degradation when adding series markers to charts with large datasets (15,000+ data points) by optimizing marker calculations to only run when necessary. (PR [#1835](https://github.com/tradingview/lightweight-charts/pull/1835), fixes [#1808](https://github.com/tradingview/lightweight-charts/issues/1808))
+
+-->
+
 ## 5.0.3
 
 **Bug Fixes**


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1808
- `N/A` ~Includes tests~
- `N/A` ~Documentation update~

## Summary
This PR addresses a significant performance degradation issue when adding markers to charts with large datasets (15,000+ data points) in Lightweight Charts™ v5.0.X.

## Problem
When rendering charts with large datasets (particularly 5-minute interval candles over a year, ~60,000+ data points), adding even a single marker causes severe performance issues:
- Extremely laggy scrolling
- Significantly impacted zooming responsiveness
- Delayed and unresponsive cursor movement

The issue becomes noticeable at approximately 15,000 data points with just one marker added.

## Root Cause
The performance bottleneck was identified in the `_recalculateMarkers` function running on every pane update within the series-markers plugin, regardless of whether recalculation was necessary.

## Solution
This PR optimizes marker calculations by:
1. Adding a `_recalculationRequired` flag to track when recalculation is needed
2. Only running `_recalculateMarkers` when this flag is true
3. Setting the flag to true only when necessary:
   - Data changes
   - Markers are set/updated
   - Component is attached

## Testing
- Verified smooth performance with 60,000+ data points and markers
- Confirmed all chart interactions (scroll, zoom, cursor movement) remain responsive
- Tested with various marker configurations to ensure correct rendering

## References
- Original issue: [#1808](https://github.com/tradingview/lightweight-charts/issues/1808)
- Reproduction example: [Glitch demo](https://glitch.com/edit/#!/lwc-1808-issue)
