### PR TITLE
Prevent crosshair marker visible on load

### DIFF
--- a/debug/default/index.html
+++ b/debug/default/index.html
@@ -3,7 +3,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
-  <body>
+  <body style="padding: 0; margin: 0">
+    <div id="container" style="position: absolute; width: 100%; height: 100%"></div>
     <script type="module" src="index.ts"></script>
   </body>
 </html>

--- a/debug/default/index.ts
+++ b/debug/default/index.ts
@@ -2,32 +2,15 @@ import {
 	AreaSeries,
 	CandlestickSeries,
 	ChartOptions,
-	ColorType,
 	createChart,
 	DeepPartial,
 } from "lightweight-charts";
 
 const chartOptions = {
-	layout: {
-		textColor: "black",
-		background: {
-			type: ColorType.Solid,
-			color: "white",
-		},
-	},
+	autosize: true,
 } satisfies DeepPartial<ChartOptions>;
 
-const chart = createChart(
-	(() => {
-		const containerElement = document.createElement("div");
-		containerElement.style.width = "1024px";
-		containerElement.style.height = "768px";
-		document.body.appendChild(containerElement);
-
-		return containerElement;
-	})(),
-	chartOptions
-);
+const chart = createChart('container', chartOptions);
 
 const areaSeries = chart.addSeries(AreaSeries, {
 	lineColor: "#2962FF",

--- a/src/model/crosshair.ts
+++ b/src/model/crosshair.ts
@@ -136,7 +136,7 @@ export class Crosshair extends DataSource {
 	private _pane: Pane | null = null;
 	private _price: number = NaN;
 	private _index: TimePointIndex = 0 as TimePointIndex;
-	private _visible: boolean = true;
+	private _visible: boolean = false; // initially the crosshair should not be visible, until the user interacts.
 	private readonly _model: IChartModelBase;
 	private _priceAxisViews: Map<PriceScale, CrosshairPriceAxisView> = new Map();
 	private readonly _timeAxisView: CrosshairTimeAxisView;

--- a/tests/e2e/graphics/test-cases/crosshair-visible-startup.js
+++ b/tests/e2e/graphics/test-cases/crosshair-visible-startup.js
@@ -1,0 +1,32 @@
+// Ignore the mouse movement because we need to test without the mouse
+window.ignoreMouseMove = true;
+
+function runTestCase(container) {
+	// Prevent the chart from getting a mouse event;
+	container.style.setProperty('pointer-events', 'none');
+
+	const chart = (window.chart = LightweightCharts.createChart(container, {
+		layout: { attributionLogo: false },
+	}));
+
+	const lineSeries = chart.addSeries(LightweightCharts.LineSeries, {
+		crosshairMarkerVisible: true,
+		crosshairMarkerRadius: 12,
+		crosshairMarkerBackgroundColor: 'red',
+	});
+
+	lineSeries.setData([
+		{ time: '2018-12-20', value: 10 },
+		{ time: '2018-12-21', value: 16 },
+		{ time: '2018-12-22', value: 21 },
+		{ time: '2018-12-23', value: 25 },
+		{ time: '2018-12-24', value: 28 },
+		{ time: '2018-12-25', value: 30 },
+		{ time: '2018-12-26', value: 28 },
+		{ time: '2018-12-27', value: 25 },
+		{ time: '2018-12-28', value: 21 },
+		{ time: '2018-12-29', value: 16 },
+		{ time: '2018-12-30', value: 10 },
+		{ time: '2018-12-31', value: 3 },
+	]);
+}


### PR DESCRIPTION
**Type of PR:** bugfix

**PR checklist:**

-  `N/A` ~Addresses an existing issue: fixes #~ Addresses an unreported bug
- [x] Includes tests
- `N/A` ~Documentation update~

**Overview of change:**
In version 4 of the library when the chart is created and there has been no interaction by the user's mouse on the chart then the crosshair (lines and marker) would not be visible. On version 5, the crosshair would be visible on the first data point of the chart (index `0`).

This behaviour has been reverted to the version 4 behaviour.
