### PR TITLE
feat: boundaries price marks

### DIFF
--- a/src/api/iprice-scale-api.ts
+++ b/src/api/iprice-scale-api.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from '../helpers/strict-type-checks';
 
 import { PriceScaleOptions } from '../model/price-scale';
+import { IRange } from '../model/time-data';
 
 /** Interface to control chart's price scale */
 export interface IPriceScaleApi {
@@ -22,4 +23,25 @@ export interface IPriceScaleApi {
 	 * Returns a width of the price scale if it's visible or 0 if invisible.
 	 */
 	width(): number;
+
+	/**
+	 * Sets the visible range of the price scale.
+	 *
+	 * @param range - The visible range to set, with `from` and `to` properties.
+	 */
+	setVisibleRange(range: IRange<number>): void;
+
+	/**
+	 * Returns the visible range of the price scale.
+	 *
+	 * @returns The visible range of the price scale, or null if the range is not set.
+	 */
+	getVisibleRange(): IRange<number> | null;
+
+	/**
+	 * Sets the auto scale mode of the price scale.
+	 *
+	 * @param on - If true, enables auto scaling; if false, disables it.
+	 */
+	setAutoScale(on: boolean): void;
 }

--- a/src/api/options/price-scale-options-defaults.ts
+++ b/src/api/options/price-scale-options-defaults.ts
@@ -15,5 +15,5 @@ export const priceScaleOptionsDefaults: PriceScaleOptions = {
 		top: 0.2,
 	},
 	minimumWidth: 0,
-	boundaryMarksVisible: false,
+	ensureEdgeTickMarksVisible: false,
 };

--- a/src/api/options/price-scale-options-defaults.ts
+++ b/src/api/options/price-scale-options-defaults.ts
@@ -15,4 +15,5 @@ export const priceScaleOptionsDefaults: PriceScaleOptions = {
 		top: 0.2,
 	},
 	minimumWidth: 0,
+	boundaryMarksVisible: false,
 };

--- a/src/api/price-scale-api.ts
+++ b/src/api/price-scale-api.ts
@@ -4,6 +4,7 @@ import { ensureNotNull } from '../helpers/assertions';
 import { DeepPartial } from '../helpers/strict-type-checks';
 
 import { isDefaultPriceScale } from '../model/default-price-scale';
+import { PriceRangeImpl } from '../model/price-range-impl';
 import { PriceScale, PriceScaleOptions } from '../model/price-scale';
 
 import { IPriceScaleApi } from './iprice-scale-api';
@@ -33,6 +34,22 @@ export class PriceScaleApi implements IPriceScaleApi {
 		}
 
 		return this._chartWidget.getPriceAxisWidth(this._priceScaleId);
+	}
+
+	public setVisibleRange(range: { from: number; to: number }): void {
+		this._priceScale().setPriceRange(new PriceRangeImpl(range.from, range.to));
+	}
+
+	public getVisibleRange(): { from: number; to: number } | null {
+		const range = this._priceScale().priceRange();
+		return range === null ? null : {
+			from: range.minValue(),
+			to: range.maxValue(),
+		};
+	}
+
+	public setAutoScale(on: boolean): void {
+		this.applyOptions({ autoScale: on });
 	}
 
 	private _priceScale(): PriceScale {

--- a/src/api/price-scale-api.ts
+++ b/src/api/price-scale-api.ts
@@ -51,15 +51,7 @@ export class PriceScaleApi implements IPriceScaleApi {
 	}
 
 	public setAutoScale(on: boolean): void {
-		const currentRange = on ? null : this.getVisibleRange();
-
 		this.applyOptions({ autoScale: on });
-
-		if (currentRange !== null) {
-			this._priceScale().setPriceRange(
-				new PriceRangeImpl(currentRange.from, currentRange.to)
-			);
-		}
 	}
 
 	private _priceScale(): PriceScale {

--- a/src/api/price-scale-api.ts
+++ b/src/api/price-scale-api.ts
@@ -39,7 +39,7 @@ export class PriceScaleApi implements IPriceScaleApi {
 
 	public setVisibleRange(range: IRange<number>): void {
 		this.setAutoScale(false);
-		this._priceScale().setPriceRange(new PriceRangeImpl(range.from, range.to));
+		this._priceScale().setCustomPriceRange(new PriceRangeImpl(range.from, range.to));
 	}
 
 	public getVisibleRange(): IRange<number> | null {

--- a/src/api/price-scale-api.ts
+++ b/src/api/price-scale-api.ts
@@ -6,6 +6,7 @@ import { DeepPartial } from '../helpers/strict-type-checks';
 import { isDefaultPriceScale } from '../model/default-price-scale';
 import { PriceRangeImpl } from '../model/price-range-impl';
 import { PriceScale, PriceScaleOptions } from '../model/price-scale';
+import { IRange } from '../model/time-data';
 
 import { IPriceScaleApi } from './iprice-scale-api';
 
@@ -36,11 +37,12 @@ export class PriceScaleApi implements IPriceScaleApi {
 		return this._chartWidget.getPriceAxisWidth(this._priceScaleId);
 	}
 
-	public setVisibleRange(range: { from: number; to: number }): void {
+	public setVisibleRange(range: IRange<number>): void {
+		this.setAutoScale(false);
 		this._priceScale().setPriceRange(new PriceRangeImpl(range.from, range.to));
 	}
 
-	public getVisibleRange(): { from: number; to: number } | null {
+	public getVisibleRange(): IRange<number> | null {
 		const range = this._priceScale().priceRange();
 		return range === null ? null : {
 			from: range.minValue(),
@@ -49,7 +51,15 @@ export class PriceScaleApi implements IPriceScaleApi {
 	}
 
 	public setAutoScale(on: boolean): void {
+		const currentRange = on ? null : this.getVisibleRange();
+
 		this.applyOptions({ autoScale: on });
+
+		if (currentRange !== null) {
+			this._priceScale().setPriceRange(
+				new PriceRangeImpl(currentRange.from, currentRange.to)
+			);
+		}
 	}
 
 	private _priceScale(): PriceScale {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export const customSeriesDefaultOptions: CustomSeriesOptions = {
 	...seriesOptionsDefaults,
 	...customStyleDefaults,
 };
-export { ICustomSeriesPaneView, ICustomSeriesPaneRenderer, CustomBarItemData, CustomData } from './model/icustom-series';
+export type { ICustomSeriesPaneView, ICustomSeriesPaneRenderer, CustomBarItemData, CustomData } from './model/icustom-series';
 
 export { createChart, createChartEx, defaultHorzScaleBehavior } from './api/create-chart';
 export { createYieldCurveChart } from './api/create-yield-curve-chart';

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -31,7 +31,7 @@ import {
 	toPercent,
 	toPercentRange,
 } from './price-scale-conversions';
-import { PriceTickMarkBuilder } from './price-tick-mark-builder';
+import { EdgeMarksOptions, PriceTickMarkBuilder } from './price-tick-mark-builder';
 import { RangeImpl } from './range-impl';
 import { sortSources } from './sort-sources';
 import { SeriesItemsIndexesRange, TimePointIndex } from './time-data';
@@ -196,7 +196,7 @@ export interface PriceScaleOptions {
 	/**
 	 * Boundary marks are the marks that are drawn at the top and bottom of the price scale.
 	 */
-	boundaryMarksVisible: boolean;
+	ensureEdgeTickMarksVisible: boolean;
 }
 
 interface RangeCache {
@@ -261,9 +261,7 @@ export class PriceScale {
 			100,
 			this._coordinateToLogical.bind(this),
 			this._logicalToCoordinate.bind(this),
-			options.boundaryMarksVisible ? {
-				getPadding: () => this.fontSize() / 2,
-			} : undefined
+			this._getEdgeMarksOptions()
 		);
 	}
 
@@ -842,9 +840,7 @@ export class PriceScale {
 			base,
 			this._coordinateToLogical.bind(this),
 			this._logicalToCoordinate.bind(this),
-			this._options.boundaryMarksVisible ? {
-				getPadding: () => this.fontSize() / 2,
-			} : undefined
+			this._getEdgeMarksOptions()
 		);
 
 		this._markBuilder.rebuildTickMarks();
@@ -968,6 +964,11 @@ export class PriceScale {
 			}
 		}
 
+		if (this._visibleEdgeMarks()) {
+			marginAbove = Math.max(marginAbove, this._getEdgeMarksPadding());
+			marginBelow = Math.max(marginBelow, this._getEdgeMarksPadding());
+		}
+
 		if (marginAbove !== this._marginAbove || marginBelow !== this._marginBelow) {
 			this._marginAbove = marginAbove;
 			this._marginBelow = marginBelow;
@@ -1050,5 +1051,17 @@ export class PriceScale {
 
 	private _formatPercentage(percentage: number, fallbackFormatter?: IPriceFormatter): string {
 		return this._formatValue(percentage, this._localizationOptions.percentageFormatter, fallbackFormatter);
+	}
+
+	private _visibleEdgeMarks(): boolean {
+		return this._options.ensureEdgeTickMarksVisible;
+	}
+
+	private _getEdgeMarksPadding(): number {
+		return this.fontSize() / 2;
+	}
+
+	private _getEdgeMarksOptions(): undefined | EdgeMarksOptions {
+		return this._visibleEdgeMarks() ? { getPadding: () => this._getEdgeMarksPadding() } : undefined;
 	}
 }

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -195,10 +195,10 @@ export interface PriceScaleOptions {
 
 	/**
 	 * Ensures that tick marks are always visible at the very top and bottom of the price scale,
-	 * regardless of the data range. When enabled, a tick mark will be drawn at both edges of the scale, 
+	 * regardless of the data range. When enabled, a tick mark will be drawn at both edges of the scale,
 	 * providing clear boundary indicators.
 	 *
-	 * @default false
+	 * @defaultValue false
 	 */
 	ensureEdgeTickMarksVisible: boolean;
 }

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -925,6 +925,10 @@ export class PriceScale {
 
 	// eslint-disable-next-line complexity
 	private _recalculatePriceRangeImpl(): void {
+		if (!this.isAutoScale()) {
+			return;
+		}
+
 		const visibleBars = this._invalidatedForRange.visibleBars;
 		if (visibleBars === null) {
 			return;

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -321,6 +321,10 @@ export class PriceScale {
 		return this._options.mode === PriceScaleMode.IndexedTo100;
 	}
 
+	public getLogFormula(): LogFormula {
+		return this._logFormula;
+	}
+
 	public mode(): PriceScaleState {
 		return {
 			autoScale: this._options.autoScale,

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -925,7 +925,7 @@ export class PriceScale {
 
 	// eslint-disable-next-line complexity
 	private _recalculatePriceRangeImpl(): void {
-		if (!this.isAutoScale()) {
+		if (!this.isAutoScale() && this.priceRange() !== null) {
 			return;
 		}
 

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -194,7 +194,11 @@ export interface PriceScaleOptions {
 	minimumWidth: number;
 
 	/**
-	 * Boundary marks are the marks that are drawn at the top and bottom of the price scale.
+	 * Ensures that tick marks are always visible at the very top and bottom of the price scale,
+	 * regardless of the data range. When enabled, a tick mark will be drawn at both edges of the scale, 
+	 * providing clear boundary indicators.
+	 *
+	 * @default false
 	 */
 	ensureEdgeTickMarksVisible: boolean;
 }

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -263,7 +263,6 @@ export class PriceScale {
 			this._logicalToCoordinate.bind(this),
 			options.boundaryMarksVisible ? {
 				getPadding: () => this.fontSize() / 2,
-				getMinDist: () => this.fontSize() * 2,
 			} : undefined
 		);
 	}
@@ -845,7 +844,6 @@ export class PriceScale {
 			this._logicalToCoordinate.bind(this),
 			this._options.boundaryMarksVisible ? {
 				getPadding: () => this.fontSize() / 2,
-				getMinDist: () => this.fontSize() * 2,
 			} : undefined
 		);
 

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -192,6 +192,11 @@ export interface PriceScaleOptions {
 	 * @defaultValue 0
 	 */
 	minimumWidth: number;
+
+	/**
+	 * Boundary marks are the marks that are drawn at the top and bottom of the price scale.
+	 */
+	boundaryMarksVisible: boolean;
 }
 
 interface RangeCache {
@@ -251,7 +256,16 @@ export class PriceScale {
 		this._layoutOptions = layoutOptions;
 		this._localizationOptions = localizationOptions;
 		this._colorParser = colorParser;
-		this._markBuilder = new PriceTickMarkBuilder(this, 100, this._coordinateToLogical.bind(this), this._logicalToCoordinate.bind(this));
+		this._markBuilder = new PriceTickMarkBuilder(
+			this,
+			100,
+			this._coordinateToLogical.bind(this),
+			this._logicalToCoordinate.bind(this),
+			options.boundaryMarksVisible ? {
+				getPadding: () => this.fontSize() / 2,
+				getMinDist: () => this.fontSize() * 2,
+			} : undefined
+		);
 	}
 
 	public id(): string {
@@ -828,7 +842,11 @@ export class PriceScale {
 			this,
 			base,
 			this._coordinateToLogical.bind(this),
-			this._logicalToCoordinate.bind(this)
+			this._logicalToCoordinate.bind(this),
+			this._options.boundaryMarksVisible ? {
+				getPadding: () => this.fontSize() / 2,
+				getMinDist: () => this.fontSize() * 2,
+			} : undefined
 		);
 
 		this._markBuilder.rebuildTickMarks();

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -233,6 +233,8 @@ export class PriceScale {
 	private _priceRangeSnapshot: PriceRangeImpl | null = null;
 	private _invalidatedForRange: RangeCache = { isValid: false, visibleBars: null };
 
+	private _isCustomPriceRange: boolean = false;
+
 	private _marginAbove: number = 0;
 	private _marginBelow: number = 0;
 
@@ -307,6 +309,10 @@ export class PriceScale {
 
 	public isAutoScale(): boolean {
 		return this._options.autoScale;
+	}
+
+	public isCustomPriceRange(): boolean {
+		return this._isCustomPriceRange;
 	}
 
 	public isLog(): boolean {
@@ -438,6 +444,11 @@ export class PriceScale {
 
 		this._marksCache = null;
 		this._priceRange = newPriceRange;
+	}
+
+	public setCustomPriceRange(newPriceRange: PriceRangeImpl | null): void {
+		this.setPriceRange(newPriceRange);
+		this._toggleCustomPriceRange(newPriceRange !== null);
 	}
 
 	public isEmpty(): boolean {
@@ -868,6 +879,10 @@ export class PriceScale {
 		return this._colorParser;
 	}
 
+	private _toggleCustomPriceRange(v: boolean): void {
+		this._isCustomPriceRange = v;
+	}
+
 	private _topMarginPx(): number {
 		return this.isInverted()
 			? this._options.scaleMargins.bottom * this.height() + this._marginBelow
@@ -925,7 +940,7 @@ export class PriceScale {
 
 	// eslint-disable-next-line complexity
 	private _recalculatePriceRangeImpl(): void {
-		if (!this.isAutoScale() && this.priceRange() !== null) {
+		if (this.isCustomPriceRange() && !this.isAutoScale()) {
 			return;
 		}
 
@@ -1036,8 +1051,6 @@ export class PriceScale {
 				this._logFormula = logFormulaForPriceRange(null);
 			}
 		}
-
-		this._invalidatedForRange.isValid = true;
 	}
 
 	private _getCoordinateTransformer(): PriceTransformer | null {

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -31,7 +31,7 @@ import {
 	toPercent,
 	toPercentRange,
 } from './price-scale-conversions';
-import { EdgeMarksOptions, PriceTickMarkBuilder } from './price-tick-mark-builder';
+import { PriceTickMarkBuilder } from './price-tick-mark-builder';
 import { RangeImpl } from './range-impl';
 import { sortSources } from './sort-sources';
 import { SeriesItemsIndexesRange, TimePointIndex } from './time-data';
@@ -264,8 +264,7 @@ export class PriceScale {
 			this,
 			100,
 			this._coordinateToLogical.bind(this),
-			this._logicalToCoordinate.bind(this),
-			this._getEdgeMarksOptions()
+			this._logicalToCoordinate.bind(this)
 		);
 	}
 
@@ -807,6 +806,14 @@ export class PriceScale {
 		this._dataSources.forEach((s: IPriceDataSource) => s.updateAllViews());
 	}
 
+	public hasVisibleEdgeMarks(): boolean {
+		return this._options.ensureEdgeTickMarksVisible && this.isAutoScale();
+	}
+
+	public getEdgeMarksPadding(): number {
+		return this.fontSize() / 2;
+	}
+
 	public updateFormatter(): void {
 		this._marksCache = null;
 
@@ -843,8 +850,7 @@ export class PriceScale {
 			this,
 			base,
 			this._coordinateToLogical.bind(this),
-			this._logicalToCoordinate.bind(this),
-			this._getEdgeMarksOptions()
+			this._logicalToCoordinate.bind(this)
 		);
 
 		this._markBuilder.rebuildTickMarks();
@@ -968,9 +974,9 @@ export class PriceScale {
 			}
 		}
 
-		if (this._visibleEdgeMarks()) {
-			marginAbove = Math.max(marginAbove, this._getEdgeMarksPadding());
-			marginBelow = Math.max(marginBelow, this._getEdgeMarksPadding());
+		if (this.hasVisibleEdgeMarks()) {
+			marginAbove = Math.max(marginAbove, this.getEdgeMarksPadding());
+			marginBelow = Math.max(marginBelow, this.getEdgeMarksPadding());
 		}
 
 		if (marginAbove !== this._marginAbove || marginBelow !== this._marginBelow) {
@@ -1055,17 +1061,5 @@ export class PriceScale {
 
 	private _formatPercentage(percentage: number, fallbackFormatter?: IPriceFormatter): string {
 		return this._formatValue(percentage, this._localizationOptions.percentageFormatter, fallbackFormatter);
-	}
-
-	private _visibleEdgeMarks(): boolean {
-		return this._options.ensureEdgeTickMarksVisible;
-	}
-
-	private _getEdgeMarksPadding(): number {
-		return this.fontSize() / 2;
-	}
-
-	private _getEdgeMarksOptions(): undefined | EdgeMarksOptions {
-		return this._visibleEdgeMarks() ? { getPadding: () => this._getEdgeMarksPadding() } : undefined;
 	}
 }

--- a/src/model/price-tick-mark-builder.ts
+++ b/src/model/price-tick-mark-builder.ts
@@ -95,17 +95,16 @@ export class PriceTickMarkBuilder {
 		}
 
 		this._updateMarks(
+			firstValue,
 			high,
 			low,
-			firstValue,
 			minCoord,
 			maxCoord
 		);
 
 		if (this._boundariesMarks) {
 			this._extendWithBoundariesMarks(
-				high,
-				low,
+				firstValue,
 				minCoord,
 				maxCoord,
 				this._boundariesMarks.getMinDist(),
@@ -126,7 +125,7 @@ export class PriceTickMarkBuilder {
 		return Math.ceil(this._fontHeight() * TICK_DENSITY);
 	}
 
-	private _updateMarks(high: number, low: number, firstValue: number, minCoord: number, maxCoord: number): void {
+	private _updateMarks(firstValue: number, high: number, low: number, minCoord: number, maxCoord: number): void {
 		const marks = this._marks;
 		const priceScale = this._priceScale;
 
@@ -176,8 +175,7 @@ export class PriceTickMarkBuilder {
 	}
 
 	private _extendWithBoundariesMarks(
-		high: number,
-		low: number,
+		firstValue: number,
 		minCoord: number,
 		maxCoord: number,
 		minDist: number,
@@ -190,14 +188,18 @@ export class PriceTickMarkBuilder {
 		}
 		marks.unshift({
 			coord: (minCoord + padding) as Coordinate,
-			label: this._priceScale.formatLogical(high),
+			label: this._priceScale.formatLogical(
+				this._coordinateToLogicalFunc(minCoord + padding, firstValue)
+			),
 		});
 		if (maxCoord - marks[marks.length - 1].coord < minDist) {
 			marks.pop();
 		}
 		marks.push({
 			coord: (maxCoord - padding) as Coordinate,
-			label: this._priceScale.formatLogical(low),
+			label: this._priceScale.formatLogical(
+				this._coordinateToLogicalFunc(maxCoord - padding, firstValue)
+			),
 		});
 	}
 }

--- a/src/model/price-tick-mark-builder.ts
+++ b/src/model/price-tick-mark-builder.ts
@@ -181,18 +181,12 @@ export class PriceTickMarkBuilder {
 		const marks = this._marks;
 
 		// top boundary
-
 		const topMark = this._computeBoundaryPriceMark(
 			firstValue,
 			minCoord,
 			minPadding,
 			maxPadding
 		);
-
-		if (marks[0].coord - topMark.coord < maxPadding) {
-			marks.shift();
-		}
-		marks.unshift(topMark);
 
 		// bottom boundary
 		const bottomMark = this._computeBoundaryPriceMark(
@@ -201,9 +195,16 @@ export class PriceTickMarkBuilder {
 			-maxPadding,
 			-minPadding
 		);
-		if (bottomMark.coord - marks[marks.length - 1].coord < maxPadding) {
+
+		if (marks.length > 0 && marks[0].coord - topMark.coord < maxPadding) {
+			marks.shift();
+		}
+
+		if (marks.length > 0 && bottomMark.coord - marks[marks.length - 1].coord < maxPadding) {
 			marks.pop();
 		}
+
+		marks.unshift(topMark);
 		marks.push(bottomMark);
 	}
 

--- a/src/model/price-tick-mark-builder.ts
+++ b/src/model/price-tick-mark-builder.ts
@@ -8,13 +8,6 @@ import { PriceTickSpanCalculator } from './price-tick-span-calculator';
 export type CoordinateToLogicalConverter = (x: number, firstValue: number) => number;
 export type LogicalToCoordinateConverter = (x: number, firstValue: number, keepItFloat: boolean) => number;
 
-export interface EdgeMarksOptions {
-	/**
-	 * Padding for the boundaries tick marks on the price scale.
-	 */
-	getPadding: () => number;
-}
-
 const TICK_DENSITY = 2.5;
 
 export class PriceTickMarkBuilder {
@@ -23,20 +16,17 @@ export class PriceTickMarkBuilder {
 	private readonly _priceScale: PriceScale;
 	private readonly _coordinateToLogicalFunc: CoordinateToLogicalConverter;
 	private readonly _logicalToCoordinateFunc: LogicalToCoordinateConverter;
-	private readonly _edgeMarks?: undefined | EdgeMarksOptions;
 
 	public constructor(
 		priceScale: PriceScale,
 		base: number,
 		coordinateToLogicalFunc: CoordinateToLogicalConverter,
-		logicalToCoordinateFunc: LogicalToCoordinateConverter,
-		boundariesMarks?: EdgeMarksOptions
+		logicalToCoordinateFunc: LogicalToCoordinateConverter
 	) {
 		this._priceScale = priceScale;
 		this._base = base;
 		this._coordinateToLogicalFunc = coordinateToLogicalFunc;
 		this._logicalToCoordinateFunc = logicalToCoordinateFunc;
-		this._edgeMarks = boundariesMarks;
 	}
 
 	public tickSpan(high: number, low: number): number {
@@ -101,8 +91,8 @@ export class PriceTickMarkBuilder {
 			maxCoord
 		);
 
-		if (this._edgeMarks && this._shouldApplyEdgeMarks(span, low, high)) {
-			const padding = this._edgeMarks.getPadding();
+		if (priceScale.hasVisibleEdgeMarks() && this._shouldApplyEdgeMarks(span, low, high)) {
+			const padding = this._priceScale.getEdgeMarksPadding();
 			this._applyEdgeMarks(
 				firstValue,
 				span,
@@ -235,10 +225,6 @@ export class PriceTickMarkBuilder {
 	}
 
 	private _shouldApplyEdgeMarks(span: number, low: number, high: number): boolean {
-		if (!this._priceScale.isAutoScale()) {
-			return false;
-		}
-
 		const range = ensure(this._priceScale.priceRange());
 		return (range.minValue() - low < span) && (high - range.maxValue() < span);
 	}

--- a/src/model/price-tick-mark-builder.ts
+++ b/src/model/price-tick-mark-builder.ts
@@ -3,6 +3,7 @@ import { min } from '../helpers/mathex';
 
 import { Coordinate } from './coordinate';
 import { PriceMark, PriceScale } from './price-scale';
+import { convertPriceRangeFromLog } from './price-scale-conversions';
 import { PriceTickSpanCalculator } from './price-tick-span-calculator';
 
 export type CoordinateToLogicalConverter = (x: number, firstValue: number) => number;
@@ -225,7 +226,12 @@ export class PriceTickMarkBuilder {
 	}
 
 	private _shouldApplyEdgeMarks(span: number, low: number, high: number): boolean {
-		const range = ensure(this._priceScale.priceRange());
+		let range = ensure(this._priceScale.priceRange());
+
+		if (this._priceScale.isLog()) {
+			range = convertPriceRangeFromLog(range, this._priceScale.getLogFormula());
+		}
+
 		return (range.minValue() - low < span) && (high - range.maxValue() < span);
 	}
 }

--- a/tests/e2e/coverage/test-cases/price-scale/change-auto-scale.js
+++ b/tests/e2e/coverage/test-cases/price-scale/change-auto-scale.js
@@ -1,0 +1,36 @@
+function interactionsToPerform() {
+	return [];
+}
+
+async function awaitNewFrame() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+let mainSeries;
+let chart;
+
+async function beforeInteractions(container) {
+	chart = LightweightCharts.createChart(container);
+
+	mainSeries = chart.addSeries(LightweightCharts.LineSeries);
+	mainSeries.setData(generateLineData());
+
+	await awaitNewFrame();
+	chart.priceScale('right').setAutoScale(false);
+
+	await awaitNewFrame();
+	chart.priceScale('right').setAutoScale(true);
+
+	await awaitNewFrame();
+	chart.priceScale('right').setVisibleRange({ from: 10, to: 100 });
+
+	return Promise.resolve();
+}
+
+function afterInteractions() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}

--- a/tests/e2e/coverage/test-cases/price-scale/change-edge-marks.js
+++ b/tests/e2e/coverage/test-cases/price-scale/change-edge-marks.js
@@ -1,0 +1,41 @@
+function interactionsToPerform() {
+	return [];
+}
+
+async function awaitNewFrame() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+let mainSeries;
+let chart;
+
+async function beforeInteractions(container) {
+	chart = LightweightCharts.createChart(container);
+
+	mainSeries = chart.addSeries(LightweightCharts.LineSeries);
+	mainSeries.setData(generateLineData());
+
+	await awaitNewFrame();
+	chart.priceScale('right').applyOptions({
+		scaleMargins: {
+			top: 0,
+			bottom: 0,
+		},
+		ensureEdgeTickMarksVisible: true,
+	});
+
+	await awaitNewFrame();
+	chart.priceScale('right').applyOptions({
+		ensureEdgeTickMarksVisible: false,
+	});
+
+	return Promise.resolve();
+}
+
+function afterInteractions() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
@@ -1,8 +1,7 @@
 function runTestCase(container) {
 	const chartOptions = {
 		rightPriceScale: {
-			// autoScale: false,
-			mode: 0,
+			mode: LightweightCharts.PriceScaleMode.Normal,
 			scaleMargins: {
 				top: 0,
 				bottom: 0,

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
@@ -1,4 +1,10 @@
-function runTestCase(container) {
+async function awaitNewFrame() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+async function runTestCase(container) {
 	const chartOptions = {
 		rightPriceScale: {
 			mode: LightweightCharts.PriceScaleMode.Normal,
@@ -20,7 +26,11 @@ function runTestCase(container) {
 
 	chart.timeScale().fitContent();
 
+	await awaitNewFrame();
+
 	chart.priceScale('right').applyOptions({
 		autoScale: false,
 	});
+
+	await awaitNewFrame();
 }

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
@@ -1,6 +1,6 @@
 async function awaitMacroTick() {
 	return new Promise(resolve => {
-		setTimeout(resolve, 1);
+		setTimeout(resolve, 10);
 	});
 }
 

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
@@ -1,6 +1,6 @@
-async function awaitNewFrame() {
+async function awaitMacroTick() {
 	return new Promise(resolve => {
-		requestAnimationFrame(resolve);
+		setTimeout(resolve, 1);
 	});
 }
 
@@ -26,11 +26,11 @@ async function runTestCase(container) {
 
 	chart.timeScale().fitContent();
 
-	await awaitNewFrame();
+	await awaitMacroTick();
 
 	chart.priceScale('right').applyOptions({
 		autoScale: false,
 	});
 
-	await awaitNewFrame();
+	await awaitMacroTick();
 }

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-disabled-on-auto-scale-off.js
@@ -1,0 +1,27 @@
+function runTestCase(container) {
+	const chartOptions = {
+		rightPriceScale: {
+			// autoScale: false,
+			mode: 0,
+			scaleMargins: {
+				top: 0,
+				bottom: 0,
+			},
+			ensureEdgeTickMarksVisible: true,
+		},
+	};
+
+	const chart = (window.chart = LightweightCharts.createChart(container, chartOptions));
+	const series = chart.addSeries(LightweightCharts.CandlestickSeries);
+
+	series.setData([
+		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
+		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
+	]);
+
+	chart.timeScale().fitContent();
+
+	chart.priceScale('right').applyOptions({
+		autoScale: false,
+	});
+}

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
@@ -1,6 +1,6 @@
-async function awaitNewFrame() {
+async function awaitMacroTick() {
 	return new Promise(resolve => {
-		requestAnimationFrame(resolve);
+		setTimeout(resolve, 1);
 	});
 }
 
@@ -27,11 +27,11 @@ async function runTestCase(container) {
 
 	chart.timeScale().fitContent();
 
-	await awaitNewFrame();
+	await awaitMacroTick();
 
 	chart.priceScale('right').applyOptions({
 		autoScale: true,
 	});
 
-	await awaitNewFrame();
+	await awaitMacroTick();
 }

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
@@ -1,6 +1,6 @@
 async function awaitMacroTick() {
 	return new Promise(resolve => {
-		setTimeout(resolve, 1);
+		setTimeout(resolve, 10);
 	});
 }
 

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
@@ -2,7 +2,7 @@ function runTestCase(container) {
 	const chartOptions = {
 		rightPriceScale: {
 			autoScale: false,
-			mode: 0,
+			mode: LightweightCharts.PriceScaleMode.Normal,
 			scaleMargins: {
 				top: 0,
 				bottom: 0,

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
@@ -1,4 +1,10 @@
-function runTestCase(container) {
+async function awaitNewFrame() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+async function runTestCase(container) {
 	const chartOptions = {
 		rightPriceScale: {
 			autoScale: false,
@@ -21,7 +27,11 @@ function runTestCase(container) {
 
 	chart.timeScale().fitContent();
 
+	await awaitNewFrame();
+
 	chart.priceScale('right').applyOptions({
 		autoScale: true,
 	});
+
+	await awaitNewFrame();
 }

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-enabled-on-auto-scale-on.js
@@ -1,0 +1,27 @@
+function runTestCase(container) {
+	const chartOptions = {
+		rightPriceScale: {
+			autoScale: false,
+			mode: 0,
+			scaleMargins: {
+				top: 0,
+				bottom: 0,
+			},
+			ensureEdgeTickMarksVisible: true,
+		},
+	};
+
+	const chart = (window.chart = LightweightCharts.createChart(container, chartOptions));
+	const series = chart.addSeries(LightweightCharts.CandlestickSeries);
+
+	series.setData([
+		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
+		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
+	]);
+
+	chart.timeScale().fitContent();
+
+	chart.priceScale('right').applyOptions({
+		autoScale: true,
+	});
+}

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks-logarithmic.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks-logarithmic.js
@@ -1,7 +1,7 @@
 function runTestCase(container) {
 	const chartOptions = {
 		rightPriceScale: {
-			mode: 0,
+			mode: LightweightCharts.PriceScaleMode.Logarithmic,
 			scaleMargins: {
 				top: 0,
 				bottom: 0,
@@ -11,17 +11,11 @@ function runTestCase(container) {
 	};
 
 	const chart = (window.chart = LightweightCharts.createChart(container, chartOptions));
-	const series1 = chart.addSeries(LightweightCharts.CandlestickSeries);
-	const series2 = chart.addSeries(LightweightCharts.CandlestickSeries);
+	const series = chart.addSeries(LightweightCharts.CandlestickSeries);
 
-	series1.setData([
+	series.setData([
 		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
 		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
-	]);
-
-	series2.setData([
-		{ time: '2018-12-23', open: 66.6, high: 99.54, low: 16, close: 20.72 },
-		{ time: '2018-12-27', open: 33, high: 35, low: 11.68, close: 20.43 },
 	]);
 
 	chart.timeScale().fitContent();

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks.js
@@ -1,8 +1,7 @@
 function runTestCase(container) {
 	const chartOptions = {
 		rightPriceScale: {
-			// autoScale: false,
-			mode: 0,
+			mode: LightweightCharts.PriceScaleMode.Normal,
 			scaleMargins: {
 				top: 0,
 				bottom: 0,

--- a/tests/e2e/graphics/test-cases/price-scale/edge-marks.js
+++ b/tests/e2e/graphics/test-cases/price-scale/edge-marks.js
@@ -1,0 +1,23 @@
+function runTestCase(container) {
+	const chartOptions = {
+		rightPriceScale: {
+			// autoScale: false,
+			mode: 0,
+			scaleMargins: {
+				top: 0,
+				bottom: 0,
+			},
+			ensureEdgeTickMarksVisible: true,
+		},
+	};
+
+	const chart = (window.chart = LightweightCharts.createChart(container, chartOptions));
+	const series = chart.addSeries(LightweightCharts.CandlestickSeries);
+
+	series.setData([
+		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
+		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
+	]);
+
+	chart.timeScale().fitContent();
+}

--- a/tests/e2e/graphics/test-cases/price-scale/set-visible-range.js
+++ b/tests/e2e/graphics/test-cases/price-scale/set-visible-range.js
@@ -1,0 +1,12 @@
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container));
+	const series = chart.addSeries(LightweightCharts.CandlestickSeries);
+
+	series.setData([
+		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
+		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
+	]);
+
+	chart.timeScale().fitContent();
+	chart.priceScale('right').setVisibleRange({ from: 10, to: 100 });
+}

--- a/tests/e2e/graphics/test-cases/price-scale/toggle-auto-scale.js
+++ b/tests/e2e/graphics/test-cases/price-scale/toggle-auto-scale.js
@@ -1,0 +1,13 @@
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container));
+	const series = chart.addSeries(LightweightCharts.CandlestickSeries);
+
+	series.setData([
+		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
+		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
+	]);
+
+	chart.timeScale().fitContent();
+	chart.priceScale('right').setVisibleRange({ from: 10, to: 100 });
+	chart.priceScale('right').setAutoScale(true);
+}

--- a/tests/e2e/graphics/test-cases/two-scales/edge-marks.js
+++ b/tests/e2e/graphics/test-cases/two-scales/edge-marks.js
@@ -1,0 +1,28 @@
+function runTestCase(container) {
+	const chartOptions = {
+		rightPriceScale: {
+			mode: 0,
+			scaleMargins: {
+				top: 0,
+				bottom: 0,
+			},
+			ensureEdgeTickMarksVisible: true,
+		},
+	};
+
+	const chart = (window.chart = LightweightCharts.createChart(container, chartOptions));
+	const series1 = chart.addSeries(LightweightCharts.CandlestickSeries);
+	const series2 = chart.addSeries(LightweightCharts.CandlestickSeries);
+
+	series1.setData([
+		{ time: '2018-12-22', open: 75.16, high: 82.84, low: 36.16, close: 45.72 },
+		{ time: '2018-12-29', open: 131.33, high: 151.17, low: 77.68, close: 96.43 },
+	]);
+
+	series2.setData([
+		{ time: '2018-12-23', open: 66.6, high: 99.54, low: 16, close: 20.72 },
+		{ time: '2018-12-27', open: 33, high: 35, low: 11.68, close: 20.43 },
+	]);
+
+	chart.timeScale().fitContent();
+}


### PR DESCRIPTION
**Type of PR:** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [ ] Includes tests
- [ ] Documentation update

**Overview of change:**
Added feature with bounded price marks.

Feature can be enabled with PriceScaleOptions flag boundaryMarksVisible(boolean).
After enabling this feature Price marks will constantly show min and max values on cavas.

**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
