### PR TITLE
Implemented series order functionality #136

### DIFF
--- a/src/api/iseries-api.ts
+++ b/src/api/iseries-api.ts
@@ -315,21 +315,21 @@ export interface ISeriesApi<
 	moveToPane(paneIndex: number): void;
 
 	/**
-	 * Returns the index of the series in all series of the pane.
+	 * Gets the zero-based index of this series within the list of all series on the current pane.
 	 *
-	 * @returns The index of the series.
+	 * @returns The current index of the series in the pane's series collection.
 	 */
 	seriesOrder(): number;
 
 	/**
-	 * Sets the index of the series in all series of the pane.
-	 * This value can be recalculated by the chart automatically after some operations
-	 * like removing other series or moving the series to another pane.
-	 * Notice that values like -1 or actual series count or greater are adjusted to correct values.
-	 * Also notice that price scales use formatters from the series with the lowest index, so moving series
-	 * to a new position may change a corresponding price scale formatter.
+	 * Sets the zero-based index of this series within the pane's series collection, thereby adjusting its rendering order.
 	 *
-	 * @param order - The index of the series.
+	 * Note:
+	 * - The chart may automatically recalculate this index after operations such as removing other series or moving this series to a different pane.
+	 * - If the provided index is less than 0, equal to, or greater than the number of series, it will be clamped to a valid range.
+	 * - Price scales derive their formatters from the series with the lowest index; changing the order may affect the price scale's formatting
+	 *
+	 * @param order - The desired zero-based index to set for this series within the pane.
 	 */
 	setSeriesOrder(order: number): void;
 

--- a/src/api/iseries-api.ts
+++ b/src/api/iseries-api.ts
@@ -315,6 +315,25 @@ export interface ISeriesApi<
 	moveToPane(paneIndex: number): void;
 
 	/**
+	 * Returns the index of the series in all series of the pane.
+	 *
+	 * @returns The index of the series.
+	 */
+	seriesOrder(): number;
+
+	/**
+	 * Sets the index of the series in all series of the pane.
+	 * This value can be recalculated by the chart automatically after some operations
+	 * like removing other series or moving the series to another pane.
+	 * Notice that values like -1 or actual series count or greater are adjusted to correct values.
+	 * Also notice that price scales use formatters from the series with the lowest index, so moving series
+	 * to a new position may change a corresponding price scale formatter.
+	 *
+	 * @param order - The index of the series.
+	 */
+	setSeriesOrder(order: number): void;
+
+	/**
 	 * Returns the pane to which the series is currently attached.
 	 *
 	 * @returns Pane API object to control the pane

--- a/src/api/series-api.ts
+++ b/src/api/series-api.ts
@@ -250,6 +250,24 @@ export class SeriesApi<
 		this._series.model().moveSeriesToPane(this._series, paneIndex);
 	}
 
+	public seriesOrder(): number {
+		const pane = this._series.model().paneForSource(this._series);
+		if (pane === null) {
+			return -1;
+		}
+
+		return pane.series().indexOf(this._series);
+	}
+
+	public setSeriesOrder(order: number): void {
+		const pane = this._series.model().paneForSource(this._series);
+		if (pane === null) {
+			return;
+		}
+
+		pane.setSeriesOrder(this._series, order);
+	}
+
 	private _onDataChanged(scope: DataChangedScope): void {
 		if (this._dataChangedDelegate.hasListeners()) {
 			this._dataChangedDelegate.fire(scope);

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -968,7 +968,7 @@ export class ChartModel<HorzScaleItem> implements IDestroyable, IChartModelBase 
 		const pane = ensureNotNull(this.paneForSource(series));
 		pane.removeDataSource(series);
 
-		pane.addDataSource(series, targetScaleId, ensureNotNull(series.zorder()));
+		pane.addDataSource(series, targetScaleId);
 	}
 
 	public fitContent(): void {

--- a/src/model/chart-model.ts
+++ b/src/model/chart-model.ts
@@ -966,9 +966,8 @@ export class ChartModel<HorzScaleItem> implements IDestroyable, IChartModelBase 
 
 	public moveSeriesToScale(series: ISeries<SeriesType>, targetScaleId: string): void {
 		const pane = ensureNotNull(this.paneForSource(series));
-		pane.removeDataSource(series);
-
-		pane.addDataSource(series, targetScaleId);
+		pane.removeDataSource(series, true);
+		pane.addDataSource(series, targetScaleId, true);
 	}
 
 	public fitContent(): void {

--- a/src/model/idata-source.ts
+++ b/src/model/idata-source.ts
@@ -13,7 +13,7 @@ export interface IPrimitiveHitTestSource {
 }
 
 export interface ZOrdered {
-	zorder(): number | null;
+	zorder(): number;
 }
 /**
  * Prefix meanings:

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -543,22 +543,10 @@ export class PriceScale {
 	}
 
 	public orderedSources(): readonly IPriceDataSource[] {
-		if (this._cachedOrderedSources) {
-			return this._cachedOrderedSources;
+		if (!this._cachedOrderedSources) {
+			this._cachedOrderedSources = sortSources<IPriceDataSource>(this._dataSources);
 		}
 
-		let sources: IPriceDataSource[] = [];
-		for (let i = 0; i < this._dataSources.length; i++) {
-			const ds = this._dataSources[i];
-			if (ds.zorder() === null) {
-				ds.setZorder(i + 1);
-			}
-
-			sources.push(ds);
-		}
-
-		sources = sortSources<IPriceDataSource>(sources);
-		this._cachedOrderedSources = sources;
 		return this._cachedOrderedSources;
 	}
 

--- a/tests/e2e/graphics/test-cases/api/change-series-order.js
+++ b/tests/e2e/graphics/test-cases/api/change-series-order.js
@@ -1,0 +1,82 @@
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, { layout: { attributionLogo: false } });
+
+	const areaSeries1 = chart.addSeries(LightweightCharts.AreaSeries, {
+		lineColor: '#2962FF',
+		topColor: '#2962FF',
+		bottomColor: 'rgba(41, 98, 255, 0.28)',
+		priceFormat: {
+			type: 'custom',
+			minMove: 0.01,
+			formatter: price => price.toFixed(1),
+		},
+	});
+
+	areaSeries1.setData([
+		{ time: '2018-12-22', value: 32.51 },
+		{ time: '2018-12-23', value: 31.11 },
+		{ time: '2018-12-24', value: 27.02 },
+		{ time: '2018-12-25', value: 27.32 },
+		{ time: '2018-12-26', value: 25.17 },
+		{ time: '2018-12-27', value: 28.89 },
+		{ time: '2018-12-28', value: 25.46 },
+		{ time: '2018-12-29', value: 23.92 },
+		{ time: '2018-12-30', value: 22.68 },
+		{ time: '2018-12-31', value: 22.67 },
+	]);
+
+	const areaSeries2 = chart.addSeries(LightweightCharts.AreaSeries, {
+		lineColor: '#ff29b4',
+		topColor: '#510a60',
+		bottomColor: 'rgba(166,104,168,0.28)',
+		priceFormat: {
+			type: 'custom',
+			minMove: 0.01,
+			formatter: price => `$${price.toFixed(3)}`,
+		},
+	});
+
+	areaSeries2.setData([
+		{ time: '2018-12-22', value: 22.51 },
+		{ time: '2018-12-23', value: 31.11 },
+		{ time: '2018-12-24', value: 33.02 },
+		{ time: '2018-12-25', value: 29.32 },
+		{ time: '2018-12-26', value: 20.17 },
+		{ time: '2018-12-27', value: 26.89 },
+		{ time: '2018-12-28', value: 23.46 },
+		{ time: '2018-12-29', value: 29.92 },
+		{ time: '2018-12-30', value: 24.68 },
+		{ time: '2018-12-31', value: 20.67 },
+	]);
+
+	const areaSeries3 = chart.addSeries(LightweightCharts.AreaSeries, {
+		lineColor: '#10ec1b',
+		topColor: '#10ec1b',
+		bottomColor: 'rgba(16,236,27,0.2)',
+		priceFormat: {
+			type: 'custom',
+			minMove: 0.01,
+			formatter: price => `${price.toFixed(0)}%`,
+		},
+	});
+
+	areaSeries3.setData([
+		{ time: '2018-12-22', value: 10 },
+		{ time: '2018-12-23', value: 33 },
+		{ time: '2018-12-24', value: 22 },
+		{ time: '2018-12-25', value: 15 },
+		{ time: '2018-12-26', value: 27 },
+		{ time: '2018-12-27', value: 25 },
+		{ time: '2018-12-28', value: 13 },
+		{ time: '2018-12-29', value: 18 },
+		{ time: '2018-12-30', value: 16 },
+		{ time: '2018-12-31', value: 25 },
+	]);
+
+	chart.timeScale().fitContent();
+
+	areaSeries2.setSeriesOrder(0);
+	areaSeries3.setSeriesOrder(0);
+	areaSeries3.applyOptions({ priceScaleId: 'left' });
+	chart.priceScale('left').applyOptions({ visible: true });
+}

--- a/tests/e2e/graphics/test-cases/api/change-series-order.js
+++ b/tests/e2e/graphics/test-cases/api/change-series-order.js
@@ -75,8 +75,26 @@ function runTestCase(container) {
 
 	chart.timeScale().fitContent();
 
+	console.assert(areaSeries1.seriesOrder() === 0, `areaSeries1 order should be 0, actual: ${areaSeries1.seriesOrder()}`);
+	console.assert(areaSeries2.seriesOrder() === 1, `areaSeries2 order should be 1, actual: ${areaSeries2.seriesOrder()}`);
+	console.assert(areaSeries3.seriesOrder() === 2, `areaSeries3 order should be 2, actual: ${areaSeries3.seriesOrder()}`);
+
 	areaSeries2.setSeriesOrder(0);
+
+	console.assert(areaSeries1.seriesOrder() === 1, `areaSeries1 order should be 1, actual: ${areaSeries1.seriesOrder()}`);
+	console.assert(areaSeries2.seriesOrder() === 0, `areaSeries2 order should be 0, actual: ${areaSeries2.seriesOrder()}`);
+	console.assert(areaSeries3.seriesOrder() === 2, `areaSeries3 order should be 2, actual: ${areaSeries3.seriesOrder()}`);
+
 	areaSeries3.setSeriesOrder(0);
+
+	console.assert(areaSeries1.seriesOrder() === 2, `areaSeries1 order should be 2, actual: ${areaSeries1.seriesOrder()}`);
+	console.assert(areaSeries2.seriesOrder() === 1, `areaSeries2 order should be 1, actual: ${areaSeries2.seriesOrder()}`);
+	console.assert(areaSeries3.seriesOrder() === 0, `areaSeries3 order should be 0, actual: ${areaSeries3.seriesOrder()}`);
+
 	areaSeries3.applyOptions({ priceScaleId: 'left' });
 	chart.priceScale('left').applyOptions({ visible: true });
+
+	console.assert(areaSeries1.seriesOrder() === 2, `areaSeries1 order should be 2, actual: ${areaSeries1.seriesOrder()}`);
+	console.assert(areaSeries2.seriesOrder() === 1, `areaSeries2 order should be 1, actual: ${areaSeries2.seriesOrder()}`);
+	console.assert(areaSeries3.seriesOrder() === 0, `areaSeries3 order should be 0, actual: ${areaSeries3.seriesOrder()}`);
 }


### PR DESCRIPTION
**Type of PR:**  enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #136
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Added possibility to change series order and get current order value

```TS
const series1 = chart.addSeries(...);
const series2 = chart.addSeries(...);

series1.order(); // 0
series2.order(); // 1

series2.setOrder(0);

series1.order(); // 1
series2.order(); // 0

chart.removeSeries(series2);

series1.order(); // 0
```

**Is there anything you'd like reviewers to focus on?**

Series are painted on a pane by their order - than more the order the more top the series.

A series order value can be recalculated by the chart automatically after some operations
like removing other series or moving the series to another pane.

Also notice that price scales use formatters from the series with the lowest order, so moving series
to a new position may change a corresponding price scale formatter.


