### PR TITLE
add options to series markers to change rendering zOrder

### DIFF
--- a/debug/default/index.ts
+++ b/debug/default/index.ts
@@ -7,7 +7,7 @@ import {
 } from "lightweight-charts";
 
 const chartOptions = {
-	autosize: true,
+	autoSize: true,
 } satisfies DeepPartial<ChartOptions>;
 
 const chart = createChart('container', chartOptions);

--- a/src/plugins/series-markers/options.ts
+++ b/src/plugins/series-markers/options.ts
@@ -1,0 +1,25 @@
+/**
+ * The visual stacking order for the markers within the chart.
+ *
+ * - `normal`: Markers are drawn together with the series they belong to. They can appear below other series depending on the series stacking order.
+ * - `aboveSeries`: Markers are drawn above all series but below primitives that use the 'top' zOrder layer.
+ * - `top`: Markers are drawn on the topmost primitive layer, above all series and (most) other primitives.
+ */
+export type SeriesMarkerZOrder = 'top' | 'aboveSeries' | 'normal';
+
+/**
+ * Configuration options for the series markers plugin.
+ * These options affect all markers managed by the plugin.
+ */
+export interface SeriesMarkersOptions {
+	/**
+	 * Defines the stacking order of the markers relative to the series and other primitives.
+	 *
+	 * @defaultValue `normal`
+	 */
+	zOrder: SeriesMarkerZOrder;
+}
+
+export const seriesMarkerOptionsDefaults: SeriesMarkersOptions = {
+	zOrder: 'normal',
+} as const;

--- a/src/plugins/series-markers/renderer.ts
+++ b/src/plugins/series-markers/renderer.ts
@@ -8,6 +8,7 @@ import { IPrimitivePaneRenderer, PrimitiveHoveredItem } from '../../model/ipane-
 import { TextWidthCache } from '../../model/text-width-cache';
 import { SeriesItemsIndexesRange, TimedValue } from '../../model/time-data';
 
+import { SeriesMarkerZOrder } from './options';
 import { drawArrow, hitTestArrow } from './series-markers-arrow';
 import { drawCircle, hitTestCircle } from './series-markers-circle';
 import { drawSquare, hitTestSquare } from './series-markers-square';
@@ -44,18 +45,20 @@ export class SeriesMarkersRenderer implements IPrimitivePaneRenderer {
 	private _fontSize: number = -1;
 	private _fontFamily: string = '';
 	private _font: string = '';
+	private _zOrder: SeriesMarkerZOrder = 'normal';
 
 	public setData(data: SeriesMarkerRendererData): void {
 		this._data = data;
 	}
 
-	public setParams(fontSize: number, fontFamily: string): void {
+	public setParams(fontSize: number, fontFamily: string, zOrder: SeriesMarkerZOrder): void {
 		if (this._fontSize !== fontSize || this._fontFamily !== fontFamily) {
 			this._fontSize = fontSize;
 			this._fontFamily = fontFamily;
 			this._font = makeFont(fontSize, fontFamily);
 			this._textWidthCache.reset();
 		}
+		this._zOrder = zOrder;
 	}
 
 	public hitTest(x: number, y: number): PrimitiveHoveredItem | null {
@@ -77,6 +80,18 @@ export class SeriesMarkersRenderer implements IPrimitivePaneRenderer {
 	}
 
 	public draw(target: CanvasRenderingTarget2D): void {
+		if (this._zOrder === 'aboveSeries') {
+			return;
+		}
+		target.useBitmapCoordinateSpace((scope: BitmapCoordinatesRenderingScope) => {
+			this._drawImpl(scope);
+		});
+	}
+
+	public drawBackground(target: CanvasRenderingTarget2D): void {
+		if (this._zOrder !== 'aboveSeries') {
+			return;
+		}
 		target.useBitmapCoordinateSpace((scope: BitmapCoordinatesRenderingScope) => {
 			this._drawImpl(scope);
 		});

--- a/src/plugins/series-markers/wrapper.ts
+++ b/src/plugins/series-markers/wrapper.ts
@@ -1,8 +1,11 @@
 import { ISeriesApi } from '../../api/iseries-api';
 
+import { DeepPartial } from '../../helpers/strict-type-checks';
+
 import { SeriesType } from '../../model/series-options';
 
 import { ISeriesPrimitiveWrapper, SeriesPrimitiveAdapter } from '../series-primitive-adapter';
+import { SeriesMarkersOptions } from './options';
 import { SeriesMarkersPrimitive } from './primitive';
 import { SeriesMarker } from './types';
 
@@ -50,6 +53,8 @@ class SeriesMarkersPrimitiveWrapper<HorzScaleItem>
  *
  * @param markers - An array of markers to be displayed on the series.
  *
+ * @param options - Options for the series markers plugin.
+ *
  * @example
  * ```js
  * import { createSeriesMarkers } from 'lightweight-charts';
@@ -74,9 +79,13 @@ class SeriesMarkersPrimitiveWrapper<HorzScaleItem>
  */
 export function createSeriesMarkers<HorzScaleItem>(
 	series: ISeriesApi<SeriesType, HorzScaleItem>,
-	markers?: SeriesMarker<HorzScaleItem>[]
+	markers?: SeriesMarker<HorzScaleItem>[],
+	options?: DeepPartial<SeriesMarkersOptions>
 ): ISeriesMarkersPluginApi<HorzScaleItem> {
-	const wrapper = new SeriesMarkersPrimitiveWrapper(series, new SeriesMarkersPrimitive<HorzScaleItem>());
+	const wrapper = new SeriesMarkersPrimitiveWrapper(
+		series,
+		new SeriesMarkersPrimitive<HorzScaleItem>(options ?? {})
+	);
 	if (markers) {
 		wrapper.setMarkers(markers);
 	}

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-zorder.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-zorder.js
@@ -1,0 +1,60 @@
+/*
+	We expect the black markers to be drawn above the area series
+ */
+
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container, {
+		layout: { attributionLogo: false },
+	}));
+	const lineSeries = chart.addSeries(LightweightCharts.LineSeries, {
+		color: '#2962FF',
+	});
+
+	const lineData = [
+		{ time: '2018-12-22', value: 32.51 },
+		{ time: '2018-12-23', value: 31.11 },
+		{ time: '2018-12-24', value: 27.02 },
+		{ time: '2018-12-25', value: 27.32 },
+		{ time: '2018-12-26', value: 25.17 },
+		{ time: '2018-12-27', value: 28.89 },
+		{ time: '2018-12-28', value: 25.46 },
+		{ time: '2018-12-29', value: 23.92 },
+		{ time: '2018-12-30', value: 22.68 },
+		{ time: '2018-12-31', value: 22.67 },
+	];
+
+	lineSeries.setData(lineData);
+
+	const areaSeries = chart.addSeries(LightweightCharts.AreaSeries, {
+		lineColor: 'red',
+		topColor: 'orange',
+		bottomColor: 'yellow',
+	});
+
+	areaSeries.setData([
+		{ time: '2018-12-22', value: 42.51 },
+		{ time: '2018-12-23', value: 41.11 },
+		{ time: '2018-12-24', value: 37.02 },
+		{ time: '2018-12-25', value: 37.32 },
+		{ time: '2018-12-26', value: 35.17 },
+		{ time: '2018-12-27', value: 38.89 },
+		{ time: '2018-12-28', value: 35.46 },
+		{ time: '2018-12-29', value: 33.92 },
+		{ time: '2018-12-30', value: 32.68 },
+		{ time: '2018-12-31', value: 32.67 },
+	]);
+
+	const seriesMarkers = LightweightCharts.createSeriesMarkers(lineSeries);
+	seriesMarkers.applyOptions?.({
+		zOrder: 'aboveSeries',
+	});
+	const markers = lineData.map(d => ({
+		time: d.time,
+		price: d.value,
+		color: 'black',
+		position: 'inBar',
+		shape: 'circle',
+	}));
+	seriesMarkers.setMarkers(markers);
+	chart.timeScale().fitContent();
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**PR checklist:**

- [ ] Addresses an existing issue
- [x] Includes tests
- [x] Documentation update

**Overview of change:**
This PR introduces a new option to the series markers plugin that allows users to control the rendering stacking order (`zOrder`) of series markers. The `zOrder` option determines how markers are visually layered relative to series and other chart primitives.

## Details
-  Added a new `SeriesMarkerZOrder` type with three possible values:
    - `normal`: Markers are drawn together with their series and may appear below other series depending on series order.
    - `aboveSeries`: Markers are drawn above all series but below other primitives on the top zOrder layer.
    - `top`: Markers are drawn on the topmost primitive layer, above all series and most other primitives.
-  Extended the `SeriesMarkersOptions` interface to include the `zOrder` option with a default value of `normal`.
-  Updated the series markers primitive, pane view, and renderer to respect the `zOrder` setting when drawing markers.
-  Added an end-to-end test case demonstrating markers rendered with `zOrder: 'aboveSeries'`, ensuring black markers appear above an area series.

## Motivation
Previously, series markers were always rendered with a fixed stacking order, limiting customization and visual layering flexibility in complex charts. This enhancement enables developers to better control marker visibility and layering relative to series and other chart elements.

## Testing
-  Added an e2e test case that creates a chart with a line series, an area series, and series markers set with `zOrder: 'aboveSeries'`.
-  Verified markers render visually above the area series as expected.
-  Existing tests were updated to accommodate the new option where necessary.

## Example Usage
```ts
const seriesMarkers = createSeriesMarkers(lineSeries);
seriesMarkers.applyOptions({ zOrder: 'aboveSeries' });
seriesMarkers.setMarkers([
  { time: '2018-12-22', price: 32.51, color: 'black', position: 'inBar', shape: 'circle' },
  // more markers...
]);
```
or 
```ts
const markers: SeriesMarkers<Time> = [
  { time: '2018-12-22', price: 32.51, color: 'black', position: 'inBar', shape: 'circle' },
  // more markers...
];
const options: SeriesMarkersOptions = {
  zOrder: 'aboveSeries'
};
const seriesMarkers = createSeriesMarkers(lineSeries, markers, options);
```
