### PR TITLE
WRT-1754: Fix card style

### DIFF
--- a/website/src/components/CardLink/index.tsx
+++ b/website/src/components/CardLink/index.tsx
@@ -36,12 +36,12 @@ function CardLayout({
 	icon?: ReactNode;
 	wrapDescription: boolean;
 }): React.JSX.Element {
-	const isSingleWord = title.trim().split(/\s+/).length === 1;
+	const isTitleSingleWord = title.trim().split(/\s+/).length === 1;
 	return (
 		<CardContainer href={href}>
 			{image && <div className={clsx(styles.cardImage)}>{image}</div>}
 			<div className={clsx(styles.cardDetails, wrapDescription && styles.centerDetails)}>
-				<h2 className={clsx(wrapDescription && styles.noBottomMargin, 'text--truncate', styles.cardTitle, isSingleWord && styles.cardTitleSingleWord)} title={title}>
+				<h2 className={clsx(wrapDescription && styles.noBottomMargin, 'text--truncate', styles.cardTitle, isTitleSingleWord && styles.cardTitleSingleWord)} title={title}>
 					{icon} {title}
 				</h2>
 				{description && (

--- a/website/src/components/CardLink/index.tsx
+++ b/website/src/components/CardLink/index.tsx
@@ -36,11 +36,12 @@ function CardLayout({
 	icon?: ReactNode;
 	wrapDescription: boolean;
 }): React.JSX.Element {
+	const isSingleWord = title.trim().split(/\s+/).length === 1;
 	return (
 		<CardContainer href={href}>
 			{image && <div className={clsx(styles.cardImage)}>{image}</div>}
 			<div className={clsx(styles.cardDetails, wrapDescription && styles.centerDetails)}>
-				<h2 className={clsx(wrapDescription && styles.noBottomMargin, 'text--truncate', styles.cardTitle)} title={title}>
+				<h2 className={clsx(wrapDescription && styles.noBottomMargin, 'text--truncate', styles.cardTitle, isSingleWord && styles.cardTitleSingleWord)} title={title}>
 					{icon} {title}
 				</h2>
 				{description && (

--- a/website/src/components/CardLink/styles.module.css
+++ b/website/src/components/CardLink/styles.module.css
@@ -9,6 +9,7 @@
 	transition-property: border, box-shadow;
 
 	flex-direction: row;
+	height: 100%;
 }
 
 .cardContainer:hover {
@@ -46,6 +47,7 @@
 
 .cardDescription {
 	font-size: 0.8rem;
+	text-wrap: wrap;
 }
 
 .noWrap {

--- a/website/src/components/CardLink/styles.module.css
+++ b/website/src/components/CardLink/styles.module.css
@@ -48,6 +48,7 @@
 .cardDescription {
 	font-size: 0.8rem;
 	text-wrap: wrap;
+	text-wrap: pretty;
 }
 
 .noWrap {

--- a/website/src/components/CardLink/styles.module.css
+++ b/website/src/components/CardLink/styles.module.css
@@ -42,20 +42,20 @@
 }
 
 .cardTitle {
-  font-size: 1.2rem;
-  overflow: hidden;              /* Hide overflow content */
-  text-overflow: ellipsis;       /* Show ellipsis when overflowing */
-  white-space: normal;           /* Allow wrapping */
-  word-break: keep-all;        /* Break only if necessary, at word boundaries */
-  overflow-wrap: break-word;     /* Break long words if needed */
-  display: -webkit-box;          /* Needed for webkit line clamping */
-  -webkit-line-clamp: 2;         /* Number of lines before ellipsis */
-  -webkit-box-orient: vertical;  /* Vertical orientation for webkit box */
+	font-size: 1.2rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: normal;
+	word-break: keep-all; /* Break only if necessary, at word boundaries */
+	overflow-wrap: break-word; /* Break long words if needed */
+	display: -webkit-box;
+	-webkit-line-clamp: 2; /* Number of lines before ellipsis */
+	-webkit-box-orient: vertical;
 }
 
 .cardTitleSingleWord {
-  white-space: nowrap;
-  -webkit-line-clamp: 1;
+	white-space: nowrap;
+	-webkit-line-clamp: 1;
 }
 
 .cardDescription {

--- a/website/src/components/CardLink/styles.module.css
+++ b/website/src/components/CardLink/styles.module.css
@@ -41,8 +41,25 @@
 	width: 62px;
 }
 
-.cardTitle {
+/* .cardTitle {
 	font-size: 1.2rem;
+} */
+
+.cardTitle {
+  font-size: 1.2rem;
+  overflow: hidden;              /* Hide overflow content */
+  text-overflow: ellipsis;       /* Show ellipsis when overflowing */
+  white-space: normal;           /* Allow wrapping */
+  word-break: keep-all;        /* Break only if necessary, at word boundaries */
+  overflow-wrap: break-word;     /* Break long words if needed */
+  display: -webkit-box;          /* Needed for webkit line clamping */
+  -webkit-line-clamp: 2;         /* Number of lines before ellipsis */
+  -webkit-box-orient: vertical;  /* Vertical orientation for webkit box */
+}
+
+.cardTitleSingleWord {
+  white-space: nowrap;
+  -webkit-line-clamp: 1;
 }
 
 .cardDescription {

--- a/website/src/components/CardLink/styles.module.css
+++ b/website/src/components/CardLink/styles.module.css
@@ -41,10 +41,6 @@
 	width: 62px;
 }
 
-/* .cardTitle {
-	font-size: 1.2rem;
-} */
-
 .cardTitle {
   font-size: 1.2rem;
   overflow: hidden;              /* Hide overflow content */


### PR DESCRIPTION
Fixed the card component style so the description text is not cut off.

Preview: https://tangerine-sprinkles-70456a.netlify.app/lightweight-charts/tutorials