### PR TITLE
add simple mouse events for price and time scales

### DIFF
--- a/src/api/iaxis-api.ts
+++ b/src/api/iaxis-api.ts
@@ -1,0 +1,69 @@
+import { AxisMouseEventHandler } from '../model/axis-model';
+
+export interface IAxisApi {
+	/**
+	 * Subscribe to the axis click event.
+	 *
+	 * @param handler - Handler to be called on mouse click.
+	 * @example
+	 * ```js
+	 * function myClickHandler(param) {
+	 *     if (!param.point) {
+	 *         return;
+	 *     }
+	 *
+	 *     console.log(`Click at ${param.point.x}, ${param.point.y}.`);
+	 * }
+	 *
+	 * chart.timeScale().subscribeClick(myClickHandler);
+	 * ```
+	 */
+	subscribeClick(handler: AxisMouseEventHandler): void;
+
+	/**
+	 * Unsubscribe a handler that was previously subscribed using {@link subscribeClick}.
+	 *
+	 * @param handler - Previously subscribed handler
+	 * @example
+	 * ```js
+	 * chart.timeScale().unsubscribeClick(myClickHandler);
+	 * ```
+	 */
+	unsubscribeClick(handler: AxisMouseEventHandler): void;
+
+	/**
+	 * Subscribe to the axis mouse move event.
+	 *
+	 * @param handler - Handler to be called on mouse move.
+	 * @example
+	 * ```js
+	 * function myMoveHandler(param) {
+	 *     if (!param.point) {
+	 *         return;
+	 *     }
+	 *
+	 *     console.log(`Mouse at ${param.point.x}, ${param.point.y}.`);
+	 * }
+	 *
+	 * chart.timeScale().subscribeMouseMove(myMoveHandler);
+	 * ```
+	 */
+	subscribeMouseMove(handler: AxisMouseEventHandler): void;
+
+	/**
+	 * Unsubscribe a handler that was previously subscribed using {@link subscribeMouseMove}.
+	 *
+	 * @param handler - Previously subscribed handler
+	 * @example
+	 * ```js
+	 * chart.timeScale().unsubscribeMouseMove(myMoveHandler);
+	 * ```
+	 */
+	unsubscribeMouseMove(handler: AxisMouseEventHandler): void;
+
+	/**
+	 * CSS cursor style as defined here: [MDN: CSS Cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) or `undefined`
+	 * if you want the library to use the default cursor style instead.
+	 */
+	overrideCursorStyle(cursor: string | undefined): void;
+}

--- a/src/api/iprice-scale-api.ts
+++ b/src/api/iprice-scale-api.ts
@@ -3,8 +3,10 @@ import { DeepPartial } from '../helpers/strict-type-checks';
 import { PriceScaleOptions } from '../model/price-scale';
 import { IRange } from '../model/time-data';
 
+import { IAxisApi } from './iaxis-api';
+
 /** Interface to control chart's price scale */
-export interface IPriceScaleApi {
+export interface IPriceScaleApi extends IAxisApi {
 	/**
 	 * Applies new options to the price scale
 	 *

--- a/src/api/itime-scale-api.ts
+++ b/src/api/itime-scale-api.ts
@@ -4,6 +4,8 @@ import { Coordinate } from '../model/coordinate';
 import { IRange, Logical, LogicalRange, TimePointIndex } from '../model/time-data';
 import { HorzScaleOptions } from '../model/time-scale';
 
+import { IAxisApi } from './iaxis-api';
+
 /**
  * A custom function used to handle changes to the time scale's time range.
  */
@@ -18,7 +20,7 @@ export type LogicalRangeChangeEventHandler = (logicalRange: LogicalRange | null)
 export type SizeChangeEventHandler = (width: number, height: number) => void;
 
 /** Interface to chart time scale */
-export interface ITimeScaleApi<HorzScaleItem> {
+export interface ITimeScaleApi<HorzScaleItem> extends IAxisApi {
 	/**
 	 * Return the distance from the right edge of the time scale to the lastest bar of the series measured in bars.
 	 */

--- a/src/api/price-scale-api.ts
+++ b/src/api/price-scale-api.ts
@@ -1,6 +1,7 @@
 import { IChartWidgetBase } from '../gui/chart-widget';
 
 import { ensureNotNull } from '../helpers/assertions';
+import { warn } from '../helpers/logger';
 import { DeepPartial } from '../helpers/strict-type-checks';
 
 import { AxisMouseEventHandler } from '../model/axis-model';
@@ -56,23 +57,41 @@ export class PriceScaleApi implements IPriceScaleApi {
 	}
 
 	public subscribeClick(handler: AxisMouseEventHandler): void {
-		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).subscribeClick(handler);
+		if (this._checkDefaultPriceScale()) {
+			this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).subscribeClick(handler);
+		}
 	}
 
 	public unsubscribeClick(handler: AxisMouseEventHandler): void {
-		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).unsubscribeClick(handler);
+		if (this._checkDefaultPriceScale()) {
+			this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).unsubscribeClick(handler);
+		}
 	}
 
 	public subscribeMouseMove(handler: AxisMouseEventHandler): void {
-		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).subscribeMouseMove(handler);
+		if (this._checkDefaultPriceScale()) {
+			this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).subscribeMouseMove(handler);
+		}
 	}
 
 	public unsubscribeMouseMove(handler: AxisMouseEventHandler): void {
-		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).unsubscribeMouseMove(handler);
+		if (this._checkDefaultPriceScale()) {
+			this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).unsubscribeMouseMove(handler);
+		}
 	}
 
 	public overrideCursorStyle(cursor: string | undefined): void {
-		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).overrideCursorStyle(cursor);
+		if (this._checkDefaultPriceScale()) {
+			this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).overrideCursorStyle(cursor);
+		}
+	}
+
+	private _checkDefaultPriceScale(): boolean {
+		if (!isDefaultPriceScale(this._priceScaleId)) {
+			warn('Method only supported on visible price scales');
+			return false;
+		}
+		return true;
 	}
 
 	private _priceScale(): PriceScale {

--- a/src/api/price-scale-api.ts
+++ b/src/api/price-scale-api.ts
@@ -3,6 +3,7 @@ import { IChartWidgetBase } from '../gui/chart-widget';
 import { ensureNotNull } from '../helpers/assertions';
 import { DeepPartial } from '../helpers/strict-type-checks';
 
+import { AxisMouseEventHandler } from '../model/axis-model';
 import { isDefaultPriceScale } from '../model/default-price-scale';
 import { PriceRangeImpl } from '../model/price-range-impl';
 import { PriceScale, PriceScaleOptions } from '../model/price-scale';
@@ -52,6 +53,26 @@ export class PriceScaleApi implements IPriceScaleApi {
 
 	public setAutoScale(on: boolean): void {
 		this.applyOptions({ autoScale: on });
+	}
+
+	public subscribeClick(handler: AxisMouseEventHandler): void {
+		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).subscribeClick(handler);
+	}
+
+	public unsubscribeClick(handler: AxisMouseEventHandler): void {
+		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).unsubscribeClick(handler);
+	}
+
+	public subscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).subscribeMouseMove(handler);
+	}
+
+	public unsubscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).unsubscribeMouseMove(handler);
+	}
+
+	public overrideCursorStyle(cursor: string | undefined): void {
+		this._chartWidget.getPriceAxisWidget(this._paneIndex, this._priceScaleId).overrideCursorStyle(cursor);
 	}
 
 	private _priceScale(): PriceScale {

--- a/src/api/time-scale-api.ts
+++ b/src/api/time-scale-api.ts
@@ -7,6 +7,7 @@ import { Delegate } from '../helpers/delegate';
 import { IDestroyable } from '../helpers/idestroyable';
 import { clone, DeepPartial } from '../helpers/strict-type-checks';
 
+import { AxisApi, AxisMouseEventHandler } from '../model/axis-model';
 import { ChartModel } from '../model/chart-model';
 import { Coordinate } from '../model/coordinate';
 import { IHorzScaleBehavior, InternalHorzScaleItem } from '../model/ihorz-scale-behavior';
@@ -19,11 +20,12 @@ import {
 	SizeChangeEventHandler,
 	TimeRangeChangeEventHandler,
 } from './itime-scale-api';
+
 const enum Constants {
 	AnimationDurationMs = 1000,
 }
 
-export class TimeScaleApi<HorzScaleItem> implements ITimeScaleApi<HorzScaleItem>, IDestroyable {
+export class TimeScaleApi<HorzScaleItem> extends AxisApi implements ITimeScaleApi<HorzScaleItem>, IDestroyable {
 	private _model: ChartModel<HorzScaleItem>;
 	private _timeScale: TimeScale<HorzScaleItem>;
 	private readonly _timeAxisWidget: TimeAxisWidget<HorzScaleItem>;
@@ -34,6 +36,7 @@ export class TimeScaleApi<HorzScaleItem> implements ITimeScaleApi<HorzScaleItem>
 	private readonly _horzScaleBehavior: IHorzScaleBehavior<HorzScaleItem>;
 
 	public constructor(model: ChartModel<HorzScaleItem>, timeAxisWidget: TimeAxisWidget<HorzScaleItem>, horzScaleBehavior: IHorzScaleBehavior<HorzScaleItem>) {
+		super();
 		this._model = model;
 		this._timeScale = model.timeScale();
 		this._timeAxisWidget = timeAxisWidget;
@@ -42,15 +45,37 @@ export class TimeScaleApi<HorzScaleItem> implements ITimeScaleApi<HorzScaleItem>
 		this._timeAxisWidget.sizeChanged().subscribe(this._onSizeChanged.bind(this));
 
 		this._horzScaleBehavior = horzScaleBehavior;
+		this._setupMouseEvents(this._timeAxisWidget);
 	}
 
 	public destroy(): void {
+		this._removeMouseEvents(this._timeAxisWidget);
 		this._timeScale.visibleBarsChanged().unsubscribeAll(this);
 		this._timeScale.logicalRangeChanged().unsubscribeAll(this);
 		this._timeAxisWidget.sizeChanged().unsubscribeAll(this);
 		this._timeRangeChanged.destroy();
 		this._logicalRangeChanged.destroy();
 		this._sizeChanged.destroy();
+	}
+
+	public subscribeClick(handler: AxisMouseEventHandler): void {
+		this._subscribeClick(handler);
+	}
+
+	public unsubscribeClick(handler: AxisMouseEventHandler): void {
+		this._unsubscribeClick(handler);
+	}
+
+	public subscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._subscribeMouseMove(handler);
+	}
+
+	public unsubscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._unsubscribeMouseMove(handler);
+	}
+
+	public overrideCursorStyle(cursor: string | undefined): void {
+		this._timeAxisWidget.overrideCursorStyle(cursor);
 	}
 
 	public scrollPosition(): number {

--- a/src/gui/axis-mouse-event-helpers.ts
+++ b/src/gui/axis-mouse-event-helpers.ts
@@ -1,0 +1,38 @@
+import { Delegate } from '../helpers/delegate';
+
+import {
+	AxisMouseEventParamsImpl,
+	AxisMouseEventParamsImplSupplier,
+} from '../model/axis-widget';
+import { Point } from '../model/point';
+
+import { MouseEventHandlerEventBase } from './mouse-event-handler';
+
+export function fireNullMouseDelegate(
+	delegate: Delegate<AxisMouseEventParamsImplSupplier>
+): void {
+	if (delegate.hasListeners()) {
+		delegate.fire(() => getAxisMouseEventParamsImpl(null, null));
+	}
+}
+
+export function fireMouseDelegate(
+	delegate: Delegate<AxisMouseEventParamsImplSupplier>,
+	event: MouseEventHandlerEventBase
+): void {
+	const x = event.localX;
+	const y = event.localY;
+	if (delegate.hasListeners()) {
+		delegate.fire(() => getAxisMouseEventParamsImpl({ x, y }, event));
+	}
+}
+
+function getAxisMouseEventParamsImpl(
+	point: Point | null,
+	event: MouseEventHandlerEventBase | null
+): AxisMouseEventParamsImpl {
+	return {
+		point: point ?? undefined,
+		touchMouseEventData: event ?? undefined,
+	};
+}

--- a/src/gui/chart-widget.ts
+++ b/src/gui/chart-widget.ts
@@ -28,6 +28,7 @@ import { TouchMouseEventData } from '../model/touch-mouse-event-data';
 import { suggestChartSize, suggestPriceScaleWidth, suggestTimeScaleHeight } from './internal-layout-sizes-hints';
 import { PaneSeparator, SeparatorConstants } from './pane-separator';
 import { PaneWidget } from './pane-widget';
+import { PriceAxisWidget } from './price-axis-widget';
 import { TimeAxisWidget } from './time-axis-widget';
 
 export interface MouseEventParamsImpl {
@@ -51,6 +52,7 @@ export interface IChartWidgetBase {
 	paneWidgets(): PaneWidget[];
 	options(): ChartOptionsInternalBase;
 	setCursorStyle(style: string | null): void;
+	getPriceAxisWidget(paneIndex: number, priceScaleId: string): PriceAxisWidget;
 }
 
 export class ChartWidget<HorzScaleItem> implements IDestroyable, IChartWidgetBase {
@@ -324,6 +326,11 @@ export class ChartWidget<HorzScaleItem> implements IDestroyable, IChartWidgetBas
 
 	public paneSize(paneIndex: number): Size {
 		return ensureDefined(this._paneWidgets[paneIndex]).getSize();
+	}
+
+	public getPriceAxisWidget(paneIndex: number, priceScaleId: string): PriceAxisWidget {
+		const pane = ensureDefined(this._paneWidgets[paneIndex]);
+		return ensureNotNull(priceScaleId === 'left' ? pane.leftPriceAxisWidget() : pane.rightPriceAxisWidget());
 	}
 
 	private _applyPanesOptions(): void {

--- a/src/gui/price-axis-widget.ts
+++ b/src/gui/price-axis-widget.ts
@@ -11,9 +11,13 @@ import {
 
 import { ensureNotNull } from '../helpers/assertions';
 import { clearRect, clearRectWithGradient } from '../helpers/canvas-helpers';
+import { Delegate } from '../helpers/delegate';
 import { IDestroyable } from '../helpers/idestroyable';
+import { ISubscription } from '../helpers/isubscription';
 import { makeFont } from '../helpers/make-font';
 
+import { AxisApi, AxisMouseEventHandler } from '../model/axis-model';
+import { AxisMouseEventParamsImplSupplier } from '../model/axis-widget';
 import { ChartOptionsInternalBase } from '../model/chart-model';
 import { Coordinate } from '../model/coordinate';
 import { CrosshairMode, CrosshairOptions } from '../model/crosshair';
@@ -30,6 +34,7 @@ import { PriceAxisRendererOptionsProvider } from '../renderers/price-axis-render
 import { IAxisView } from '../views/pane/iaxis-view';
 import { IPriceAxisView } from '../views/price-axis/iprice-axis-view';
 
+import { fireMouseDelegate, fireNullMouseDelegate } from './axis-mouse-event-helpers';
 import { createBoundCanvas, releaseCanvas } from './canvas-utils';
 import { ViewsGetter } from './draw-functions';
 import { suggestPriceScaleWidth } from './internal-layout-sizes-hints';
@@ -124,7 +129,7 @@ function priceScaleCrosshairLabelVisible(crosshair: CrosshairOptions): boolean {
 	return crosshair.mode !== CrosshairMode.Hidden && crosshair.horzLine.visible && crosshair.horzLine.labelVisible;
 }
 
-export class PriceAxisWidget implements IDestroyable {
+export class PriceAxisWidget extends AxisApi implements IDestroyable {
 	private readonly _pane: PaneWidget;
 	private readonly _options: Readonly<ChartOptionsInternalBase>;
 	private readonly _layoutOptions: Readonly<LayoutOptions>;
@@ -152,7 +157,12 @@ export class PriceAxisWidget implements IDestroyable {
 	private _sourceTopPaneViews: ViewsGetter<IDataSourcePaneViews>;
 	private _sourceBottomPaneViews: ViewsGetter<IDataSourcePaneViews>;
 
+	private _cursorOverride: string | undefined = undefined;
+	private _clicked: Delegate<AxisMouseEventParamsImplSupplier> = new Delegate();
+	private _mouseMoved: Delegate<AxisMouseEventParamsImplSupplier> = new Delegate();
+
 	public constructor(pane: PaneWidget, options: Readonly<ChartOptionsInternalBase>, rendererOptionsProvider: PriceAxisRendererOptionsProvider, side: PriceAxisWidgetSide) {
+		super();
 		this._pane = pane;
 		this._options = options;
 		this._layoutOptions = options['layout'];
@@ -194,7 +204,9 @@ export class PriceAxisWidget implements IDestroyable {
 			mouseDownOutsideEvent: this._mouseDownOutsideEvent.bind(this),
 			mouseUpEvent: this._mouseUpEvent.bind(this),
 			touchEndEvent: this._mouseUpEvent.bind(this),
+			mouseMoveEvent: this._mouseMoveEvent.bind(this),
 			mouseDoubleClickEvent: this._mouseDoubleClickEvent.bind(this),
+			mouseClickEvent: this._mouseClickEvent.bind(this),
 			doubleTapEvent: this._mouseDoubleClickEvent.bind(this),
 			mouseEnterEvent: this._mouseEnterEvent.bind(this),
 			mouseLeaveEvent: this._mouseLeaveEvent.bind(this),
@@ -207,9 +219,13 @@ export class PriceAxisWidget implements IDestroyable {
 				treatHorzTouchDragAsPageScroll: () => true,
 			}
 		);
+		this._setupMouseEvents(this);
 	}
 
 	public destroy(): void {
+		this._removeMouseEvents(this);
+		this._clicked.destroy();
+		this._mouseMoved.destroy();
 		this._mouseEventHandler.destroy();
 
 		this._topCanvasBinding.unsubscribeSuggestedBitmapSizeChanged(this._topCanvasSuggestedBitmapSizeChangedHandler);
@@ -225,6 +241,14 @@ export class PriceAxisWidget implements IDestroyable {
 		}
 
 		this._priceScale = null;
+	}
+
+	public clicked(): ISubscription<AxisMouseEventParamsImplSupplier> {
+		return this._clicked;
+	}
+
+	public mouseMoved(): ISubscription<AxisMouseEventParamsImplSupplier> {
+		return this._mouseMoved;
 	}
 
 	public getElement(): HTMLElement {
@@ -404,6 +428,27 @@ export class PriceAxisWidget implements IDestroyable {
 		this._priceScale?.marks();
 	}
 
+	public overrideCursorStyle(cursor: string | undefined): void {
+		this._cursorOverride = cursor;
+		this._setCursor(CursorType.Default);
+	}
+
+	public subscribeClick(handler: AxisMouseEventHandler): void {
+		this._subscribeClick(handler);
+	}
+
+	public unsubscribeClick(handler: AxisMouseEventHandler): void {
+		this._unsubscribeClick(handler);
+	}
+
+	public subscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._subscribeMouseMove(handler);
+	}
+
+	public unsubscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._unsubscribeMouseMove(handler);
+	}
+
 	private _mouseDownEvent(e: TouchMouseEvent): void {
 		if (this._priceScale === null || this._priceScale.isEmpty() || !this._options['handleScale'].axisPressedMouseMove.price) {
 			return;
@@ -470,6 +515,15 @@ export class PriceAxisWidget implements IDestroyable {
 
 	private _mouseLeaveEvent(e: TouchMouseEvent): void {
 		this._setCursor(CursorType.Default);
+		fireNullMouseDelegate(this._mouseMoved);
+	}
+
+	private _mouseMoveEvent(e: TouchMouseEvent): void {
+		fireMouseDelegate(this._mouseMoved, e);
+	}
+
+	private _mouseClickEvent(e: TouchMouseEvent): void {
+		fireMouseDelegate(this._clicked, e);
 	}
 
 	private _backLabels(): IPriceAxisView[] {
@@ -713,7 +767,7 @@ export class PriceAxisWidget implements IDestroyable {
 	}
 
 	private _setCursor(type: CursorType): void {
-		this._cell.style.cursor = type === CursorType.NsResize ? 'ns-resize' : 'default';
+		this._cell.style.cursor = this._cursorOverride || (type === CursorType.NsResize ? 'ns-resize' : 'default');
 	}
 
 	private _onMarksChanged(): void {

--- a/src/model/axis-model.ts
+++ b/src/model/axis-model.ts
@@ -50,8 +50,8 @@ export abstract class AxisApi {
 
 	protected _removeMouseEvents(widget: IAxisWidget): void {
 		widget.clicked().unsubscribeAll(this);
-		this._clickedDelegate.destroy();
 		widget.mouseMoved().unsubscribeAll(this);
+		this._clickedDelegate.destroy();
 		this._movedDelegate.destroy();
 	}
 

--- a/src/model/axis-model.ts
+++ b/src/model/axis-model.ts
@@ -1,0 +1,87 @@
+import { Delegate } from '../helpers/delegate';
+
+import { Point } from '../model/point';
+import { TouchMouseEventData } from '../model/touch-mouse-event-data';
+
+import { AxisMouseEventParamsImpl, AxisMouseEventParamsImplSupplier, IAxisWidget } from './axis-widget';
+
+/**
+ * Represents a mouse event.
+ */
+export interface AxisMouseEventParams {
+	/**
+	 * Location of the event in the chart.
+	 *
+	 * The value will be `undefined` if the event is fired outside the chart, for example a mouse leave event.
+	 */
+	point?: Point;
+	/**
+	 * The underlying source mouse or touch event data, if available
+	 */
+	sourceEvent?: TouchMouseEventData;
+}
+
+/**
+ * A custom function use to handle mouse events.
+ */
+export type AxisMouseEventHandler = (param: AxisMouseEventParams) => void;
+
+export abstract class AxisApi {
+	private readonly _clickedDelegate: Delegate<AxisMouseEventParams> =
+		new Delegate();
+	private readonly _movedDelegate: Delegate<AxisMouseEventParams> =
+		new Delegate();
+
+	protected _subscribeClick(handler: AxisMouseEventHandler): void {
+		this._clickedDelegate.subscribe(handler);
+	}
+
+	protected _unsubscribeClick(handler: AxisMouseEventHandler): void {
+		this._clickedDelegate.unsubscribe(handler);
+	}
+
+	protected _subscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._movedDelegate.subscribe(handler);
+	}
+
+	protected _unsubscribeMouseMove(handler: AxisMouseEventHandler): void {
+		this._movedDelegate.unsubscribe(handler);
+	}
+
+	protected _removeMouseEvents(widget: IAxisWidget): void {
+		widget.clicked().unsubscribeAll(this);
+		this._clickedDelegate.destroy();
+		widget.mouseMoved().unsubscribeAll(this);
+		this._movedDelegate.destroy();
+	}
+
+	protected _setupMouseEvents(widget: IAxisWidget): void {
+		widget
+			.clicked()
+			.subscribe(
+				(paramSupplier: AxisMouseEventParamsImplSupplier) => {
+					if (this._clickedDelegate.hasListeners()) {
+						this._clickedDelegate.fire(convertMouseParams(paramSupplier()));
+					}
+				},
+				this
+			);
+		widget
+			.mouseMoved()
+			.subscribe(
+				(paramSupplier: AxisMouseEventParamsImplSupplier) => {
+					if (this._movedDelegate.hasListeners()) {
+						this._movedDelegate.fire(convertMouseParams(paramSupplier()));
+					}
+				},
+				this
+			);
+	}
+}
+
+function convertMouseParams(param: AxisMouseEventParamsImpl): AxisMouseEventParams {
+	return {
+		point: param.point,
+		sourceEvent: param.touchMouseEventData,
+	};
+}

--- a/src/model/axis-widget.ts
+++ b/src/model/axis-widget.ts
@@ -1,0 +1,17 @@
+import { ISubscription } from '../helpers/isubscription';
+
+import { Point } from './point';
+import { TouchMouseEventData } from './touch-mouse-event-data';
+
+export interface IAxisWidget {
+	clicked(): ISubscription<AxisMouseEventParamsImplSupplier>;
+	mouseMoved(): ISubscription<AxisMouseEventParamsImplSupplier>;
+}
+
+export interface AxisMouseEventParamsImpl {
+	point?: Point;
+	hoveredObject?: string;
+	touchMouseEventData?: TouchMouseEventData;
+}
+
+export type AxisMouseEventParamsImplSupplier = () => AxisMouseEventParamsImpl;

--- a/tests/e2e/interactions/test-cases/mouse/pricescale-mouse-events.js
+++ b/tests/e2e/interactions/test-cases/mouse/pricescale-mouse-events.js
@@ -1,0 +1,83 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function initialInteractionsToPerform() {
+	return [
+		{ action: 'moveMouseBottomRight', target: 'rightpricescale' },
+		{ action: 'moveMouseTopLeft', target: 'rightpricescale' },
+		{ action: 'moveMouseCenter', target: 'rightpricescale' },
+		{ action: 'click', target: 'rightpricescale' },
+	];
+}
+
+function finalInteractionsToPerform() {
+	return [];
+}
+
+let chart;
+let moveCount = 0;
+let clickCount = 0;
+
+function beforeInteractions(container) {
+	chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addSeries(LightweightCharts.LineSeries);
+
+	const mainSeriesData = generateData();
+	mainSeries.setData(mainSeriesData);
+
+	mainSeries.priceScale().subscribeClick(mouseParams => {
+		if (!mouseParams) {
+			return;
+		}
+		clickCount += 1;
+	});
+	mainSeries.priceScale().subscribeMouseMove(mouseParams => {
+		if (!mouseParams) {
+			return;
+		}
+		moveCount += 1;
+	});
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			resolve();
+		});
+	});
+}
+
+function afterInitialInteractions() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+function afterFinalInteractions() {
+	if (clickCount < 1) {
+		throw new Error('Expected Click event handler to be evoked.');
+	}
+	if (moveCount < 1) {
+		throw new Error('Expected MouseMove event handler to be evoked.');
+	}
+	if (moveCount === 1) {
+		throw new Error(
+			'Expected MouseMove event handler to be evoked more than once.'
+		);
+	}
+	if (clickCount > 1) {
+		throw new Error('Expected click event handler to be evoked only once.');
+	}
+
+	return Promise.resolve();
+}

--- a/tests/e2e/interactions/test-cases/mouse/timescale-mouse-events.js
+++ b/tests/e2e/interactions/test-cases/mouse/timescale-mouse-events.js
@@ -1,0 +1,81 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 500; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function initialInteractionsToPerform() {
+	return [
+		{ action: 'moveMouseBottomRight', target: 'timescale' },
+		{ action: 'moveMouseTopLeft', target: 'timescale' },
+		{ action: 'moveMouseCenter', target: 'timescale' },
+		{ action: 'click', target: 'timescale' },
+	];
+}
+
+function finalInteractionsToPerform() {
+	return [];
+}
+
+let chart;
+let moveCount = 0;
+let clickCount = 0;
+
+function beforeInteractions(container) {
+	chart = LightweightCharts.createChart(container);
+
+	const mainSeries = chart.addSeries(LightweightCharts.LineSeries);
+
+	const mainSeriesData = generateData();
+	mainSeries.setData(mainSeriesData);
+
+	chart.timeScale().subscribeClick(mouseParams => {
+		if (!mouseParams) {
+			return;
+		}
+		clickCount += 1;
+	});
+	chart.timeScale().subscribeMouseMove(mouseParams => {
+		if (!mouseParams) {
+			return;
+		}
+		moveCount += 1;
+	});
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			resolve();
+		});
+	});
+}
+
+function afterInitialInteractions() {
+	return new Promise(resolve => {
+		requestAnimationFrame(resolve);
+	});
+}
+
+function afterFinalInteractions() {
+	if (clickCount < 1) {
+		throw new Error('Expected Click event handler to be evoked.');
+	}
+	if (moveCount < 1) {
+		throw new Error('Expected MouseMove event handler to be evoked.');
+	}
+	if (moveCount === 1) {
+		throw new Error('Expected MouseMove event handler to be evoked more than once.');
+	}
+	if (clickCount > 1) {
+		throw new Error('Expected click event handler to be evoked only once.');
+	}
+
+	return Promise.resolve();
+}


### PR DESCRIPTION
**Type of PR:** enhancement

**To do:**

- [ ] Tests
- [x] Documentation update

**Overview of change:**
Adds simple mouse (and touch) event handlers for movement and clicking on the price and time scales. These could be useful for plugin developers.

Adds about `0.44kb` to the bundle size.