### PR TITLE
Fixed unexpected base issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ commands:
             echo 'export BRANCH_SPECIFIC_TEST=<< parameters.branchSpecificTest >>' >> $BASH_ENV
       - run:
           command: scripts/run-graphics-tests.sh
-          no_output_timeout: 10m
+          no_output_timeout: 5m
 
       - store_test_results:
           path: test-results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ commands:
             echo 'export BRANCH_SPECIFIC_TEST=<< parameters.branchSpecificTest >>' >> $BASH_ENV
       - run:
           command: scripts/run-graphics-tests.sh
-          no_output_timeout: 20m
+          no_output_timeout: 10m
 
       - store_test_results:
           path: test-results/

--- a/src/helpers/mathex.ts
+++ b/src/helpers/mathex.ts
@@ -7,6 +7,11 @@ export function isBaseDecimal(value: number): boolean {
 		return false;
 	}
 
+	// cannot calculate exactly due to rounding error
+	if (value > 1e18) {
+		return true;
+	}
+
 	for (let current = value; current > 1; current /= 10) {
 		if ((current % 10) !== 0) {
 			return false;

--- a/src/model/iprice-data-source.ts
+++ b/src/model/iprice-data-source.ts
@@ -15,7 +15,7 @@ export interface IPriceDataSource extends IDataSource {
 	firstValue(): FirstValue | null;
 	formatter(): IPriceFormatter;
 	priceLineColor(lastBarColor: string): string;
-	minMove(): number;
+	base(): number;
 	autoscaleInfo(startTimePoint: TimePointIndex, endTimePoint: TimePointIndex): AutoscaleInfoImpl | null;
 	model(): IChartModelBase;
 }

--- a/src/model/price-data-source.ts
+++ b/src/model/price-data-source.ts
@@ -18,7 +18,7 @@ export abstract class PriceDataSource extends DataSource implements IPriceDataSo
 		return this._model;
 	}
 
-	public abstract minMove(): number;
+	public abstract base(): number;
 
 	public abstract autoscaleInfo(startTimePoint: TimePointIndex, endTimePoint: TimePointIndex): AutoscaleInfoImpl | null;
 

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -856,7 +856,7 @@ export class PriceScale {
 
 		let base = 100;
 		if (this._formatterSource !== null) {
-			base = Math.round(1 / this._formatterSource.minMove());
+			base = this._formatterSource.base();
 		}
 
 		this._formatter = defaultPriceFormatter;
@@ -1025,7 +1025,7 @@ export class PriceScale {
 			// keep current range is new is empty
 			if (priceRange.minValue() === priceRange.maxValue()) {
 				const formatterSource = this._formatterSource;
-				const minMove = formatterSource === null || this.isPercentage() || this.isIndexedTo100() ? 1 : formatterSource.minMove();
+				const minMove = formatterSource === null || this.isPercentage() || this.isIndexedTo100() ? 1 : 1 / formatterSource.base();
 
 				// if price range is degenerated to 1 point let's extend it by 10 min move values
 				// to avoid incorrect range and empty (blank) scale (in case of min tick much greater than 1)

--- a/src/model/price-scale.ts
+++ b/src/model/price-scale.ts
@@ -856,7 +856,7 @@ export class PriceScale {
 
 		let base = 100;
 		if (this._formatterSource !== null) {
-			base = this._formatterSource.base();
+			base = Math.round(this._formatterSource.base());
 		}
 
 		this._formatter = defaultPriceFormatter;

--- a/src/model/series-options.ts
+++ b/src/model/series-options.ts
@@ -569,6 +569,12 @@ export interface PriceFormatBuiltIn {
 	 * @defaultValue `0.01`
 	 */
 	minMove: number;
+	/**
+	 * The base value for the price format. It should equal to 1 / {@link minMove}.
+	 * If this option is specified, we ignore the {@link minMove} option.
+	 * It can be useful for cases with very small price movements like `1e-18` where we can reach limitations of floating point precision.
+	 */
+	base?: number;
 }
 
 /**
@@ -596,6 +602,12 @@ export interface PriceFormatCustom {
 	 * @defaultValue `0.01`
 	 */
 	minMove: number;
+	/**
+	 * The base value for the price format. It should equal to 1 / {@link minMove}.
+	 * If this option is specified, we ignore the {@link minMove} option.
+	 * It can be useful for cases with very small price movements like `1e-18` where we can reach limitations of floating point precision.
+	 */
+	base?: number;
 }
 
 /**

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -430,12 +430,7 @@ export class Series<T extends SeriesType> extends PriceDataSource implements IDe
 
 	public base(): number {
 		const priceFormat = this._options.priceFormat;
-		if (priceFormat.base !== undefined) {
-			return priceFormat.base;
-		}
-
-		const result = (1 / priceFormat.minMove);
-		return result > 1 ? Math.round(result) : result;
+		return priceFormat.base ?? (1 / priceFormat.minMove);
 	}
 
 	public formatter(): IPriceFormatter {

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -428,8 +428,9 @@ export class Series<T extends SeriesType> extends PriceDataSource implements IDe
 		return this._autoscaleInfoImpl(startTimePoint, endTimePoint);
 	}
 
-	public minMove(): number {
-		return this._options.priceFormat.minMove;
+	public base(): number {
+		const priceFormat = this._options.priceFormat;
+		return priceFormat.base ?? (1 / priceFormat.minMove);
 	}
 
 	public formatter(): IPriceFormatter {

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -430,7 +430,12 @@ export class Series<T extends SeriesType> extends PriceDataSource implements IDe
 
 	public base(): number {
 		const priceFormat = this._options.priceFormat;
-		return priceFormat.base ?? (1 / priceFormat.minMove);
+		if (priceFormat.base !== undefined) {
+			return priceFormat.base;
+		}
+
+		const result = (1 / priceFormat.minMove);
+		return result > 1 ? Math.round(result) : result;
 	}
 
 	public formatter(): IPriceFormatter {

--- a/tests/e2e/graphics/test-cases/series/series-price-formatter-extra-small-values.js
+++ b/tests/e2e/graphics/test-cases/series/series-price-formatter-extra-small-values.js
@@ -19,6 +19,7 @@ function runTestCase(container) {
 		priceFormat: {
 			type: 'custom',
 			formatter: p => `$${p}`,
+			minMove: 1e-18, // should be ignored because base is specified
 			base: 1e18,
 		},
 	});

--- a/tests/e2e/graphics/test-cases/series/series-price-formatter-extra-small-values.js
+++ b/tests/e2e/graphics/test-cases/series/series-price-formatter-extra-small-values.js
@@ -1,0 +1,26 @@
+function generateData() {
+	const res = [];
+	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
+	for (let i = 0; i < 60; ++i) {
+		res.push({
+			time: time.getTime() / 1000,
+			value: i * 1e-18,
+		});
+
+		time.setUTCDate(time.getUTCDate() + 1);
+	}
+	return res;
+}
+
+function runTestCase(container) {
+	const chart = window.chart = LightweightCharts.createChart(container, { layout: { attributionLogo: false } });
+
+	const lineSeries = chart.addSeries(LightweightCharts.LineSeries, {
+		priceFormat: {
+			type: 'custom',
+			format: p => `$${p}`,
+			base: 1e18,
+		},
+	});
+	lineSeries.setData(generateData());
+}

--- a/tests/e2e/graphics/test-cases/series/series-price-formatter-extra-small-values.js
+++ b/tests/e2e/graphics/test-cases/series/series-price-formatter-extra-small-values.js
@@ -18,7 +18,7 @@ function runTestCase(container) {
 	const lineSeries = chart.addSeries(LightweightCharts.LineSeries, {
 		priceFormat: {
 			type: 'custom',
-			format: p => `$${p}`,
+			formatter: p => `$${p}`,
 			base: 1e18,
 		},
 	});


### PR DESCRIPTION
**Type of PR:**  bugfix
**PR checklist:**

- [x] Addresses an existing issue: fixes #1951
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Added one additional option `base` to avoid calculation errors when we use `minMove`
