### PR TITLE
Fix typings path in compile script

### DIFF
--- a/indicator-examples/compile.mjs
+++ b/indicator-examples/compile.mjs
@@ -145,7 +145,7 @@ const compile = async () => {
 			}
 			const esModuleTyping = generateDtsBundle([
 				{
-					filePath: `./typings/indicator-examples/src/indicators/${stripCalculation(
+					filePath: `./typings/indicators/${stripCalculation(
 						file.exportName
 					)}/${file.exportName}.d.ts`,
 					// libraries: {

--- a/indicator-examples/package-lock.json
+++ b/indicator-examples/package-lock.json
@@ -17,7 +17,7 @@
             }
         },
         "..": {
-            "version": "5.0.6",
+            "version": "5.0.8",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {


### PR DESCRIPTION
**Type of PR:** examples fix

**PR checklist:**

- [x] Addresses an existing issue: fixes #1968
- `N/A` Includes tests
- `N/A` Documentation update

Corrects the typings file path in the compile.mjs script to reference the correct directory structure for indicator typings. Fixes #1968