### PR TITLE
perf: use blazediff for faster screenshots comparison

### DIFF
--- a/indicator-examples/package-lock.json
+++ b/indicator-examples/package-lock.json
@@ -24,7 +24,7 @@
                 "fancy-canvas": "2.1.0"
             },
             "devDependencies": {
-                "@blazediff/core": "~1.1.0",
+                "@blazediff/core": "1.4.1",
                 "@juggle/resize-observer": "3.4.0",
                 "@rollup/plugin-node-resolve": "16.0.1",
                 "@rollup/plugin-replace": "6.0.2",

--- a/indicator-examples/package-lock.json
+++ b/indicator-examples/package-lock.json
@@ -24,7 +24,7 @@
                 "fancy-canvas": "2.1.0"
             },
             "devDependencies": {
-                "@blazediff/core": "1.4.1",
+                "@blazediff/core": "~1.9.0",
                 "@juggle/resize-observer": "3.4.0",
                 "@rollup/plugin-node-resolve": "16.0.1",
                 "@rollup/plugin-replace": "6.0.2",

--- a/indicator-examples/package-lock.json
+++ b/indicator-examples/package-lock.json
@@ -24,6 +24,7 @@
                 "fancy-canvas": "2.1.0"
             },
             "devDependencies": {
+                "@blazediff/core": "~1.1.0",
                 "@juggle/resize-observer": "3.4.0",
                 "@rollup/plugin-node-resolve": "16.0.1",
                 "@rollup/plugin-replace": "6.0.2",
@@ -34,7 +35,6 @@
                 "@types/express": "5.0.1",
                 "@types/glob": "8.1.0",
                 "@types/node": "22",
-                "@types/pixelmatch": "5.2.6",
                 "@types/pngjs": "6.0.5",
                 "@typescript-eslint/eslint-plugin": "7.18.0",
                 "@typescript-eslint/eslint-plugin-tslint": "7.0.2",
@@ -64,7 +64,6 @@
                 "markdownlint-cli": "0.44.0",
                 "memlab": "1.1.57",
                 "npm-run-all": "4.1.5",
-                "pixelmatch": "7.1.0",
                 "pngjs": "7.0.0",
                 "puppeteer": "24.6.1",
                 "rimraf": "6.0.1",
@@ -1442,6 +1441,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1585,6 +1585,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "fancy-canvas": "2.1.0"
       },
       "devDependencies": {
-        "@blazediff/core": "~1.1.0",
+        "@blazediff/core": "~1.4.1",
         "@juggle/resize-observer": "3.4.0",
         "@rollup/plugin-node-resolve": "16.0.1",
         "@rollup/plugin-replace": "6.0.2",
@@ -201,19 +201,19 @@
       }
     },
     "node_modules/@blazediff/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-f1qdZ2Z0f9bqityiH07mFz29uVGBL9QySKFpBz6dyTjt5ucCdW0pb4umTepZI5rKJVzaw0ZAsE7VoGC56usO/g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-mNhxncafu6xHV1+6v4K7AvwOodnIFcmqERNbdcDCL7jb9mMXDy4DKcidbnQG5ExKsgBYUhOhJs2qrpdOS52qUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@blazediff/types": "1.1.0"
+        "@blazediff/types": "1.4.1"
       }
     },
     "node_modules/@blazediff/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@blazediff/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-yNTG53982iTy6sFzEdxnt0pLcFyMuLVY+FKaeMQiyeCaOjELGmELmamDxltIHfDnr8/laxijPgdnmTRy58sOiQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/types/-/types-1.4.1.tgz",
+      "integrity": "sha512-c5se1YZMvdJiF/M/kPOFkw/E1BbfV6U4KsE6QcJiM9dVL1ix4ze/EmLIYvHwOX54kzxi2iWL0BZgMOlfWQRJ2A==",
       "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "fancy-canvas": "2.1.0"
       },
       "devDependencies": {
+        "@blazediff/core": "~1.1.0",
         "@juggle/resize-observer": "3.4.0",
         "@rollup/plugin-node-resolve": "16.0.1",
         "@rollup/plugin-replace": "6.0.2",
@@ -23,7 +24,6 @@
         "@types/express": "5.0.1",
         "@types/glob": "8.1.0",
         "@types/node": "22",
-        "@types/pixelmatch": "5.2.6",
         "@types/pngjs": "6.0.5",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/eslint-plugin-tslint": "7.0.2",
@@ -53,7 +53,6 @@
         "markdownlint-cli": "0.44.0",
         "memlab": "1.1.57",
         "npm-run-all": "4.1.5",
-        "pixelmatch": "7.1.0",
         "pngjs": "7.0.0",
         "puppeteer": "24.6.1",
         "rimraf": "6.0.1",
@@ -200,6 +199,22 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-f1qdZ2Z0f9bqityiH07mFz29uVGBL9QySKFpBz6dyTjt5ucCdW0pb4umTepZI5rKJVzaw0ZAsE7VoGC56usO/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/types": "1.1.0"
+      }
+    },
+    "node_modules/@blazediff/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@blazediff/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-yNTG53982iTy6sFzEdxnt0pLcFyMuLVY+FKaeMQiyeCaOjELGmELmamDxltIHfDnr8/laxijPgdnmTRy58sOiQ==",
+      "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2572,16 +2587,6 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/pixelmatch": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.6.tgz",
-      "integrity": "sha512-wC83uexE5KGuUODn6zkm9gMzTwdY5L0chiK+VrKcDfEjzxh1uadlWTvOmAbCpnM9zx/Ww3f8uKlYQVnO/TrqVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/pngjs": {
       "version": "6.0.5",
@@ -11001,19 +11006,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
-      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^7.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/pluralize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "fancy-canvas": "2.1.0"
       },
       "devDependencies": {
-        "@blazediff/core": "~1.4.1",
+        "@blazediff/core": "~1.9.0",
         "@juggle/resize-observer": "3.4.0",
         "@rollup/plugin-node-resolve": "16.0.1",
         "@rollup/plugin-replace": "6.0.2",
@@ -201,20 +201,11 @@
       }
     },
     "node_modules/@blazediff/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-mNhxncafu6xHV1+6v4K7AvwOodnIFcmqERNbdcDCL7jb9mMXDy4DKcidbnQG5ExKsgBYUhOhJs2qrpdOS52qUA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-4W6TNzvD5KyUWiAHT+MyAg79FWe8rv493nfvWKeWox67lbUHTiTy40n7rmg6cQjhu5hflCDw73FExgmv22IgNQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@blazediff/types": "1.4.1"
-      }
-    },
-    "node_modules/@blazediff/types": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@blazediff/types/-/types-1.4.1.tgz",
-      "integrity": "sha512-c5se1YZMvdJiF/M/kPOFkw/E1BbfV6U4KsE6QcJiM9dVL1ix4ze/EmLIYvHwOX54kzxi2iWL0BZgMOlfWQRJ2A==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "fancy-canvas": "2.1.0"
   },
   "devDependencies": {
+    "@blazediff/core": "~1.1.0",
     "@juggle/resize-observer": "3.4.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-replace": "6.0.2",
@@ -65,7 +66,6 @@
     "@types/express": "5.0.1",
     "@types/glob": "8.1.0",
     "@types/node": "22",
-    "@types/pixelmatch": "5.2.6",
     "@types/pngjs": "6.0.5",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/eslint-plugin-tslint": "7.0.2",
@@ -95,7 +95,6 @@
     "markdownlint-cli": "0.44.0",
     "memlab": "1.1.57",
     "npm-run-all": "4.1.5",
-    "pixelmatch": "7.1.0",
     "pngjs": "7.0.0",
     "puppeteer": "24.6.1",
     "rimraf": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fancy-canvas": "2.1.0"
   },
   "devDependencies": {
-    "@blazediff/core": "~1.1.0",
+    "@blazediff/core": "~1.4.1",
     "@juggle/resize-observer": "3.4.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-replace": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fancy-canvas": "2.1.0"
   },
   "devDependencies": {
-    "@blazediff/core": "~1.4.1",
+    "@blazediff/core": "~1.9.0",
     "@juggle/resize-observer": "3.4.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-replace": "6.0.2",

--- a/plugin-examples/package-lock.json
+++ b/plugin-examples/package-lock.json
@@ -24,7 +24,7 @@
                 "fancy-canvas": "2.1.0"
             },
             "devDependencies": {
-                "@blazediff/core": "~1.1.0",
+                "@blazediff/core": "1.4.1",
                 "@juggle/resize-observer": "3.4.0",
                 "@rollup/plugin-node-resolve": "16.0.1",
                 "@rollup/plugin-replace": "6.0.2",

--- a/plugin-examples/package-lock.json
+++ b/plugin-examples/package-lock.json
@@ -24,7 +24,7 @@
                 "fancy-canvas": "2.1.0"
             },
             "devDependencies": {
-                "@blazediff/core": "1.4.1",
+                "@blazediff/core": "~1.9.0",
                 "@juggle/resize-observer": "3.4.0",
                 "@rollup/plugin-node-resolve": "16.0.1",
                 "@rollup/plugin-replace": "6.0.2",

--- a/plugin-examples/package-lock.json
+++ b/plugin-examples/package-lock.json
@@ -24,6 +24,7 @@
                 "fancy-canvas": "2.1.0"
             },
             "devDependencies": {
+                "@blazediff/core": "~1.1.0",
                 "@juggle/resize-observer": "3.4.0",
                 "@rollup/plugin-node-resolve": "16.0.1",
                 "@rollup/plugin-replace": "6.0.2",
@@ -34,7 +35,6 @@
                 "@types/express": "5.0.1",
                 "@types/glob": "8.1.0",
                 "@types/node": "22",
-                "@types/pixelmatch": "5.2.6",
                 "@types/pngjs": "6.0.5",
                 "@typescript-eslint/eslint-plugin": "7.18.0",
                 "@typescript-eslint/eslint-plugin-tslint": "7.0.2",
@@ -64,7 +64,6 @@
                 "markdownlint-cli": "0.44.0",
                 "memlab": "1.1.57",
                 "npm-run-all": "4.1.5",
-                "pixelmatch": "7.1.0",
                 "pngjs": "7.0.0",
                 "puppeteer": "24.6.1",
                 "rimraf": "6.0.1",
@@ -1442,6 +1441,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1585,6 +1585,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/tests/e2e/graphics/README.md
+++ b/tests/e2e/graphics/README.md
@@ -1,13 +1,13 @@
 # Graphics tests
 
-This tests uses [puppeteer](https://github.com/GoogleChrome/puppeteer) to generate screenshots and then [pixelmatch](https://github.com/mapbox/pixelmatch) to compare them.
+This tests uses [puppeteer](https://github.com/GoogleChrome/puppeteer) to generate screenshots and then [blazediff](https://blazediff.dev) to compare them.
 
 ## How it works
 
 1. If there are local files to serve - run web server.
 1. Run `node:test` with loaded test cases.
 1. Then, for each test case, open webpage by `puppeteer` for golden and test version, take 2 screenshots.
-1. Compare given screenshots by `pixelmatch`, write them in out folder (with HTML pages).
+1. Compare given screenshots by `blazediff`, write them in out folder (with HTML pages).
 
 ## Writing new test case
 

--- a/tests/e2e/graphics/helpers/compare-screenshots.ts
+++ b/tests/e2e/graphics/helpers/compare-screenshots.ts
@@ -1,4 +1,4 @@
-import pixelmatch from 'pixelmatch';
+import blazediff from '@blazediff/core';
 import { PNG } from 'pngjs';
 
 export interface CompareResult {
@@ -20,7 +20,7 @@ export function compareScreenshots(leftImg: PNG, rightImg: PNG): CompareResult {
 		height: rightImg.height,
 	});
 
-	const diffPixelsCount = pixelmatch(
+	const diffPixelsCount = blazediff(
 		leftImg.data, rightImg.data,
 		diffImg.data,
 		leftImg.width, leftImg.height,


### PR DESCRIPTION
**perf** <!-- bugfix, enhancement, fix typo, etc -->

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

This PR replaces [pixelmatch](https://github.com/mapbox/pixelmatch) with [blazediff](https://www.blazediff.dev/) in the E2E testing infrastructure to improve image comparison performance.

BlazeDiff is ~1.5x times faster than pixelmatch, producing the same results in type-safe code that is available in ESM and CJS.

BlazeDiff is already integrated in:
- [ant-design/ant-design](https://github.com/ant-design/ant-design/blob/b5d72b5a77ea03be576f9946bd21a3b05c3e857d/package.json#L170)
- [antvis/g](https://github.com/antvis/G/blob/95d348ba6728bc547dbf4139b02278f173721d4f/package.json#L62)
- [vega/vega](https://github.com/vega/vega/blob/dae7a7dd26dfd8ce8574e0df3224d394c6098881/package.json#L31)
- [apexcharts/apexchartsjs](https://github.com/apexcharts/apexcharts.js/blob/0e7addc291d4fadbe4aa6f07d682dda106f3ebf1/package.json#L51)

**Is there anything you'd like reviewers to focus on?**

<!-- optional -->
