### PR TITLE
Fix conflation logic and update tests for data handling

### DIFF
--- a/src/model/data-conflater.ts
+++ b/src/model/data-conflater.ts
@@ -445,7 +445,6 @@ export class DataConflater<T extends SeriesType, HorzScaleItem = unknown> {
 		}
 
 		const lastOriginalIndex = originalData.length - 1;
-		const overrideIndex = lastOriginalIndex;
 		const chunkStartIndex = Math.floor(lastOriginalIndex / conflationLevel) * conflationLevel;
 		const chunkEndIndex = Math.min(chunkStartIndex + conflationLevel, originalData.length);
 
@@ -453,11 +452,11 @@ export class DataConflater<T extends SeriesType, HorzScaleItem = unknown> {
 			// we must allocate a new array here to do a full rebuild.
 			const newOriginalData = originalData.slice();
 			newOriginalData[newOriginalData.length - 1] = newLastRow;
-			return this.conflateByFactor(originalData, conflationLevel, customReducer, isCustomSeries, priceValueBuilder);
+			return this.conflateByFactor(newOriginalData, conflationLevel, customReducer, isCustomSeries, priceValueBuilder);
 		}
 
 		const lastChunkIndex = Math.floor((lastOriginalIndex - 1) / conflationLevel);
-		const newChunkIndex = Math.floor(overrideIndex / conflationLevel);
+		const newChunkIndex = Math.floor(lastOriginalIndex / conflationLevel);
 
 		if (lastChunkIndex === newChunkIndex || cachedRows.length === 1) {
 			// Data length is within the same chunk OR it's the only chunk
@@ -469,10 +468,10 @@ export class DataConflater<T extends SeriesType, HorzScaleItem = unknown> {
 			}
 
 			const mergedChunk = count === 1
-				? this._plotRowToChunk((chunkStartIndex === overrideIndex) ? newLastRow : originalData[chunkStartIndex], /* isRemainder*/ true)
+				? this._plotRowToChunk((chunkStartIndex === lastOriginalIndex) ? newLastRow : originalData[chunkStartIndex], /* isRemainder*/ true)
 				: this._mergeRangeWithOverride(
 					originalData, chunkStartIndex, actualEndIndex,
-					overrideIndex, newLastRow,
+					lastOriginalIndex, newLastRow,
 					customReducer, isCustomSeries, priceValueBuilder
 				);
 

--- a/src/model/time-scale.ts
+++ b/src/model/time-scale.ts
@@ -261,9 +261,9 @@ export interface HorzScaleOptions {
 
 	/**
 	 * Precompute conflation chunks for common levels right after data load.
-	 * When enabled, the system will precompute conflation data for standard factors
-	 * (2, 5, 10, 25, 50, 100, 200, 300) in the background, which improves performance
-	 * when zooming out but increases initial load time and memory usage.
+	 * When enabled, the system will precompute conflation data in the background,
+	 * which improves performance when zooming out but increases initial load time
+	 * and memory usage.
 	 *
 	 * Performance impact:
 	 * - Initial load: +100-500ms depending on dataset size
@@ -271,7 +271,6 @@ export interface HorzScaleOptions {
 	 * - Zoom performance: Significant improvement (10-100x faster)
 	 *
 	 * Recommended for: Large datasets (\>10K points) on machines with sufficient memory
-	 * Precompute conflation chunks for common levels right after data load.
 	 * @defaultValue false
 	 */
 	precomputeConflationOnInit: boolean;

--- a/tests/e2e/graphics/test-cases/time-scale/conflation-line-series.js
+++ b/tests/e2e/graphics/test-cases/time-scale/conflation-line-series.js
@@ -1,7 +1,7 @@
-function generateData() {
+function generateData(count) {
 	const res = [];
 	const time = new Date(Date.UTC(2018, 0, 1, 0, 0, 0, 0));
-	for (let i = 0; i < 1000; ++i) {
+	for (let i = 0; i < count; ++i) {
 		res.push({
 			time: time.getTime() / 1000,
 			value: i,
@@ -28,7 +28,7 @@ function runTestCase(container) {
 		lineWidth: 2,
 	});
 
-	// Generate 400k data points
+	// Generate 40k data points
 	const data = generateData(40000);
 	lineSeries.setData(data);
 

--- a/tests/unittests/data-layer.spec.ts
+++ b/tests/unittests/data-layer.spec.ts
@@ -23,6 +23,7 @@ function createSeriesMock<T extends SeriesType = SeriesType>(seriesType?: T): Se
 
 	return {
 		bars: () => data,
+		conflatedBars: () => data,
 		seriesType: () => seriesType || 'Line',
 		customSeriesPlotValuesBuilder: () => {},
 		customSeriesWhitespaceCheck: () => {},


### PR DESCRIPTION
Corrects the logic in `DataConflater` to use the updated last row for conflation, ensuring proper chunk merging. Updates the `HorzScaleOptions` documentation for clarity, adjusts the test data size in the E2E test, and adds a missing mock method in the unit test.

Address some review comments on the #1945 PR.