### PR TITLE
feat(price-line): add configurable hitTestTolerance option

### DIFF
--- a/src/api/options/price-line-options-defaults.ts
+++ b/src/api/options/price-line-options-defaults.ts
@@ -6,6 +6,7 @@ export const priceLineOptionsDefaults: PriceLineOptions = {
 	price: 0,
 	lineStyle: LineStyle.Dashed,
 	lineWidth: 1,
+	hitTestTolerance: 7,
 	lineVisible: true,
 	axisLabelVisible: true,
 	title: '',

--- a/src/model/data-validators.ts
+++ b/src/model/data-validators.ts
@@ -1,6 +1,7 @@
 /// <reference types="_build-time-constants" />
 
 import { assert } from '../helpers/assertions';
+import { isNumber } from '../helpers/strict-type-checks';
 
 import { isFulfilledData, OhlcData, SeriesDataItemTypeMap } from './data-consumer';
 import { IHorzScaleBehavior } from './ihorz-scale-behavior';
@@ -15,7 +16,7 @@ export function checkPriceLineOptions(options: CreatePriceLineOptions): void {
 	assert(typeof options.price === 'number', `the type of 'price' price line's property must be a number, got '${typeof options.price}'`);
 
 	if (options.hitTestTolerance !== undefined) {
-		assert(typeof options.hitTestTolerance === 'number', `the type of 'hitTestTolerance' price line's property must be a number, got '${typeof options.hitTestTolerance}'`);
+		assert(isNumber(options.hitTestTolerance), `'hitTestTolerance' price line's property must be a finite number, got '${options.hitTestTolerance}'`);
 		assert(options.hitTestTolerance >= 0, `'hitTestTolerance' price line's property must be a non-negative number, got '${options.hitTestTolerance}'`);
 	}
 }

--- a/src/model/data-validators.ts
+++ b/src/model/data-validators.ts
@@ -13,6 +13,11 @@ export function checkPriceLineOptions(options: CreatePriceLineOptions): void {
 	}
 
 	assert(typeof options.price === 'number', `the type of 'price' price line's property must be a number, got '${typeof options.price}'`);
+
+	if (options.hitTestTolerance !== undefined) {
+		assert(typeof options.hitTestTolerance === 'number', `the type of 'hitTestTolerance' price line's property must be a number, got '${typeof options.hitTestTolerance}'`);
+		assert(options.hitTestTolerance >= 0, `'hitTestTolerance' price line's property must be a non-negative number, got '${options.hitTestTolerance}'`);
+	}
 }
 
 export function checkItemsAreOrdered<HorzScaleItem>(data: readonly (SeriesDataItemTypeMap<HorzScaleItem>[SeriesType])[], bh: IHorzScaleBehavior<HorzScaleItem>, allowDuplicates: boolean = false): void {

--- a/src/model/price-line-options.ts
+++ b/src/model/price-line-options.ts
@@ -63,6 +63,16 @@ export interface PriceLineOptions {
 	 * @defaultValue `''`
 	 */
 	axisLabelTextColor: string;
+	/**
+	 * Hit-test tolerance in pixels, added on each side of the line (in addition to its
+	 * {@link lineWidth}) when determining whether a pointer event hits this price line.
+	 * Lower values require more precise pointing; `0` limits hits to the line itself.
+	 * Useful on desktop where the default tolerance can cause nearby price lines to
+	 * register as the same hit.
+	 *
+	 * @defaultValue `7`
+	 */
+	hitTestTolerance: number;
 }
 
 /**

--- a/src/renderers/horizontal-line-renderer.ts
+++ b/src/renderers/horizontal-line-renderer.ts
@@ -10,13 +10,14 @@ export interface HorizontalLineRendererData {
 	color: string;
 	lineStyle: LineStyle;
 	lineWidth: LineWidth;
+	hitTestTolerance?: number;
 
 	y: Coordinate;
 	visible?: boolean;
 	externalId?: string;
 }
 
-const enum Constants { HitTestThreshold = 7, }
+const DEFAULT_HIT_TEST_TOLERANCE = 7;
 
 export class HorizontalLineRenderer extends BitmapCoordinatesPaneRenderer {
 	private _data: HorizontalLineRendererData | null = null;
@@ -30,10 +31,11 @@ export class HorizontalLineRenderer extends BitmapCoordinatesPaneRenderer {
 			return null;
 		}
 
-		const { y: itemY, lineWidth, externalId } = this._data;
-		// Price lines and baseline lines use the renderer fallback path, not the
-		// main-series hitTestTolerance option. Keep their legacy grab area stable.
-		if (y >= itemY - lineWidth - Constants.HitTestThreshold && y <= itemY + lineWidth + Constants.HitTestThreshold) {
+		const { y: itemY, lineWidth, hitTestTolerance = DEFAULT_HIT_TEST_TOLERANCE, externalId } = this._data;
+		// Expand the hit area by lineWidth + tolerance on each side. Baseline lines and
+		// internal price lines use this renderer's fallback default rather than the
+		// series hitTestTolerance option, so callers that omit the field keep the legacy grab area.
+		if (y >= itemY - lineWidth - hitTestTolerance && y <= itemY + lineWidth + hitTestTolerance) {
 			return {
 				hitTestData: this._data,
 				distance: Math.abs(y - itemY),

--- a/src/views/pane/custom-price-line-pane-view.ts
+++ b/src/views/pane/custom-price-line-pane-view.ts
@@ -32,6 +32,7 @@ export class CustomPriceLinePaneView extends SeriesHorizontalLinePaneView {
 		data.color = lineOptions.color;
 		data.lineWidth = lineOptions.lineWidth;
 		data.lineStyle = lineOptions.lineStyle;
+		data.hitTestTolerance = lineOptions.hitTestTolerance;
 		data.externalId = this._priceLine.options().id;
 	}
 }

--- a/tests/unittests/price-line-options-validator.spec.ts
+++ b/tests/unittests/price-line-options-validator.spec.ts
@@ -24,7 +24,18 @@ describe('checkPriceLineOptions', () => {
 	it('rejects a non-number hitTestTolerance', () => {
 		throws(
 			() => checkPriceLineOptions({ price: 42, hitTestTolerance: 'big' as unknown as number }),
-			/hitTestTolerance.*must be a number/i
+			/hitTestTolerance.*must be a finite number/i
+		);
+	});
+
+	it('rejects Infinity and NaN', () => {
+		throws(
+			() => checkPriceLineOptions({ price: 42, hitTestTolerance: Infinity }),
+			/hitTestTolerance.*must be a finite number/i
+		);
+		throws(
+			() => checkPriceLineOptions({ price: 42, hitTestTolerance: NaN }),
+			/hitTestTolerance.*must be a finite number/i
 		);
 	});
 });

--- a/tests/unittests/price-line-options-validator.spec.ts
+++ b/tests/unittests/price-line-options-validator.spec.ts
@@ -1,0 +1,29 @@
+import { doesNotThrow, throws } from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { checkPriceLineOptions } from '../../src/model/data-validators';
+
+describe('checkPriceLineOptions', () => {
+	it('accepts a valid price with no hitTestTolerance', () => {
+		doesNotThrow(() => checkPriceLineOptions({ price: 42 }));
+	});
+
+	it('accepts a non-negative hitTestTolerance', () => {
+		doesNotThrow(() => checkPriceLineOptions({ price: 42, hitTestTolerance: 0 }));
+		doesNotThrow(() => checkPriceLineOptions({ price: 42, hitTestTolerance: 12 }));
+	});
+
+	it('rejects a negative hitTestTolerance', () => {
+		throws(
+			() => checkPriceLineOptions({ price: 42, hitTestTolerance: -1 }),
+			/hitTestTolerance.*non-negative/i
+		);
+	});
+
+	it('rejects a non-number hitTestTolerance', () => {
+		throws(
+			() => checkPriceLineOptions({ price: 42, hitTestTolerance: 'big' as unknown as number }),
+			/hitTestTolerance.*must be a number/i
+		);
+	});
+});

--- a/tests/unittests/price-line-options-validator.spec.ts
+++ b/tests/unittests/price-line-options-validator.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { doesNotThrow, throws } from 'node:assert/strict';
 import { describe, it } from 'node:test';
 


### PR DESCRIPTION
## Summary

Closes #1610.

If you stack several price lines close together on a chart, hovering over one can register as a hit on a neighbor. The reason is a 7-pixel hit-test extension around each line that's hardcoded in the renderer. On desktop, where the cursor is precise, that extra padding is usually more confusing than helpful, and there's no way to tighten it.

This PR makes the value configurable per price line via a new `hitTestTolerance: number` on `PriceLineOptions`. The name matches the series-level `hitTestTolerance` option added in #2090, so the two hit-test surfaces stay consistent. Default stays at 7 (the historical price-line value), so existing integrations don't change. Set it to 0 on desktop for exact hits, or bump it higher for a fatter touch target on mobile.

## The change

- Adds `hitTestTolerance: number` to `PriceLineOptions` with TSDoc and `@defaultValue 7`.
- Sets `hitTestTolerance: 7` in `priceLineOptionsDefaults`.
- `HorizontalLineRenderer` reads the field from its data. It falls back to 7 when the field is absent, which keeps `SeriesPriceLinePaneView` and `SeriesHorizontalBaseLinePaneView` (the two internal consumers of this renderer that aren't user-configurable) on their legacy behavior with no code change.
- Deletes the private `const enum Constants { HitTestThreshold = 7 }`. The constant lives in one place now, inside the renderer module.
- `CustomPriceLinePaneView` populates the new field from user options.
- `checkPriceLineOptions` (dev builds only) rejects non-finite and negative values using the existing `isNumber` helper.

## How it was tested

- 5 unit tests in `tests/unittests/price-line-options-validator.spec.ts` cover the accept/reject paths, including `Infinity` and `NaN`.
- `tsc -b src/tsconfig.composite.json`, `eslint` on the changed files, and the unit suite all pass after rebasing onto current `master`.

## History note

Rebased onto current `master` to resolve a conflict in `horizontal-line-renderer.ts` introduced by #2090, and renamed the option from the original `hitTestThreshold` to `hitTestTolerance` for consistency with the series-level option. The runtime hit-test math is unchanged (`itemY ± (lineWidth + tolerance)`), so this revision is a rename plus rebase on top of the originally reviewed behavior.

PS: No graphics tests added. This change only affects hit-testing math, not pixels.