### PR TITLE
Security improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -52,7 +54,7 @@ jobs:
         run: npm run build:examples:site
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -11,10 +11,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -11,8 +11,10 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v1
-      - uses: andresz1/size-limit-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: build:prod

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/scripts/compare-size-with-merge-base.js
+++ b/scripts/compare-size-with-merge-base.js
@@ -22,14 +22,41 @@ function run(file, args) {
 	}
 }
 
+// Only use this for static command strings with no dynamic content.
+// This keeps fixed npm commands compatible with Windows shells.
+function runShell(command) {
+	try {
+		return {
+			success: true,
+			output: childProcess.execSync(command, { encoding: 'utf-8', stdio: 'pipe' }).trim(),
+		};
+	} catch (e) {
+		return { success: false, output: e.stderr || e.stdout || e.toString() };
+	}
+}
+
 function runForSuccess(file, args) {
 	runForOutput(file, args);
+}
+
+function runShellForSuccess(command) {
+	runShellForOutput(command);
 }
 
 function runForOutput(file, args) {
 	const res = run(file, args);
 	if (!res.success) {
 		console.error(`Can't execute "${file} ${args.join(' ')}":\n${res.output}`);
+		process.exit(1);
+	}
+
+	return res.output;
+}
+
+function runShellForOutput(command) {
+	const res = runShell(command);
+	if (!res.success) {
+		console.error(`Can't execute "${command}":\n${res.output}`);
 		process.exit(1);
 	}
 
@@ -78,10 +105,10 @@ async function main() {
 	runForSuccess('git', ['checkout', revToCheck]);
 
 	console.log(`Installing dependencies...`);
-	runForSuccess('npm', ['install']);
+	runShellForSuccess('npm install');
 
 	console.log(`Building the library...`);
-	runForSuccess('npm', ['run', 'build:prod']);
+	runShellForSuccess('npm run build:prod');
 
 	const oldSizes = await getSizes();
 
@@ -89,10 +116,10 @@ async function main() {
 	runForSuccess('git', ['checkout', headRev]);
 
 	console.log(`Installing dependencies...`);
-	runForSuccess('npm', ['install']);
+	runShellForSuccess('npm install');
 
 	console.log(`Building the library...`);
-	runForSuccess('npm', ['run', 'build:prod']);
+	runShellForSuccess('npm run build:prod');
 
 	const newSizes = await getSizes();
 

--- a/scripts/compare-size-with-merge-base.js
+++ b/scripts/compare-size-with-merge-base.js
@@ -11,25 +11,25 @@ import filePlugin from '@size-limit/file';
 
 import sizeLimitConfig from '../.size-limit.js';
 
-function run(cmd) {
+function run(file, args) {
 	try {
 		return {
 			success: true,
-			output: childProcess.execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trim(),
+			output: childProcess.execFileSync(file, args, { encoding: 'utf-8', stdio: 'pipe' }).trim(),
 		};
 	} catch (e) {
 		return { success: false, output: e.stderr || e.stdout || e.toString() };
 	}
 }
 
-function runForSuccess(cmd) {
-	runForOutput(cmd);
+function runForSuccess(file, args) {
+	runForOutput(file, args);
 }
 
-function runForOutput(cmd) {
-	const res = run(cmd);
+function runForOutput(file, args) {
+	const res = run(file, args);
 	if (!res.success) {
-		console.error(`Can't execute "${cmd}":\n${res.output}`);
+		console.error(`Can't execute "${file} ${args.join(' ')}":\n${res.output}`);
 		process.exit(1);
 	}
 
@@ -63,36 +63,36 @@ function formatChange(newSize, oldSize) {
 const compareBranch = process.env.COMPARE_BRANCH;
 
 async function main() {
-	let headRev = runForOutput('git rev-parse --abbrev-ref HEAD');
+	let headRev = runForOutput('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
 	if (headRev.length === 0 || headRev === 'HEAD') {
-		headRev = runForOutput('git rev-parse HEAD');
+		headRev = runForOutput('git', ['rev-parse', 'HEAD']);
 	}
 
 	const revToCheck = compareBranch
-		? runForOutput(`git rev-parse origin/${compareBranch}`)
-		: runForOutput(`git merge-base origin/master "${headRev}"`);
+		? runForOutput('git', ['rev-parse', `origin/${compareBranch}`])
+		: runForOutput('git', ['merge-base', 'origin/master', headRev]);
 
 	console.log(`Using "${revToCheck}" as base\n`);
 
 	console.log(`Switching to ${revToCheck}`);
-	runForSuccess(`git checkout ${revToCheck}`);
+	runForSuccess('git', ['checkout', revToCheck]);
 
 	console.log(`Installing dependencies...`);
-	runForSuccess(`npm install`);
+	runForSuccess('npm', ['install']);
 
 	console.log(`Building the library...`);
-	runForSuccess(`npm run build:prod`);
+	runForSuccess('npm', ['run', 'build:prod']);
 
 	const oldSizes = await getSizes();
 
 	console.log(`\nSwitching back to ${headRev}`);
-	runForSuccess(`git checkout ${headRev}`);
+	runForSuccess('git', ['checkout', headRev]);
 
 	console.log(`Installing dependencies...`);
-	runForSuccess(`npm install`);
+	runForSuccess('npm', ['install']);
 
 	console.log(`Building the library...`);
-	runForSuccess(`npm run build:prod`);
+	runForSuccess('npm', ['run', 'build:prod']);
 
 	const newSizes = await getSizes();
 

--- a/scripts/githooks/pre-commit/lint.js
+++ b/scripts/githooks/pre-commit/lint.js
@@ -30,38 +30,21 @@ function checkGitConflicts(files) {
 	return hasErrors;
 }
 
-function run(cmd) {
+function run(file, args) {
 	try {
-		childProcess.execSync(cmd, { stdio: 'inherit' });
+		childProcess.execFileSync(file, args, { stdio: 'inherit' });
 		return false;
 	} catch (e) {
 		return true;
 	}
 }
 
-function shellEscape(arg) {
-	if (!/[\s"$`]/.test(arg)) {
-		return arg;
-	}
-
-	return `"${arg
-		.replace(/"/g, '\\"')
-		.replace(/\$/g, '\\$')
-		.replace(/`/g, '\\`')
-	}"`;
-}
-
-function runForFiles(cmd, files) {
+function runForFiles(file, baseArgs, files) {
 	if (files.length === 0) {
 		return false;
 	}
 
-	cmd += ' ';
-	for (const file of files) {
-		cmd += `${shellEscape(file)} `;
-	}
-
-	return run(cmd);
+	return run(file, [...baseArgs, ...files]);
 }
 
 function runESLintForFiles(files) {
@@ -69,11 +52,11 @@ function runESLintForFiles(files) {
 		return false;
 	}
 
-	return runForFiles('node ./node_modules/eslint/bin/eslint --quiet --format=unix', files);
+	return runForFiles('node', ['./node_modules/eslint/bin/eslint', '--quiet', '--format=unix'], files);
 }
 
 function runMarkdownLintForFiles(mdFiles) {
-	return runForFiles('node ./node_modules/markdownlint-cli/markdownlint.js', mdFiles);
+	return runForFiles('node', ['./node_modules/markdownlint-cli/markdownlint.js'], mdFiles);
 }
 
 function filterByExt(files, ext) {
@@ -92,7 +75,7 @@ function lintFiles(files) {
 	const tsFiles = filterByExt(files, '.ts');
 	const tsxFiles = filterByExt(files, '.tsx');
 	if (tsFiles.length !== 0 || tsxFiles.length !== 0) {
-		hasErrors = run('npm run tsc-verify') || hasErrors;
+		hasErrors = run('npm', ['run', 'tsc-verify']) || hasErrors;
 		hasErrors = runESLintForFiles(tsFiles) || hasErrors;
 		hasErrors = runESLintForFiles(tsxFiles) || hasErrors;
 	}
@@ -103,7 +86,7 @@ function lintFiles(files) {
 		// yeah, eslint might check code inside markdown files
 		hasErrors = runESLintForFiles(mdFiles) || hasErrors;
 		hasErrors = runMarkdownLintForFiles(mdFiles) || hasErrors;
-		hasErrors = run('node scripts/check-markdown-links.js') || hasErrors;
+		hasErrors = run('node', ['scripts/check-markdown-links.js']) || hasErrors;
 	}
 
 	// markdown react

--- a/scripts/githooks/pre-commit/lint.js
+++ b/scripts/githooks/pre-commit/lint.js
@@ -39,6 +39,17 @@ function run(file, args) {
 	}
 }
 
+// Only use this for static command strings with no dynamic content.
+// This keeps fixed npm commands compatible with Windows shells.
+function runShell(command) {
+	try {
+		childProcess.execSync(command, { stdio: 'inherit' });
+		return false;
+	} catch (e) {
+		return true;
+	}
+}
+
 function runForFiles(file, baseArgs, files) {
 	if (files.length === 0) {
 		return false;
@@ -52,10 +63,12 @@ function runESLintForFiles(files) {
 		return false;
 	}
 
+	// Staged filenames are untrusted input, so this must avoid shell execution.
 	return runForFiles('node', ['./node_modules/eslint/bin/eslint', '--quiet', '--format=unix'], files);
 }
 
 function runMarkdownLintForFiles(mdFiles) {
+	// Staged filenames are untrusted input, so this must avoid shell execution.
 	return runForFiles('node', ['./node_modules/markdownlint-cli/markdownlint.js'], mdFiles);
 }
 
@@ -75,7 +88,7 @@ function lintFiles(files) {
 	const tsFiles = filterByExt(files, '.ts');
 	const tsxFiles = filterByExt(files, '.tsx');
 	if (tsFiles.length !== 0 || tsxFiles.length !== 0) {
-		hasErrors = run('npm', ['run', 'tsc-verify']) || hasErrors;
+		hasErrors = runShell('npm run tsc-verify') || hasErrors;
 		hasErrors = runESLintForFiles(tsFiles) || hasErrors;
 		hasErrors = runESLintForFiles(tsxFiles) || hasErrors;
 	}


### PR DESCRIPTION
- Pin several GitHub Actions to specific commit SHAs for reproducible, auditable runs and tighten checkout security (persist-credentials: false).
- Updated .github/workflows/deploy.yml and pkg-pr-new.yml to use pinned actions/checkout and actions/setup-node SHAs and pinned peaceiris/actions-gh-pages in deploy.
- Updated size-limit workflow to use pinned checkout and size-limit-action.
- Added a new zizmor.yml workflow to run zizmor security analysis (pinned checkout and zizmor-action) with necessary permissions to upload SARIF.
- Fix command injection in pre-commit lint hook
    - Switch from shell-string execSync to argv-array execFileSync so staged filenames are passed verbatim and cannot be interpreted as shell metacharacters. Removes the incomplete shellEscape helper.
- Fix command injection in pre-commit and size-compare scripts
    - Switch from shell-string execSync to argv-array execFileSync so filenames, env vars, and git output are passed verbatim and cannot be interpreted as shell metacharacters. Removes the incomplete shellEscape helper. 