### PR TITLE
add a11y plugin example

### DIFF
--- a/plugin-examples/src/index.html
+++ b/plugin-examples/src/index.html
@@ -40,6 +40,7 @@
 		</ul>
         <h2>Primitives</h2>
 		<ul>
+            <li>Accessibility (a11y): <a href="./plugins/accessibility/example/">Example</a> / <a href="./plugins/accessibility/example/index.es.html">Español</a></li>
             <li><a href="./plugins/anchored-text/example/">Anchored Text</a></li>
             <li><a href="./plugins/bands-indicator/example/">Bands Indicator</a></li>
             <li><a href="./plugins/delta-tooltip/example/">Delta Tooltip</a></li>

--- a/plugin-examples/src/plugins/accessibility/README.md
+++ b/plugin-examples/src/plugins/accessibility/README.md
@@ -124,7 +124,10 @@ By default (`dataScope: 'visible'`) the on-demand summary (`Enter` / `Space`) an
 the background data-update announcements describe only the points within the
 current visible range – for example *"65 data points in view"*. This is the
 recommended setting for charts with large data sets because it keeps those
-summaries focused on what the user is currently inspecting.
+summaries focused on what the user is currently inspecting. The update
+announcement's *"Latest"* value is the one exception: it always reports the
+series' newest bar – the bar the update actually changed – even when that bar
+is outside the visible range.
 
 Use `dataScope: 'all'` when you want the summary and update announcements to
 describe the full data set, even if only part of the history is visible.
@@ -212,18 +215,20 @@ The precedence for the overridable pieces:
 
 The plugin uses an **active-point-only** strategy: it never mirrors every data
 point into the DOM. Regardless of whether a series holds 500 or 50,000 bars each
-pane adds only three DOM nodes (a semantic overlay, an assertive live region and
-a focus ring), plus one polite live region shared across the whole chart for
-data-update announcements.
+pane adds only four DOM nodes (a semantic overlay, a visually-hidden
+description, an assertive live region and a focus ring), plus one polite live
+region shared across the whole chart for data-update announcements.
 
 Data stays in sync through one `subscribeDataChanged` listener per series, so
 scrolling and zooming do no data work at all – the focus ring is repositioned
-with a couple of coordinate look-ups and nothing is read or copied. When a
-series' data actually changes the plugin re-reads only that series
-(`series.data()` returns a cloned array, so this is O(n) in that series' length)
-and coalesces simultaneous updates into a single debounced announcement. The
-work is therefore proportional to how often and how much your data changes, not
-to how often the user scrolls.
+with a couple of coordinate look-ups and nothing is read or copied. Data
+changes are handled lazily too: a change is only noted when it happens. The
+focused pane re-reads its active series right away (`series.data()` returns a
+cloned array, so a read is O(n) in that series' length), an unfocused pane
+defers that read until it is focused again, and update announcements read each
+changed series once per debounced announcement. The work is therefore
+proportional to how much the chart is actually being used, not to how often
+the user scrolls or how often your data ticks.
 
 ## Notes & limitations
 
@@ -235,7 +240,9 @@ to how often the user scrolls.
 - Series added to or removed from a pane at runtime are picked up automatically.
   Adding or removing whole **panes**, however, requires re-running
   `addAccessibilityPlugin` (or calling `controller.refresh()`) so the new panes
-  get their own layer.
+  get their own layer. Beware that removing a pane's **last** series removes the
+  pane itself (the library prunes empty panes), so that seemingly series-level
+  operation also needs a `refresh()`.
 - Series in a pane do not need to share timestamps. Navigation is aligned by
   *time* on the chart's shared time scale: switching series with the up / down
   arrows keeps the focused time (the nearest point in the new series is

--- a/plugin-examples/src/plugins/accessibility/README.md
+++ b/plugin-examples/src/plugins/accessibility/README.md
@@ -72,6 +72,12 @@ attach to.
 - **Visible focus indicator.** The focused pane receives an outline, and an
   optional focus ring is drawn over the active point. The point ring stays
   aligned with the canvas as you scroll or zoom.
+- **Visible shortcuts & high contrast (opt-in).** With `showShortcuts: true`,
+  sighted keyboard users get a "Press H" hint on focus and an `H`-toggled
+  on-screen list of the controls. `highContrast` (default `'auto'`, following the
+  OS) restyles the plugin's own focus ring and overlay, and `onHighContrastChange`
+  lets you restyle the chart itself to match — for users who navigate by keyboard
+  or need higher contrast but don't use a screen reader.
 
 ### Keyboard map
 
@@ -82,8 +88,10 @@ attach to.
 | `↑` / `↓` | Switch to the previous / next series in the pane |
 | `Page Up` / `Page Down` | Jump by `pageStep` points (default 10): `Page Up` forward in time, `Page Down` back — following the ARIA slider convention that `Page Up` increases the value |
 | `Home` / `End` | Jump to the first / last point |
+| `+` / `-` | Zoom the chart in / out |
 | `Enter` / `Space` | Announce a summary of the active series |
-| `H` | Announce the list of keyboard controls |
+| `H` | Announce the controls, and — when `showShortcuts` is on — show / hide the visible shortcuts panel |
+| `Esc` | Close the visible shortcuts panel |
 
 ## Options
 
@@ -105,6 +113,9 @@ All options are optional and have sensible defaults.
 | `describeChart` | `(points, seriesLabel) => string` | built-in summary | Generates the `Enter` / `Space` summary. |
 | `messages` | `PartialAccessibilityMessages` | English `defaultMessages` | Overrides for the announced text — translate some or all of it (see Localization). |
 | `lang` | `string` | chart `localization.locale` | BCP-47 `lang` set on the announced regions so screen readers use the right voice. |
+| `showShortcuts` | `boolean` | `false` | Show a visible keyboard-shortcuts overlay (focus hint + `H`-toggled panel) for sighted keyboard users (see below). |
+| `highContrast` | `boolean \| 'auto' \| (() => boolean)` | `'auto'` | High-contrast styling for the plugin's own focus ring / outline / overlay. `'auto'` follows the OS `prefers-contrast` / `forced-colors`. |
+| `onHighContrastChange` | `(enabled: boolean) => void` | — | Called when the resolved high-contrast state changes (and once on attach), so you can restyle the chart's own series / grid / font to match. |
 
 Options can be changed at runtime. Use the controller's
 `accessibility.applyOptions({ ... })` for chart-level changes (`chartTitle`,
@@ -211,13 +222,51 @@ The precedence for the overridable pieces:
 - **summary:** `describeChart` (full override) → `messages.summary`
 - **strings:** your `messages` entry → English `defaultMessages`
 
+## Visible shortcuts and high contrast
+
+These help users who navigate by keyboard, or need higher contrast, but don't use
+a screen reader.
+
+**Shortcuts overlay** — set `showShortcuts: true`. While the pane is focused a
+small *"Press H for keyboard shortcuts"* hint is shown; `H` toggles an on-screen
+panel listing the controls and `Esc` closes it. It is `aria-hidden` (screen-reader
+users already get the spoken `H` help) and its text comes from the `messages`
+bundle (`shortcutsHint`, `shortcutsTitle`, `shortcuts`), so it localises with the
+rest. The overlay text is sized in `rem`, so it scales with the page/browser font.
+
+**High contrast** — `highContrast` (`boolean | 'auto' | (() => boolean)`, default
+`'auto'`) controls the plugin's *own* visuals (focus ring, focus outline, the
+overlay). `'auto'` follows the OS `prefers-contrast` / `forced-colors` and updates
+live; pass a predicate to wire it to your own app setting.
+
+The plugin deliberately does **not** restyle the chart's series, grid or font —
+that's the chart theme's job (see the
+[Readability](https://tradingview.github.io/lightweight-charts/tutorials/a11y/readability)
+tutorial). Instead it calls `onHighContrastChange(enabled)` whenever the state
+changes (and once on attach) so you can apply your own high-contrast chart theme
+in one place:
+
+```js
+addAccessibilityPlugin(chart, {
+    showShortcuts: true,
+    onHighContrastChange: enabled => {
+        chart.applyOptions({ layout: { textColor: enabled ? '#000' : '#222' } });
+        series.applyOptions({ lineWidth: enabled ? 4 : 2 });
+    },
+});
+```
+
+The example wires both of these up (the "Enable high contrast" and "Large font"
+buttons).
+
 ## Performance
 
 The plugin uses an **active-point-only** strategy: it never mirrors every data
 point into the DOM. Regardless of whether a series holds 500 or 50,000 bars each
-pane adds only four DOM nodes (a semantic overlay, a visually-hidden
-description, an assertive live region and a focus ring), plus one polite live
-region shared across the whole chart for data-update announcements.
+pane adds only a small fixed set of nodes (a semantic overlay, a visually-hidden
+description, an assertive live region, a focus ring and — when `showShortcuts` is
+on — the shortcuts hint and panel), plus one polite live region shared across the
+whole chart for data-update announcements.
 
 Data stays in sync through one `subscribeDataChanged` listener per series, so
 scrolling and zooming do no data work at all – the focus ring is repositioned

--- a/plugin-examples/src/plugins/accessibility/README.md
+++ b/plugin-examples/src/plugins/accessibility/README.md
@@ -91,7 +91,6 @@ attach to.
 | `+` / `-` | Zoom the chart in / out |
 | `Enter` / `Space` | Announce a summary of the active series |
 | `H` | Announce the controls, and — when `showShortcuts` is on — show / hide the visible shortcuts panel |
-| `Esc` | Close the visible shortcuts panel |
 
 ## Options
 
@@ -229,7 +228,7 @@ a screen reader.
 
 **Shortcuts overlay** — set `showShortcuts: true`. While the pane is focused a
 small *"Press H for keyboard shortcuts"* hint is shown; `H` toggles an on-screen
-panel listing the controls and `Esc` closes it. It is `aria-hidden` (screen-reader
+panel listing the controls. It is `aria-hidden` (screen-reader
 users already get the spoken `H` help) and its text comes from the `messages`
 bundle (`shortcutsHint`, `shortcutsTitle`, `shortcuts`), so it localises with the
 rest. The overlay text is sized in `rem`, so it scales with the page/browser font.

--- a/plugin-examples/src/plugins/accessibility/README.md
+++ b/plugin-examples/src/plugins/accessibility/README.md
@@ -1,0 +1,247 @@
+# Accessibility Plugin (a11y)
+
+A drop-in accessibility helper built on
+[pane primitives](https://tradingview.github.io/lightweight-charts/docs/next/plugins/intro)
+that adds a semantic accessibility layer to a Lightweight Charts™ chart, helping
+your application meet [WCAG 2.1 Level AA](https://www.w3.org/TR/WCAG21/).
+
+Canvas-based charts are opaque to assistive technology. This plugin productises
+the techniques from the
+[accessibility tutorial](https://tradingview.github.io/lightweight-charts/tutorials/a11y/intro)
+so you get keyboard navigation, screen-reader announcements and a visible focus
+indicator without any manual wiring.
+
+Use the chart-level helper for normal integration. It attaches one primitive per
+pane, and each pane gets an independent, labelled, keyboard-focusable semantic
+layer. Within a pane the plugin handles every series, so multi-series and
+multi-pane charts are supported out of the box.
+
+## How to use
+
+Enable the plugin for every current pane with one chart-level call:
+
+```js
+import { createChart, LineSeries } from 'lightweight-charts';
+import { addAccessibilityPlugin } from './plugins/accessibility/accessibility';
+
+const chart = createChart(document.getElementById('chart'));
+const series = chart.addSeries(LineSeries);
+series.setData(myData);
+
+const accessibility = addAccessibilityPlugin(chart, {
+    chartTitle: 'Apple daily close',
+});
+```
+
+For a multi-pane chart, pass a title resolver:
+
+```js
+addAccessibilityPlugin(chart, {
+    chartTitle: paneIndex => paneIndex === 0 ? 'Price' : 'Volume',
+});
+```
+
+To turn it off again, detach the controller – the plugin restores the DOM to
+the state it found it in:
+
+```js
+accessibility.detach();
+```
+
+If you need low-level control, you can still attach `AccessibilityPlugin`
+directly as a pane primitive. In that mode `paneIndex` must match the pane you
+attach to.
+
+## What it does
+
+- **Semantic layer.** Each pane gets a labelled, keyboard-focusable overlay
+  (`role="application"`, `aria-label`, `tabindex="0"`), while the pane's table
+  scaffolding is marked presentational and the visual canvases are hidden from
+  assistive technology with `aria-hidden`. Focusable chart internals such as the
+  attribution link are removed from the tab order and hidden from the
+  accessibility tree.
+- **Keyboard navigation.** Users traverse every data point with the left/right
+  arrows and switch between the series in the pane with the up/down arrows. The
+  focused point is always paged into view, so the whole series is reachable by
+  keyboard even when only part of it is on screen.
+- **ARIA-live announcements.** The focused point, series changes and on-demand
+  summaries are announced through a per-pane assertive live region. Background
+  data updates go through a single polite live region shared by the whole chart,
+  so simultaneous updates in different panes never talk over each other
+  (`announceDataUpdates`, see below).
+- **Visible focus indicator.** The focused pane receives an outline, and an
+  optional focus ring is drawn over the active point. The point ring stays
+  aligned with the canvas as you scroll or zoom.
+
+### Keyboard map
+
+| Key | Action |
+| --- | --- |
+| `Tab` | Move focus between panes / out of the chart |
+| `←` / `→` | Move to the previous / next data point |
+| `↑` / `↓` | Switch to the previous / next series in the pane |
+| `Page Up` / `Page Down` | Jump by `pageStep` points (default 10) |
+| `Home` / `End` | Jump to the first / last point |
+| `Enter` / `Space` | Announce a summary of the active series |
+| `H` | Announce the list of keyboard controls |
+
+## Options
+
+All options are optional and have sensible defaults.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `chartTitle` | `string` | `'Interactive financial chart'` | Accessible name of the pane region. |
+| `paneIndex` | `number` | `0` | Index of the pane this primitive is attached to. Only needed when manually attaching `AccessibilityPlugin`; `addAccessibilityPlugin` sets it for you. |
+| `showFocusIndicator` | `boolean` | `true` | Draw a visible focus ring on the active point. |
+| `focusIndicatorColor` | `string` | `'#2962FF'` | Colour of the focus ring. |
+| `focusIndicatorSize` | `number` | `14` | Diameter of the focus ring, in CSS pixels. |
+| `announceDataUpdates` | `boolean \| 'active' \| (paneIndex)=>boolean` | `'active'` (helper); `true` (standalone) | Which panes announce data updates, and how they combine (see below). |
+| `pageStep` | `number` | `10` | Points to jump with `Page Up` / `Page Down`. |
+| `dataScope` | `'all' \| 'visible'` | `'visible'` | Whether the on-demand summary and data-update announcements describe the visible range or the full data set (see below). |
+| `priceFormatter` | `(value: number) => string` | chart `localization.priceFormatter`, else the active series price formatter | Formats values for announcements. |
+| `timeFormatter` | `(time: Time) => string` | chart `localization.timeFormatter`, else a locale-aware date | Formats times for announcements (uses the chart's `localization.locale`). |
+| `seriesLabel` | `(series, index) => string` | series `title`, else `Series N` | Accessible label for each series. |
+| `describeChart` | `(points, seriesLabel) => string` | built-in summary | Generates the `Enter` / `Space` summary. |
+| `messages` | `PartialAccessibilityMessages` | English `defaultMessages` | Overrides for the announced text — translate some or all of it (see Localization). |
+| `lang` | `string` | chart `localization.locale` | BCP-47 `lang` set on the announced regions so screen readers use the right voice. |
+
+Options can be changed at runtime. Use the controller's
+`accessibility.applyOptions({ ... })` for chart-level changes (`chartTitle`,
+`announceDataUpdates`, `messages`, `lang`, …): it updates every pane **and** the
+shared update region together. A single primitive also has its own
+`plugin.applyOptions({ ... })` for per-pane tweaks (e.g. `dataScope`), but that
+does not reach the chart-level shared update region — use the controller for
+`announceDataUpdates` / `messages` / `lang`.
+
+### Scoping announcements to the visible range
+
+Keyboard navigation always covers the whole series – the arrow keys page the
+chart so every point is reachable regardless of this setting. `dataScope` only
+controls what the *summaries* describe.
+
+By default (`dataScope: 'visible'`) the on-demand summary (`Enter` / `Space`) and
+the background data-update announcements describe only the points within the
+current visible range – for example *"65 data points in view"*. This is the
+recommended setting for charts with large data sets because it keeps those
+summaries focused on what the user is currently inspecting.
+
+Use `dataScope: 'all'` when you want the summary and update announcements to
+describe the full data set, even if only part of the history is visible.
+
+Per-point announcements always report the absolute position (*"Point 247 of
+500"*) so the user knows where they are in the whole series.
+
+### Announcing data updates
+
+When a chart streams live data, several panes can update in the same tick. Each
+pane keeps its own assertive region for navigation, but all *data-update*
+announcements go through **one** polite region shared by the whole chart, so the
+updates never talk over each other.
+
+`announceDataUpdates` (on `addAccessibilityPlugin`) chooses which panes speak:
+
+- `'active'` (default): only the **last-focused** pane announces (pane 0 until you
+  focus one). Navigating the volume pane, for example, makes its updates the ones
+  you hear; otherwise you hear the main pane.
+- `true`: every pane announces; simultaneous updates are combined into a single
+  message in pane order (*"Chart data updated. 3 series changed. …"*).
+- `false`: no update announcements.
+- `(paneIndex) => boolean`: decide per pane; the enabled panes are combined.
+
+Switch this at runtime through the controller —
+`accessibility.applyOptions({ announceDataUpdates: true })` — which reconfigures
+the shared region's mode; a per-pane `plugin.applyOptions` cannot change it.
+
+A directly-attached `AccessibilityPlugin` (without the helper) takes a plain
+`boolean` here and uses its own polite region.
+
+## Localization
+
+Out of the box the announcements are English, but **numbers and dates follow the
+chart's locale** and **every spoken string is translatable**.
+
+**Numbers and dates** come from the chart's
+[`localization`](https://tradingview.github.io/lightweight-charts/docs/next/api/interfaces/LocalizationOptions):
+dates use `localization.locale`, the summary's percentage uses it via
+`Intl.NumberFormat`, and if you set `localization.priceFormatter` /
+`localization.timeFormatter` the announcements use those too. So a chart you have
+already localized (see the
+[Custom locale](https://tradingview.github.io/lightweight-charts/tutorials/demos/custom-locale)
+and [Price format](https://tradingview.github.io/lightweight-charts/tutorials/customization/price-format)
+tutorials) gets localized announcements for free. You can still override per
+plugin with `priceFormatter` / `timeFormatter`.
+
+**Strings** are supplied through the `messages` bundle. Every announced sentence
+is a formatter function (so a translation controls word order and pluralisation);
+atomic words are plain strings. Pass a partial override — anything you leave out
+stays English:
+
+```js
+import { addAccessibilityPlugin } from './plugins/accessibility/accessibility';
+
+addAccessibilityPlugin(chart, {
+    chartTitle: 'Gráfico de precios',
+    lang: 'es',
+    messages: {
+        ohlc: { close: 'cierre' }, // only some keys — the rest stay English
+        point: ({ position, total, time, label, values }) =>
+            `Punto ${position} de ${total}. ${time}, ${label} ${values}.`,
+        help: ({ multiSeries }) =>
+            `Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Intro o Espacio lee un resumen de la serie.`,
+    },
+});
+```
+
+`lang` sets the BCP-47 `lang` attribute on the announced regions so a screen
+reader pronounces them with the right voice; it defaults to
+`localization.locale`. `messages`/`lang` are uniform across panes. To switch
+language at runtime, call `accessibility.applyOptions({ messages, lang })` on the
+controller — it updates every pane and the shared update region together. A
+complete, runnable Spanish bundle lives in the example
+(`example/example.es.ts`, rendered by `example/index.es.html`).
+
+The precedence for the overridable pieces:
+
+- **value:** `priceFormatter` → chart `localization.priceFormatter` → series formatter
+- **time:** `timeFormatter` → chart `localization.timeFormatter` → locale-aware date
+- **summary:** `describeChart` (full override) → `messages.summary`
+- **strings:** your `messages` entry → English `defaultMessages`
+
+## Performance
+
+The plugin uses an **active-point-only** strategy: it never mirrors every data
+point into the DOM. Regardless of whether a series holds 500 or 50,000 bars each
+pane adds only three DOM nodes (a semantic overlay, an assertive live region and
+a focus ring), plus one polite live region shared across the whole chart for
+data-update announcements.
+
+Data stays in sync through one `subscribeDataChanged` listener per series, so
+scrolling and zooming do no data work at all – the focus ring is repositioned
+with a couple of coordinate look-ups and nothing is read or copied. When a
+series' data actually changes the plugin re-reads only that series
+(`series.data()` returns a cloned array, so this is O(n) in that series' length)
+and coalesces simultaneous updates into a single debounced announcement. The
+work is therefore proportional to how often and how much your data changes, not
+to how often the user scrolls.
+
+## Notes & limitations
+
+- This is an example/starting-point plugin (see the repository disclaimer). It
+  targets line / area / candlestick / histogram series: OHLC series announce
+  their open / high / low / close, value series announce their value, and exotic
+  custom series may need the value extraction adapted via `priceFormatter` /
+  `describeChart`.
+- Series added to or removed from a pane at runtime are picked up automatically.
+  Adding or removing whole **panes**, however, requires re-running
+  `addAccessibilityPlugin` (or calling `controller.refresh()`) so the new panes
+  get their own layer.
+- Navigation maps the time scale's logical indices onto each series' data, which
+  assumes the series in a pane share the same time scale (the usual case). Series
+  that start at very different times may not line up one-to-one.
+- The plugin provides the semantic layer and keyboard model. Visual contrast and
+  font-scaling (covered in the
+  [Readability](https://tradingview.github.io/lightweight-charts/tutorials/a11y/readability)
+  part of the tutorial) remain the responsibility of your chart theme.
+- Always validate with real assistive technology (VoiceOver, NVDA) as part of
+  your own accessibility testing before shipping.

--- a/plugin-examples/src/plugins/accessibility/README.md
+++ b/plugin-examples/src/plugins/accessibility/README.md
@@ -80,7 +80,7 @@ attach to.
 | `Tab` | Move focus between panes / out of the chart |
 | `←` / `→` | Move to the previous / next data point |
 | `↑` / `↓` | Switch to the previous / next series in the pane |
-| `Page Up` / `Page Down` | Jump by `pageStep` points (default 10) |
+| `Page Up` / `Page Down` | Jump by `pageStep` points (default 10): `Page Up` forward in time, `Page Down` back — following the ARIA slider convention that `Page Up` increases the value |
 | `Home` / `End` | Jump to the first / last point |
 | `Enter` / `Space` | Announce a summary of the active series |
 | `H` | Announce the list of keyboard controls |
@@ -186,7 +186,7 @@ addAccessibilityPlugin(chart, {
     messages: {
         ohlc: { close: 'cierre' }, // only some keys — the rest stay English
         point: ({ position, total, time, label, values }) =>
-            `Punto ${position} de ${total}. ${time}, ${label} ${values}.`,
+            `${label} ${values}, ${time}. Punto ${position} de ${total}.`,
         help: ({ multiSeries }) =>
             `Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Intro o Espacio lee un resumen de la serie.`,
     },
@@ -236,9 +236,11 @@ to how often the user scrolls.
   Adding or removing whole **panes**, however, requires re-running
   `addAccessibilityPlugin` (or calling `controller.refresh()`) so the new panes
   get their own layer.
-- Navigation maps the time scale's logical indices onto each series' data, which
-  assumes the series in a pane share the same time scale (the usual case). Series
-  that start at very different times may not line up one-to-one.
+- Series in a pane do not need to share timestamps. Navigation is aligned by
+  *time* on the chart's shared time scale: switching series with the up / down
+  arrows keeps the focused time (the nearest point in the new series is
+  selected and paged into view), and the visible-range scoping follows each
+  series' own data.
 - The plugin provides the semantic layer and keyboard model. Visual contrast and
   font-scaling (covered in the
   [Readability](https://tradingview.github.io/lightweight-charts/tutorials/a11y/readability)

--- a/plugin-examples/src/plugins/accessibility/accessibility.ts
+++ b/plugin-examples/src/plugins/accessibility/accessibility.ts
@@ -133,7 +133,11 @@ export interface AccessibilityOptions {
 	 * `aria-live` region.
 	 */
 	announceDataUpdates: boolean;
-	/** Number of points to jump when using `PageUp` / `PageDown`. */
+	/**
+	 * Number of points to jump when using `PageUp` / `PageDown`. `PageUp` moves
+	 * forward in time and `PageDown` back, following the ARIA slider convention
+	 * that `PageUp` increases the value.
+	 */
 	pageStep: number;
 	/**
 	 * Controls what the on-demand summary (`Enter` / `Space`) and the data-update
@@ -228,8 +232,14 @@ function defaultTimeFormatter(time: Time, locale?: string): string {
 		// BusinessDay months are 1-12, whereas Date expects 0-11.
 		date = new Date(Date.UTC(time.year, time.month - 1, time.day));
 	} else {
-		// Business-day string, e.g. '2019-05-15'.
-		return time;
+		// Business-day string, e.g. '2019-05-15' – parse it so it is localised
+		// like the other time formats (with a verbatim fallback if it does not
+		// match the expected YYYY-MM-DD shape).
+		const [year, month, day] = time.split('-').map(Number);
+		if (!year || !month || !day) {
+			return time;
+		}
+		date = new Date(Date.UTC(year, month - 1, day));
 	}
 	// `locale || undefined` guards against the empty-string locale used server-side,
 	// which is not a valid Intl locale.
@@ -362,9 +372,11 @@ export const defaultMessages: AccessibilityMessages = {
 			? 'Use the left and right arrow keys to move between data points, and the up and down arrows to switch series.'
 			: 'Use the left and right arrow keys to move between data points.',
 	help: ({ multiSeries }): string =>
-		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up and Page Down jump ten points. Home and End jump to the first and last points. Enter or Space reads a summary of the series.`,
+		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up jumps ten points forward, Page Down ten points back. Home and End jump to the first and last points. Enter or Space reads a summary of the series.`,
+	// Most important information first: the value, then the date; the position
+	// counter is context, so it comes last.
 	point: ({ position, total, time, label, values }): string =>
-		`Point ${position} of ${total}. ${time}, ${label} ${values}.`,
+		`${label} ${values}, ${time}. Point ${position} of ${total}.`,
 	seriesPosition: ({ label, position, total, point }): string =>
 		`${label}, series ${position} of ${total}.${point}`,
 	ohlcValues: ({ labels, open, high, low, close }): string => {
@@ -1036,18 +1048,62 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		return { from: 0, to: last };
 	}
 
+	/**
+	 * Logical index of a data point on the chart's shared time scale. A series'
+	 * own data indices need not match the scale (a series can start later or
+	 * skip points), so every viewport comparison goes through this mapping.
+	 */
+	private _logicalIndexOf(point: SeriesDataPoint): number | null {
+		return this._chart?.timeScale().timeToIndex(point.time, true) ?? null;
+	}
+
+	/** Index of the first point whose logical index is >= `target` (`points.length` when none is). */
+	private _lowerBoundByLogical(points: readonly SeriesDataPoint[], target: number): number {
+		let low = 0;
+		let high = points.length;
+		while (low < high) {
+			const mid = (low + high) >> 1;
+			const logical = this._logicalIndexOf(points[mid]);
+			if (logical !== null && logical < target) {
+				low = mid + 1;
+			} else {
+				high = mid;
+			}
+		}
+		return low;
+	}
+
+	/** Index of the point closest (by logical index) to `target`; `points` must be non-empty. */
+	private _nearestIndexByLogical(points: readonly SeriesDataPoint[], target: number): number {
+		const last = points.length - 1;
+		const upper = this._lowerBoundByLogical(points, target);
+		if (upper <= 0) {
+			return 0;
+		}
+		if (upper > last) {
+			return last;
+		}
+		const before = this._logicalIndexOf(points[upper - 1]);
+		const after = this._logicalIndexOf(points[upper]);
+		if (before === null || after === null) {
+			return upper;
+		}
+		return target - before <= after - target ? upper - 1 : upper;
+	}
+
 	private _visibleBounds(points: readonly SeriesDataPoint[]): { from: number; to: number } | null {
 		const range = this._chart?.timeScale().getVisibleLogicalRange();
 		const last = points.length - 1;
 		if (!range || last < 0) {
 			return null;
 		}
-		const from = clamp(Math.ceil(range.from), 0, last);
-		const to = clamp(Math.floor(range.to), 0, last);
+		const from = clamp(this._lowerBoundByLogical(points, Math.ceil(range.from)), 0, last);
+		// Last point whose logical index is <= floor(range.to).
+		const to = this._lowerBoundByLogical(points, Math.floor(range.to) + 1) - 1;
 		if (to < from) {
 			return null;
 		}
-		return { from, to };
+		return { from, to: clamp(to, 0, last) };
 	}
 
 	private _movePoint(delta: number): void {
@@ -1072,11 +1128,18 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		if (next === this._activeSeriesIndex) {
 			return;
 		}
+		// Series in a pane need not share timestamps (e.g. a moving average that
+		// starts later), so carry the focused *time* across, not the raw index:
+		// the nearest point in time is selected in the new series.
+		const previousPoint = this._points[this._activePointIndex];
+		const targetLogical = previousPoint ? this._logicalIndexOf(previousPoint) : null;
 		this._activeSeriesIndex = next;
 		this._refreshActivePoints();
-		// Keep the focused point index, clamped to what is valid for the new series.
-		if (this._activePointIndex >= 0) {
-			this._activePointIndex = clamp(this._activePointIndex, 0, Math.max(0, this._points.length - 1));
+		if (this._activePointIndex >= 0 && this._points.length > 0) {
+			this._activePointIndex = targetLogical !== null
+				? this._nearestIndexByLogical(this._points, targetLogical)
+				: clamp(this._activePointIndex, 0, this._points.length - 1);
+			this._scrollActiveIntoView();
 		}
 		const series = this._activeSeries();
 		const label = series ? this._seriesLabel(series, next) : '';
@@ -1093,10 +1156,14 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 
 	private _firstVisibleIndex(): number {
 		const range = this._chart?.timeScale().getVisibleLogicalRange();
-		if (!range) {
+		if (!range || this._points.length === 0) {
 			return 0;
 		}
-		return clamp(Math.ceil(range.from), 0, this._points.length - 1);
+		return clamp(
+			this._lowerBoundByLogical(this._points, Math.ceil(range.from)),
+			0,
+			this._points.length - 1
+		);
 	}
 
 	private _setActivePoint(index: number): void {
@@ -1123,12 +1190,20 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		if (!range) {
 			return;
 		}
-		const last = this._points.length - 1;
+		const point = this._points[this._activePointIndex];
+		if (!point) {
+			return;
+		}
+		// Compare in the time scale's logical indices, which need not match this
+		// series' own data indices (e.g. a moving average that starts later).
+		const index = this._logicalIndexOf(point);
+		if (index === null) {
+			return;
+		}
 		const span = range.to - range.from;
 		// Keep a one-point margin from the edge (when the window is wide enough) so
 		// the following point is already visible after a step.
 		const margin = span > 4 ? 1 : 0;
-		const index = this._activePointIndex;
 		let from: number;
 		if (index < range.from + margin) {
 			from = index - margin;
@@ -1137,7 +1212,8 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		} else {
 			return; // already comfortably within view
 		}
-		from = clamp(from, 0, Math.max(0, last));
+		const lastLogical = this._logicalIndexOf(this._points[this._points.length - 1]) ?? index;
+		from = clamp(from, 0, Math.max(0, lastLogical));
 		timeScale.setVisibleLogicalRange({ from, to: from + span });
 	}
 

--- a/plugin-examples/src/plugins/accessibility/accessibility.ts
+++ b/plugin-examples/src/plugins/accessibility/accessibility.ts
@@ -183,8 +183,8 @@ export interface AccessibilityOptions {
 	/**
 	 * Show a visible keyboard-shortcuts overlay for sighted keyboard users: a
 	 * "Press H" hint while the pane is focused, and an `H`-toggled panel listing
-	 * the controls (`Esc` closes it). Screen-reader users always get the spoken
-	 * `H` help regardless of this option. Defaults to `false`.
+	 * the controls. Screen-reader users always get the spoken `H` help regardless
+	 * of this option. Defaults to `false`.
 	 */
 	showShortcuts: boolean;
 	/**
@@ -472,7 +472,6 @@ export const defaultMessages: AccessibilityMessages = {
 		// Enter / Space (the spoken summary) is intentionally omitted: it has no
 		// on-screen effect, so it stays in `help` (for screen readers) only.
 		{ keys: 'H', action: 'Show or hide this panel' },
-		{ keys: 'Esc', action: 'Close this panel' },
 	],
 	// Most important information first: the value, then the date; the position
 	// counter is context, so it comes last.
@@ -1371,12 +1370,6 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 				event.preventDefault();
 				this._announce(this._helpText());
 				this._setShortcutsOpen(!this._shortcutsOpen);
-				break;
-			case 'Escape':
-				if (this._shortcutsOpen) {
-					event.preventDefault();
-					this._setShortcutsOpen(false);
-				}
 				break;
 			default:
 				break;

--- a/plugin-examples/src/plugins/accessibility/accessibility.ts
+++ b/plugin-examples/src/plugins/accessibility/accessibility.ts
@@ -1,0 +1,1731 @@
+import {
+	BarPrice,
+	IChartApiBase,
+	IPaneApi,
+	IPanePrimitive,
+	ISeriesApi,
+	PaneAttachedParameter,
+	SeriesDataItemTypeMap,
+	SeriesType,
+	Time,
+	isBusinessDay,
+	isUTCTimestamp,
+} from 'lightweight-charts';
+
+/** A series of any type attached to the pane. */
+type AnySeries = ISeriesApi<SeriesType, Time>;
+
+/**
+ * The union of every data item a series can return (line, area, candlestick,
+ * bar, histogram, whitespace, …) – exactly what {@link ISeriesApi.data} yields
+ * for a series of unknown type.
+ */
+type SeriesDataPoint = SeriesDataItemTypeMap<Time>[SeriesType];
+
+interface SeriesSnapshot {
+	series: AnySeries;
+	data: readonly SeriesDataPoint[];
+}
+
+interface PresentationRoleState {
+	count: number;
+	previousValue: string | null;
+}
+
+const presentationRoles = new WeakMap<HTMLElement, PresentationRoleState>();
+const ariaHiddenStates = new WeakMap<HTMLElement, PresentationRoleState>();
+
+function retainPresentationRole(element: HTMLElement): void {
+	const state = presentationRoles.get(element);
+	if (state) {
+		state.count += 1;
+		return;
+	}
+	presentationRoles.set(element, {
+		count: 1,
+		previousValue: element.getAttribute('role'),
+	});
+	element.setAttribute('role', 'presentation');
+}
+
+function releasePresentationRole(element: HTMLElement): void {
+	const state = presentationRoles.get(element);
+	if (!state) {
+		return;
+	}
+	state.count -= 1;
+	if (state.count > 0) {
+		return;
+	}
+	presentationRoles.delete(element);
+	if (state.previousValue === null) {
+		element.removeAttribute('role');
+	} else {
+		element.setAttribute('role', state.previousValue);
+	}
+}
+
+function retainAriaHidden(element: HTMLElement): void {
+	const state = ariaHiddenStates.get(element);
+	if (state) {
+		state.count += 1;
+		return;
+	}
+	ariaHiddenStates.set(element, {
+		count: 1,
+		previousValue: element.getAttribute('aria-hidden'),
+	});
+	element.setAttribute('aria-hidden', 'true');
+}
+
+function releaseAriaHidden(element: HTMLElement): void {
+	const state = ariaHiddenStates.get(element);
+	if (!state) {
+		return;
+	}
+	state.count -= 1;
+	if (state.count > 0) {
+		return;
+	}
+	ariaHiddenStates.delete(element);
+	if (state.previousValue === null) {
+		element.removeAttribute('aria-hidden');
+	} else {
+		element.setAttribute('aria-hidden', state.previousValue);
+	}
+}
+
+/**
+ * Options for the {@link AccessibilityPlugin}.
+ *
+ * Every option has a sensible default. For normal chart-level integration, use
+ * {@link addAccessibilityPlugin}; it creates one correctly indexed primitive per
+ * pane:
+ *
+ * ```js
+ * addAccessibilityPlugin(chart, { chartTitle: 'Apple daily close' });
+ * ```
+ */
+export interface AccessibilityOptions {
+	/**
+	 * Human readable title for the pane. Announced by screen readers when the
+	 * pane receives focus and used as the accessible name of the pane region.
+	 */
+	chartTitle: string;
+	/**
+	 * Index of the pane this primitive is attached to. Must match the pane it is
+	 * attached to (e.g. `chart.panes()[1].attachPrimitive(new AccessibilityPlugin({ paneIndex: 1 }))`).
+	 * Defaults to `0`, which is correct for the main pane. When using
+	 * {@link addAccessibilityPlugin}, this is set automatically.
+	 */
+	paneIndex: number;
+	/**
+	 * When `true` a visible focus ring is drawn over the currently focused data
+	 * point. This is the "visible focus indicator" required by WCAG 2.4.7.
+	 */
+	showFocusIndicator: boolean;
+	/** Colour of the visible focus indicator. */
+	focusIndicatorColor: string;
+	/** Diameter (in CSS pixels) of the visible focus indicator. */
+	focusIndicatorSize: number;
+	/**
+	 * When `true` changes to the underlying data are announced through a polite
+	 * `aria-live` region.
+	 */
+	announceDataUpdates: boolean;
+	/** Number of points to jump when using `PageUp` / `PageDown`. */
+	pageStep: number;
+	/**
+	 * Controls what the on-demand summary (`Enter` / `Space`) and the data-update
+	 * announcements describe. Keyboard navigation always covers the whole series
+	 * regardless of this setting.
+	 *
+	 * - `'visible'` (default): only the points within the current visible range
+	 *   (e.g. "65 data points in view").
+	 * - `'all'`: the full data set, regardless of what is on screen.
+	 */
+	dataScope: 'all' | 'visible';
+	/**
+	 * Formats a numeric value for screen reader announcements. Defaults to the
+	 * chart's `localization.priceFormatter` if set, otherwise the active series'
+	 * own price formatter.
+	 */
+	priceFormatter?: (value: number) => string;
+	/**
+	 * Formats a {@link Time} value for screen reader announcements. Defaults to the
+	 * chart's `localization.timeFormatter` if set, otherwise a locale-aware date.
+	 */
+	timeFormatter?: (time: Time) => string;
+	/**
+	 * Produces the accessible label for a series, used when announcing data
+	 * points and when switching series. Defaults to the series' `title` option,
+	 * falling back to `Series N`.
+	 */
+	seriesLabel?: (series: AnySeries, index: number) => string;
+	/**
+	 * Produces the chart summary announced when the user presses `Enter` /
+	 * `Space`. Receives the active series' data and label. Takes precedence over
+	 * {@link AccessibilityMessages.summary}.
+	 */
+	describeChart?: (points: readonly SeriesDataPoint[], seriesLabel: string) => string;
+	/**
+	 * Overrides for the announced text, so the plugin can speak in any language.
+	 * Anything left out falls back to the built-in English {@link defaultMessages}.
+	 * Numbers and dates are localised separately (see {@link priceFormatter} /
+	 * {@link timeFormatter} and the chart's `localization.locale`).
+	 */
+	messages?: PartialAccessibilityMessages;
+	/**
+	 * BCP-47 language tag set as the `lang` attribute on the announced regions, so
+	 * screen readers pronounce them with the right voice. Defaults to the chart's
+	 * `localization.locale`.
+	 */
+	lang?: string;
+}
+
+const defaultOptions: AccessibilityOptions = {
+	chartTitle: 'Interactive financial chart',
+	paneIndex: 0,
+	showFocusIndicator: true,
+	focusIndicatorColor: '#2962FF',
+	focusIndicatorSize: 14,
+	announceDataUpdates: true,
+	pageStep: 10,
+	dataScope: 'visible',
+};
+
+/** CSS applied to elements that should be available to assistive technology but invisible on screen. */
+const VISUALLY_HIDDEN =
+	'position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;border:0;';
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Extracts the representative numeric value from a data point, if it has one.
+ * Value-based series (line, area, …) carry `value`; OHLC series (bar,
+ * candlestick) carry `close`; whitespace points carry neither.
+ */
+function extractValue(point: SeriesDataPoint | undefined): number | undefined {
+	if (!point) {
+		return undefined;
+	}
+	if ('value' in point && typeof point.value === 'number') {
+		return point.value;
+	}
+	if ('close' in point && typeof point.close === 'number') {
+		return point.close;
+	}
+	return undefined;
+}
+
+function defaultTimeFormatter(time: Time, locale?: string): string {
+	let date: Date;
+	if (isUTCTimestamp(time)) {
+		date = new Date(time * 1000);
+	} else if (isBusinessDay(time)) {
+		// BusinessDay months are 1-12, whereas Date expects 0-11.
+		date = new Date(Date.UTC(time.year, time.month - 1, time.day));
+	} else {
+		// Business-day string, e.g. '2019-05-15'.
+		return time;
+	}
+	// `locale || undefined` guards against the empty-string locale used server-side,
+	// which is not a valid Intl locale.
+	return date.toLocaleDateString(locale || undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	});
+}
+
+/** Field labels for an OHLC (bar / candlestick) data point. */
+export interface OhlcLabels {
+	open: string;
+	high: string;
+	low: string;
+	close: string;
+}
+
+/** Words describing a series' overall direction in the summary. */
+export interface DirectionLabels {
+	up: string;
+	down: string;
+	unchanged: string;
+}
+
+/** Pre-formatted fields passed to {@link AccessibilityMessages.summary}. */
+export interface SummaryArgs {
+	label: string;
+	count: number;
+	/** Localised scope note built from {@link AccessibilityMessages.inView}, with a leading space, or `''`. */
+	scopeNote: string;
+	firstValue: string;
+	firstTime: string;
+	lastValue: string;
+	lastTime: string;
+	direction: 'up' | 'down' | 'unchanged';
+	directionLabel: string;
+	changeValue: string;
+	/** Formatted percentage change, or `null` when it is undefined (the series starts at zero). */
+	percent: string | null;
+	lowValue: string;
+	lowTime: string;
+	highValue: string;
+	highTime: string;
+}
+
+/** Pre-formatted OHLC values passed to {@link AccessibilityMessages.ohlcValues} (absent fields are `null`). */
+export interface OhlcValueArgs {
+	labels: OhlcLabels;
+	open: string | null;
+	high: string | null;
+	low: string | null;
+	close: string;
+}
+
+/**
+ * Every screen-reader string produced by the plugin. Atomic strings are localised
+ * directly; sentences are formatter functions so a translation controls word order
+ * and pluralisation. All numeric / date values arrive **pre-formatted**, and
+ * position counters are **1-based**, so a message function only assembles words.
+ *
+ * Override some or all entries via {@link AccessibilityOptions.messages}; anything
+ * left out falls back to the built-in English {@link defaultMessages}.
+ */
+export interface AccessibilityMessages {
+	/** Spoken role of the pane region (`aria-roledescription`). */
+	roleDescription: string;
+	/** Spoken when a data point has no numeric value. */
+	noValue: string;
+	/** Scope word added to summaries when `dataScope` is `'visible'` (the plugin adds the leading space). */
+	inView: string;
+	/** Field labels for OHLC points, used by the default {@link ohlcValues}. */
+	ohlc: OhlcLabels;
+	/** Words for the summary's overall direction. */
+	directions: DirectionLabels;
+	/** Default label for the series at 1-based `position` when it has no title. */
+	defaultSeriesLabel: (position: number) => string;
+	/** Accessible name of the pane region. */
+	paneLabel: (args: { title: string; seriesCount: number; seriesLabel: string | null }) => string;
+	/**
+	 * Accessible description of the pane (via `aria-describedby`). Read after the
+	 * name on focus, and gives the pane real content so screen readers don't
+	 * report the `application` region as "empty".
+	 */
+	description: (args: { multiSeries: boolean }) => string;
+	/** Announced on `H`. */
+	help: (args: { multiSeries: boolean; pageStep: number }) => string;
+	/** Announced for the focused data point (`position` is 1-based). */
+	point: (args: { position: number; total: number; time: string; label: string; values: string }) => string;
+	/** Announced when switching series (`position` is 1-based; `point` is pre-spaced or `''`). */
+	seriesPosition: (args: { label: string; position: number; total: number; point: string }) => string;
+	/** Assembles a point's value(s); for OHLC series this controls order and separators. */
+	ohlcValues: (args: OhlcValueArgs) => string;
+	/** The `Enter` / `Space` summary. Bypassed entirely when {@link AccessibilityOptions.describeChart} is set. */
+	summary: (args: SummaryArgs) => string;
+	/** Summary when the active series has no valued points. */
+	noData: (args: { label: string }) => string;
+	/** One series' contribution to a data-update announcement. */
+	seriesUpdate: (args: { label: string; count: number; scopeNote: string; latest: string }) => string;
+	/** Wraps the per-series update summaries into one announcement (`total` >= 1). */
+	dataUpdated: (args: { summaries: readonly string[]; total: number; shownMax: number }) => string;
+}
+
+/** A partial {@link AccessibilityMessages} override: top-level entries and the two string groups are each optional. */
+export type PartialAccessibilityMessages =
+	Partial<Omit<AccessibilityMessages, 'ohlc' | 'directions'>> & {
+		ohlc?: Partial<OhlcLabels>;
+		directions?: Partial<DirectionLabels>;
+	};
+
+/** Built-in English strings. Reproduces the plugin's original wording exactly; use as a template for a translation. */
+export const defaultMessages: AccessibilityMessages = {
+	roleDescription: 'Interactive chart pane',
+	noValue: 'no value',
+	inView: 'in view',
+	ohlc: { open: 'open', high: 'high', low: 'low', close: 'close' },
+	directions: { up: 'up', down: 'down', unchanged: 'unchanged' },
+	defaultSeriesLabel: (position: number): string => `Series ${position}`,
+	paneLabel: ({ title, seriesCount, seriesLabel }): string => {
+		const seriesPart =
+			seriesCount > 1
+				? `${seriesCount} series. `
+				: seriesLabel
+					? `${seriesLabel}. `
+					: '';
+		return `${title}. ${seriesPart}Press H for keyboard help.`;
+	},
+	description: ({ multiSeries }): string =>
+		multiSeries
+			? 'Use the left and right arrow keys to move between data points, and the up and down arrows to switch series.'
+			: 'Use the left and right arrow keys to move between data points.',
+	help: ({ multiSeries }): string =>
+		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up and Page Down jump ten points. Home and End jump to the first and last points. Enter or Space reads a summary of the series.`,
+	point: ({ position, total, time, label, values }): string =>
+		`Point ${position} of ${total}. ${time}, ${label} ${values}.`,
+	seriesPosition: ({ label, position, total, point }): string =>
+		`${label}, series ${position} of ${total}.${point}`,
+	ohlcValues: ({ labels, open, high, low, close }): string => {
+		const parts: string[] = [];
+		if (open !== null) {
+			parts.push(`${labels.open} ${open}`);
+		}
+		if (high !== null) {
+			parts.push(`${labels.high} ${high}`);
+		}
+		if (low !== null) {
+			parts.push(`${labels.low} ${low}`);
+		}
+		parts.push(`${labels.close} ${close}`);
+		return parts.join(', ');
+	},
+	summary: ({ label, count, scopeNote, firstValue, firstTime, lastValue, lastTime, directionLabel, changeValue, percent, lowValue, lowTime, highValue, highTime }): string =>
+		`${label} with ${count} data points${scopeNote}. From ${firstValue} on ${firstTime} to ${lastValue} on ${lastTime}. Overall ${directionLabel} by ${changeValue}${percent !== null ? `, ${percent} percent` : ''}. Lowest ${lowValue} on ${lowTime}, highest ${highValue} on ${highTime}.`,
+	noData: ({ label }): string => `${label}: no data available.`,
+	seriesUpdate: ({ label, count, scopeNote, latest }): string =>
+		`${label}, ${count} data points${scopeNote}. Latest ${latest}`,
+	dataUpdated: ({ summaries, total, shownMax }): string => {
+		if (total === 1) {
+			return `Chart data updated. ${summaries[0]}.`;
+		}
+		const shown = summaries.slice(0, shownMax);
+		const remaining = total > shown.length
+			? ` ${total - shown.length} more series changed.`
+			: '';
+		return `Chart data updated. ${total} series changed. ${shown.join(' ')}.${remaining}`;
+	},
+};
+
+/**
+ * Overlays a partial override onto {@link defaultMessages}. Top-level entries
+ * replace wholesale; the known string groups (`ohlc`, `directions`) shallow-merge.
+ * Keep the group list in sync if a new nested group is added to the interface.
+ */
+function mergeMessages(base: AccessibilityMessages, override?: PartialAccessibilityMessages): AccessibilityMessages {
+	if (!override) {
+		return base;
+	}
+	const merged: AccessibilityMessages = {
+		...base,
+		...override,
+		ohlc: { ...base.ohlc, ...override.ohlc },
+		directions: { ...base.directions, ...override.directions },
+	};
+	// An explicit `undefined` in the override must not erase a default entry.
+	(Object.keys(merged) as (keyof AccessibilityMessages)[]).forEach(key => {
+		if (merged[key] === undefined) {
+			(merged as unknown as Record<string, unknown>)[key] = base[key];
+		}
+	});
+	return merged;
+}
+
+/** Source of unique ids for the per-pane `aria-describedby` target. */
+let descriptionIdCounter = 0;
+
+/** Debounce window (ms) for coalescing data-update announcements. */
+const UPDATE_DEBOUNCE_MS = 150;
+
+/** Maximum number of changed series listed in a single update announcement. */
+const UPDATE_MAX_SERIES = 3;
+
+/**
+ * Builds the spoken text for a batch of changed-series summaries. Shared by the
+ * standalone per-pane path and the chart-level {@link UpdateAnnouncer}. Returns
+ * an empty string when there is nothing to announce.
+ */
+function formatUpdateMessage(summaries: readonly string[], messages: AccessibilityMessages): string {
+	if (summaries.length === 0) {
+		return '';
+	}
+	return messages.dataUpdated({ summaries, total: summaries.length, shownMax: UPDATE_MAX_SERIES });
+}
+
+/**
+ * Private channel between {@link AccessibilityPlugin}, {@link addAccessibilityPlugin}
+ * and {@link UpdateAnnouncer}. Keeping this cross-object coordination in a
+ * module-scoped WeakMap (rather than on the plugin class) means it never appears
+ * on the public `AccessibilityPlugin` surface or in the generated typings.
+ */
+interface PluginLink {
+	attachAnnouncer(announcer: UpdateAnnouncer | null): void;
+	collectPendingUpdateSummaries(): string[];
+}
+const pluginLinks = new WeakMap<AccessibilityPlugin, PluginLink>();
+
+/**
+ * AccessibilityPlugin – a pane primitive that adds a semantic accessibility
+ * layer to one pane of a Lightweight Charts™ chart.
+ *
+ * Most applications should use {@link addAccessibilityPlugin}, which attaches
+ * one correctly indexed primitive per pane. Each pane gets an independent,
+ * labelled, keyboard-focusable semantic layer. Within a pane the plugin
+ * provides:
+ *
+ * - An ARIA-described overlay (the pane's canvas is hidden from assistive
+ *   technology with `aria-hidden`, and table scaffolding is presentational).
+ * - Keyboard navigation: the left/right arrows move between data points, and
+ *   the up/down arrows switch between the series in the pane.
+ * - `aria-live` announcements of the focused point, series changes, on-demand
+ *   summaries and background data updates.
+ * - An optional visible focus indicator that stays synchronised with the canvas
+ *   as the user scrolls or zooms.
+ *
+ * To keep the DOM lightweight regardless of the number of bars, the plugin uses
+ * an "active-point-only" strategy: it never mirrors every data point into the
+ * DOM, rendering only a small fixed set of nodes per pane (a semantic overlay, a
+ * live region, a description and a focus indicator). Keyboard navigation always
+ * covers the whole series; the default `dataScope: 'visible'` keeps the spoken
+ * summaries scoped to the viewport on large data sets.
+ */
+export class AccessibilityPlugin implements IPanePrimitive<Time> {
+	private _options: AccessibilityOptions;
+	private _chart: IChartApiBase<Time> | null = null;
+	private _container: HTMLElement | null = null;
+
+	private _liveRegion: HTMLElement | null = null;
+	private _statusRegion: HTMLElement | null = null;
+	private _descriptionRegion: HTMLElement | null = null;
+	private _focusIndicator: HTMLElement | null = null;
+
+	// Restored on detach so we leave the host DOM exactly as we found it.
+	// Descendants of the pane element whose attributes we changed, paired with
+	// their original value, so detach() can restore them.
+	private _presentedElements: HTMLElement[] = [];
+	private _hiddenCanvases: HTMLElement[] = [];
+	private _neutralised: [HTMLElement, string | null, string | null][] = [];
+
+	private _seriesList: AnySeries[] = [];
+	private _seriesData: SeriesSnapshot[] = [];
+	private _points: readonly SeriesDataPoint[] = [];
+	private _activeSeriesIndex = 0;
+	private _activePointIndex = -1;
+	// One `subscribeDataChanged` handler per series, so we react to real data
+	// changes instead of polling and re-hashing on every redraw.
+	private _dataChangedHandlers = new Map<AnySeries, () => void>();
+	private _dirtySeries = new Set<AnySeries>();
+	private _announceUpdateHandle: ReturnType<typeof setTimeout> | null = null;
+	private _liveFrame: ReturnType<typeof requestAnimationFrame> | null = null;
+	private _pendingMessage: string | null = null;
+	// When attached via addAccessibilityPlugin, data-update announcements are
+	// routed through one shared region instead of this pane's own polite region.
+	private _updateAnnouncer: UpdateAnnouncer | null = null;
+	private _hasFocus = false;
+	private _built = false;
+	private _initAttempts = 0;
+
+	private _messages: AccessibilityMessages;
+	// Memoised percent formatter, rebuilt only when the chart's locale changes.
+	private _percentFormatter: Intl.NumberFormat | null = null;
+	private _percentLocale: string | undefined;
+
+	public constructor(options: Partial<AccessibilityOptions> = {}) {
+		this._options = { ...defaultOptions, ...options };
+		this._messages = mergeMessages(defaultMessages, this._options.messages);
+		// Internal coordination is registered off the public surface (see PluginLink).
+		pluginLinks.set(this, {
+			attachAnnouncer: announcer => this._attachAnnouncer(announcer),
+			collectPendingUpdateSummaries: () => this._collectPendingUpdateSummaries(),
+		});
+	}
+
+	// region IPanePrimitive lifecycle ---------------------------------------------------
+
+	public attached(param: PaneAttachedParameter<Time>): void {
+		this._chart = param.chart;
+		this._tryInit();
+	}
+
+	/**
+	 * A freshly created pane may not have its HTML element yet, so initialisation
+	 * is retried on subsequent animation frames until the element is available.
+	 */
+	private _tryInit(): void {
+		if (this._built || !this._chart) {
+			return;
+		}
+		const paneElement = this._pane()?.getHTMLElement() ?? null;
+		const paneContent = paneElement ? this._paneContentElement(paneElement) : null;
+		if (!paneElement || !paneContent) {
+			if (this._initAttempts++ < 60) {
+				requestAnimationFrame(() => this._tryInit());
+			}
+			return;
+		}
+		this._built = true;
+
+		this._buildDom(paneElement, paneContent);
+		this._syncSeries();
+
+		this._container?.addEventListener('keydown', this._handleKeyDown);
+		this._container?.addEventListener('focusin', this._handleFocusIn);
+		this._container?.addEventListener('focusout', this._handleFocusOut);
+	}
+
+	public detached(): void {
+		if (this._announceUpdateHandle !== null) {
+			clearTimeout(this._announceUpdateHandle);
+			this._announceUpdateHandle = null;
+		}
+		if (this._liveFrame !== null) {
+			cancelAnimationFrame(this._liveFrame);
+			this._liveFrame = null;
+		}
+		this._unsubscribeAll();
+		// The announcer itself is owned and disposed by addAccessibilityPlugin;
+		// here we just drop our reference to it.
+		this._updateAnnouncer = null;
+		const container = this._container;
+		if (container) {
+			container.removeEventListener('keydown', this._handleKeyDown);
+			container.removeEventListener('focusin', this._handleFocusIn);
+			container.removeEventListener('focusout', this._handleFocusOut);
+			container.remove();
+		}
+		this._restorePresentationRoles();
+		this._restoreHiddenCanvases();
+		this._restoreFocusables();
+
+		this._chart = null;
+		this._container = null;
+		this._liveRegion = null;
+		this._statusRegion = null;
+		this._descriptionRegion = null;
+		this._focusIndicator = null;
+		this._pendingMessage = null;
+		this._seriesList = [];
+		this._seriesData = [];
+		this._points = [];
+		this._activePointIndex = -1;
+		this._activeSeriesIndex = 0;
+		this._built = false;
+		this._initAttempts = 0;
+	}
+
+	/**
+	 * Called by the library whenever the viewport changes (scroll / zoom / resize)
+	 * and on every redraw. We use it to keep the focus indicator aligned with the
+	 * canvas and to reconcile our per-series data subscriptions. Data *content*
+	 * changes are handled by those subscriptions, so this path never reads or
+	 * hashes bar data and stays cheap during scrolling and zooming.
+	 */
+	public updateAllViews(): void {
+		if (!this._built) {
+			this._tryInit();
+			return;
+		}
+		this._positionIndicator();
+		this._syncSeries();
+	}
+
+	// region Options --------------------------------------------------------------------
+
+	public applyOptions(options: Partial<AccessibilityOptions>): void {
+		this._options = { ...this._options, ...options };
+		// Re-merge from defaultMessages so repeated partial overrides compose
+		// against English rather than each other.
+		this._messages = mergeMessages(defaultMessages, this._options.messages);
+		this._container?.setAttribute('aria-roledescription', this._messages.roleDescription);
+		this._updatePaneLabel();
+		this._updateDescription();
+		this._applyLang();
+		if (this._focusIndicator) {
+			this._styleFocusIndicator(this._focusIndicator);
+		}
+		this._styleFocusOutline();
+		this._positionIndicator();
+	}
+
+	public options(): Readonly<AccessibilityOptions> {
+		return this._options;
+	}
+
+	public focus(): void {
+		this._container?.focus();
+	}
+
+	/**
+	 * Routes this pane's data-update announcements through the chart-level shared
+	 * region (set by {@link addAccessibilityPlugin} via the internal PluginLink).
+	 * A non-null announcer removes this pane's own polite region so only the shared
+	 * region remains; `null` (used at teardown) detaches from the announcer.
+	 */
+	private _attachAnnouncer(announcer: UpdateAnnouncer | null): void {
+		this._updateAnnouncer = announcer;
+		if (announcer && this._statusRegion) {
+			this._statusRegion.remove();
+			this._statusRegion = null;
+		}
+	}
+
+	// region Pane / series resolution ---------------------------------------------------
+
+	private _pane(): IPaneApi<Time> | null {
+		return this._chart?.panes()[this._options.paneIndex] ?? null;
+	}
+
+	private _activeSeries(): AnySeries | null {
+		return this._seriesList[this._activeSeriesIndex] ?? null;
+	}
+
+	private _seriesLabel(series: AnySeries, index: number): string {
+		if (this._options.seriesLabel) {
+			return this._options.seriesLabel(series, index);
+		}
+		const title = series.options().title;
+		return title.length > 0 ? title : this._messages.defaultSeriesLabel(index + 1);
+	}
+
+	// region DOM construction -----------------------------------------------------------
+
+	private _paneContentElement(paneElement: HTMLElement): HTMLElement | null {
+		const cells = Array.from(paneElement.children).filter(
+			(cell): cell is HTMLElement => cell instanceof HTMLElement
+		);
+		// The pane row holds the (optional) left price-axis cell, the main pane
+		// cell and the (optional) right price-axis cell. Every one of them can
+		// contain a canvas, so "first cell with a canvas" would wrongly pick the
+		// left axis when it is visible. The library only sets `position:relative`
+		// on the main pane cell, so we key off that and fall back to the first
+		// canvas-bearing cell for forward compatibility.
+		const paneCell =
+			cells.find(cell => cell.style.position === 'relative' && cell.querySelector('canvas')) ??
+			cells.find(cell => cell.querySelector('canvas'));
+		if (!paneCell) {
+			return null;
+		}
+		return paneCell.firstElementChild instanceof HTMLElement
+			? paneCell.firstElementChild
+			: paneCell;
+	}
+
+	private _buildDom(paneElement: HTMLElement, paneContent: HTMLElement): void {
+		this._markTableStructurePresentational(paneElement);
+
+		// Hide the visual canvas(es) from assistive technology and take any
+		// focusable descendant (e.g. the attribution link) out of the tab order –
+		// a focusable element inside an aria-hidden subtree is a WCAG failure.
+		const chartTable = paneElement.closest('table') ?? paneElement;
+		chartTable.querySelectorAll<HTMLElement>('canvas').forEach(element => {
+			retainAriaHidden(element);
+			this._hiddenCanvases.push(element);
+		});
+		this._neutraliseFocusables(paneElement);
+
+		const semanticLayer = document.createElement('div');
+		semanticLayer.className = 'lw-chart-a11y-layer';
+		semanticLayer.tabIndex = 0;
+		// `application` role lets screen readers forward arrow keys to our handler
+		// instead of using them for virtual cursor navigation.
+		semanticLayer.setAttribute('role', 'application');
+		semanticLayer.setAttribute('aria-roledescription', this._messages.roleDescription);
+		semanticLayer.setAttribute('aria-label', this._buildPaneLabel());
+		semanticLayer.style.cssText = [
+			'position:absolute',
+			'inset:0',
+			'outline:none',
+			'outline-offset:-3px',
+			'pointer-events:none',
+			'z-index:5',
+		].join(';');
+		paneContent.appendChild(semanticLayer);
+		this._container = semanticLayer;
+
+		// A visually-hidden description gives the application real content – so a
+		// screen reader doesn't report the region as "empty" – and is read after the
+		// name on focus via aria-describedby.
+		const description = document.createElement('div');
+		const descriptionId = `lw-chart-a11y-desc-${++descriptionIdCounter}`;
+		description.id = descriptionId;
+		description.className = 'lw-chart-a11y-description';
+		description.style.cssText = VISUALLY_HIDDEN;
+		semanticLayer.setAttribute('aria-describedby', descriptionId);
+		semanticLayer.appendChild(description);
+		this._descriptionRegion = description;
+		this._updateDescription();
+
+		// Assertive: announces the focused point / series change immediately in
+		// response to a key press. (Not `role="status"`, which would imply the
+		// contradictory `aria-live="polite"`.)
+		const liveRegion = document.createElement('div');
+		liveRegion.className = 'lw-chart-a11y-live-region';
+		liveRegion.setAttribute('aria-live', 'assertive');
+		liveRegion.setAttribute('aria-atomic', 'true');
+		liveRegion.style.cssText = VISUALLY_HIDDEN;
+		semanticLayer.appendChild(liveRegion);
+		this._liveRegion = liveRegion;
+
+		// Skip the per-pane polite region when a shared announcer is already in
+		// place (it owns the single chart-level polite region). DOM construction can
+		// be deferred past the announcer injection, so this guard – together with the
+		// removal in _attachAnnouncer – keeps exactly one polite region either way.
+		if (!this._updateAnnouncer) {
+			const statusRegion = document.createElement('div');
+			statusRegion.className = 'lw-chart-a11y-status-region';
+			statusRegion.setAttribute('aria-live', 'polite');
+			statusRegion.setAttribute('aria-atomic', 'true');
+			statusRegion.style.cssText = VISUALLY_HIDDEN;
+			semanticLayer.appendChild(statusRegion);
+			this._statusRegion = statusRegion;
+		}
+
+		const focusIndicator = document.createElement('div');
+		focusIndicator.className = 'lw-chart-a11y-focus-ring';
+		this._styleFocusIndicator(focusIndicator);
+		semanticLayer.appendChild(focusIndicator);
+		this._focusIndicator = focusIndicator;
+
+		this._applyLang();
+	}
+
+	private _markTableStructurePresentational(paneElement: HTMLElement): void {
+		const elements = [
+			paneElement.closest('table'),
+			paneElement,
+			...Array.from(paneElement.children),
+		].filter((element): element is HTMLElement => element instanceof HTMLElement);
+
+		for (const element of elements) {
+			retainPresentationRole(element);
+			this._presentedElements.push(element);
+		}
+	}
+
+	private _styleFocusIndicator(element: HTMLElement): void {
+		const size = this._options.focusIndicatorSize;
+		element.style.cssText = [
+			'position:absolute',
+			'box-sizing:border-box',
+			`width:${size}px`,
+			`height:${size}px`,
+			'border-radius:50%',
+			`border:2px solid ${this._options.focusIndicatorColor}`,
+			'box-shadow:0 0 0 2px rgba(255,255,255,0.9)',
+			'transform:translate(-50%, -50%)',
+			'pointer-events:none',
+			'z-index:4',
+			'display:none',
+		].join(';');
+	}
+
+	private _styleFocusOutline(): void {
+		if (!this._container) {
+			return;
+		}
+		this._container.style.outline = this._hasFocus
+			? `3px solid ${this._options.focusIndicatorColor}`
+			: 'none';
+	}
+
+	private _neutraliseFocusables(root: HTMLElement): void {
+		const selector =
+			'a[href],button,input,select,textarea,iframe,[tabindex],[contenteditable="true"],audio[controls],video[controls]';
+		root.querySelectorAll<HTMLElement>(selector).forEach(element => {
+			this._neutralised.push([
+				element,
+				element.getAttribute('tabindex'),
+				element.getAttribute('aria-hidden'),
+			]);
+			element.setAttribute('tabindex', '-1');
+			element.setAttribute('aria-hidden', 'true');
+		});
+	}
+
+	private _restoreFocusables(): void {
+		for (const [element, previousTabIndex, previousAriaHidden] of this._neutralised) {
+			if (previousTabIndex === null) {
+				element.removeAttribute('tabindex');
+			} else {
+				element.setAttribute('tabindex', previousTabIndex);
+			}
+			if (previousAriaHidden === null) {
+				element.removeAttribute('aria-hidden');
+			} else {
+				element.setAttribute('aria-hidden', previousAriaHidden);
+			}
+		}
+		this._neutralised = [];
+	}
+
+	private _restorePresentationRoles(): void {
+		for (const element of this._presentedElements) {
+			releasePresentationRole(element);
+		}
+		this._presentedElements = [];
+	}
+
+	private _restoreHiddenCanvases(): void {
+		for (const element of this._hiddenCanvases) {
+			releaseAriaHidden(element);
+		}
+		this._hiddenCanvases = [];
+	}
+
+	private _buildPaneLabel(): string {
+		const series = this._activeSeries();
+		return this._messages.paneLabel({
+			title: this._options.chartTitle,
+			seriesCount: this._seriesList.length,
+			seriesLabel: series ? this._seriesLabel(series, this._activeSeriesIndex) : null,
+		});
+	}
+
+	private _updatePaneLabel(): void {
+		this._container?.setAttribute('aria-label', this._buildPaneLabel());
+	}
+
+	private _updateDescription(): void {
+		if (this._descriptionRegion) {
+			this._descriptionRegion.textContent = this._messages.description({
+				multiSeries: this._seriesList.length > 1,
+			});
+		}
+	}
+
+	// region Localisation helpers -------------------------------------------------------
+
+	/** The chart's current locale, or `undefined` (e.g. server-side `''`) for the runtime default. */
+	private _locale(): string | undefined {
+		const locale = this._chart?.options().localization.locale;
+		return locale ? locale : undefined;
+	}
+
+	/** Localised, leading-spaced scope note for summaries, or `''` when not scoped (or the note is blank). */
+	private _scopeNote(): string {
+		const inView = this._messages.inView;
+		return this._options.dataScope === 'visible' && inView ? ` ${inView}` : '';
+	}
+
+	private _formatPercent(value: number): string {
+		const locale = this._locale();
+		if (this._percentFormatter === null || this._percentLocale !== locale) {
+			this._percentLocale = locale;
+			this._percentFormatter = new Intl.NumberFormat(locale, {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			});
+		}
+		return this._percentFormatter.format(value);
+	}
+
+	/** Sets (or clears) the BCP-47 `lang` on the announced regions so screen readers pick the right voice. */
+	private _applyLang(): void {
+		const lang = this._options.lang ?? this._locale();
+		const apply = (element: HTMLElement | null): void => {
+			if (!element) {
+				return;
+			}
+			if (lang) {
+				element.setAttribute('lang', lang);
+			} else {
+				element.removeAttribute('lang');
+			}
+		};
+		apply(this._container);
+		apply(this._liveRegion);
+		apply(this._statusRegion);
+	}
+
+	// region Focus handling -------------------------------------------------------------
+
+	private _handleFocusIn = (): void => {
+		this._hasFocus = true;
+		this._styleFocusOutline();
+		this._positionIndicator();
+		// Tell the shared announcer this pane is now the active one, so in the
+		// default 'active' mode its data updates are the ones that get announced.
+		this._updateAnnouncer?.setActivePane(this._options.paneIndex);
+		// No live-region announcement on focus: the accessible name (aria-label) and
+		// the aria-describedby hint are spoken when focus lands. An assertive message
+		// here would interrupt the name (e.g. VoiceOver cuts off the title); the H key
+		// gives the full controls.
+	};
+
+	private _handleFocusOut = (event: FocusEvent): void => {
+		const next = event.relatedTarget as Node | null;
+		if (next && this._container?.contains(next)) {
+			return;
+		}
+		this._hasFocus = false;
+		this._styleFocusOutline();
+		if (this._focusIndicator) {
+			this._focusIndicator.style.display = 'none';
+		}
+	};
+
+	private _handleKeyDown = (event: KeyboardEvent): void => {
+		if (this._points.length === 0 && this._seriesList.length === 0) {
+			return;
+		}
+		// Leave shortcut combinations (e.g. browser or screen-reader commands such
+		// as Ctrl+Home, or VoiceOver's modifier chords) to the platform.
+		if (event.altKey || event.ctrlKey || event.metaKey) {
+			return;
+		}
+		switch (event.key) {
+			case 'ArrowRight':
+				event.preventDefault();
+				this._movePoint(1);
+				break;
+			case 'ArrowLeft':
+				event.preventDefault();
+				this._movePoint(-1);
+				break;
+			case 'ArrowUp':
+				event.preventDefault();
+				this._moveSeries(-1);
+				break;
+			case 'ArrowDown':
+				event.preventDefault();
+				this._moveSeries(1);
+				break;
+			case 'PageUp':
+				event.preventDefault();
+				this._movePoint(this._options.pageStep);
+				break;
+			case 'PageDown':
+				event.preventDefault();
+				this._movePoint(-this._options.pageStep);
+				break;
+			case 'Home':
+				event.preventDefault();
+				if (this._points.length > 0) {
+					this._setActivePoint(0);
+				}
+				break;
+			case 'End':
+				event.preventDefault();
+				if (this._points.length > 0) {
+					this._setActivePoint(this._points.length - 1);
+				}
+				break;
+			case 'Enter':
+			case ' ':
+				event.preventDefault();
+				this._announce(this._describe());
+				break;
+			case 'h':
+			case 'H':
+				event.preventDefault();
+				this._announce(this._helpText());
+				break;
+			default:
+				break;
+		}
+	};
+
+	private _helpText(): string {
+		return this._messages.help({
+			multiSeries: this._seriesList.length > 1,
+			pageStep: this._options.pageStep,
+		});
+	}
+
+	// region Navigation -----------------------------------------------------------------
+
+	private _boundsForPoints(points: readonly SeriesDataPoint[]): { from: number; to: number } {
+		const last = points.length - 1;
+		if (this._options.dataScope === 'visible') {
+			const visible = this._visibleBounds(points);
+			if (visible) {
+				return visible;
+			}
+		}
+		return { from: 0, to: last };
+	}
+
+	private _visibleBounds(points: readonly SeriesDataPoint[]): { from: number; to: number } | null {
+		const range = this._chart?.timeScale().getVisibleLogicalRange();
+		const last = points.length - 1;
+		if (!range || last < 0) {
+			return null;
+		}
+		const from = clamp(Math.ceil(range.from), 0, last);
+		const to = clamp(Math.floor(range.to), 0, last);
+		if (to < from) {
+			return null;
+		}
+		return { from, to };
+	}
+
+	private _movePoint(delta: number): void {
+		if (this._points.length === 0) {
+			return;
+		}
+		const last = this._points.length - 1;
+		const base =
+			this._activePointIndex < 0
+				? this._firstVisibleIndex()
+				: this._activePointIndex + delta;
+		// Navigation spans the whole series; _setActivePoint pages the viewport so
+		// the target stays on screen, giving keyboard users access to every point.
+		this._setActivePoint(clamp(base, 0, last));
+	}
+
+	private _moveSeries(delta: number): void {
+		if (this._seriesList.length <= 1) {
+			return;
+		}
+		const next = clamp(this._activeSeriesIndex + delta, 0, this._seriesList.length - 1);
+		if (next === this._activeSeriesIndex) {
+			return;
+		}
+		this._activeSeriesIndex = next;
+		this._refreshActivePoints();
+		// Keep the focused point index, clamped to what is valid for the new series.
+		if (this._activePointIndex >= 0) {
+			this._activePointIndex = clamp(this._activePointIndex, 0, Math.max(0, this._points.length - 1));
+		}
+		const series = this._activeSeries();
+		const label = series ? this._seriesLabel(series, next) : '';
+		this._positionIndicator();
+		const pointPart =
+			this._activePointIndex >= 0 ? ` ${this._describePoint(this._activePointIndex)}` : '';
+		this._announce(this._messages.seriesPosition({
+			label,
+			position: next + 1,
+			total: this._seriesList.length,
+			point: pointPart,
+		}));
+	}
+
+	private _firstVisibleIndex(): number {
+		const range = this._chart?.timeScale().getVisibleLogicalRange();
+		if (!range) {
+			return 0;
+		}
+		return clamp(Math.ceil(range.from), 0, this._points.length - 1);
+	}
+
+	private _setActivePoint(index: number): void {
+		this._activePointIndex = index;
+		this._scrollActiveIntoView();
+		this._positionIndicator();
+		this._announce(this._describePoint(index));
+	}
+
+	/**
+	 * Pages the visible logical range so the active point stays on screen. Runs for
+	 * every navigation step, so the arrow / Page / Home / End keys can traverse the
+	 * whole series even when only part of it is visible. The window is nudged by the
+	 * smallest amount that reveals the point (rather than recentring it) so stepping
+	 * past an edge scrolls smoothly.
+	 */
+	private _scrollActiveIntoView(): void {
+		const chart = this._chart;
+		if (!chart || this._points.length === 0) {
+			return;
+		}
+		const timeScale = chart.timeScale();
+		const range = timeScale.getVisibleLogicalRange();
+		if (!range) {
+			return;
+		}
+		const last = this._points.length - 1;
+		const span = range.to - range.from;
+		// Keep a one-point margin from the edge (when the window is wide enough) so
+		// the following point is already visible after a step.
+		const margin = span > 4 ? 1 : 0;
+		const index = this._activePointIndex;
+		let from: number;
+		if (index < range.from + margin) {
+			from = index - margin;
+		} else if (index > range.to - margin) {
+			from = index - span + margin;
+		} else {
+			return; // already comfortably within view
+		}
+		from = clamp(from, 0, Math.max(0, last));
+		timeScale.setVisibleLogicalRange({ from, to: from + span });
+	}
+
+	// region Announcements --------------------------------------------------------------
+
+	private _announce(message: string): void {
+		if (!this._liveRegion) {
+			return;
+		}
+		// Clear now, then write on the next frame. Re-setting textContent across a
+		// frame boundary forces assistive technology to re-announce even when the
+		// message is identical to the previous one (e.g. Home pressed twice); a
+		// synchronous clear-and-set does not reliably do that.
+		this._liveRegion.textContent = '';
+		this._pendingMessage = message;
+		if (this._liveFrame !== null) {
+			cancelAnimationFrame(this._liveFrame);
+		}
+		this._liveFrame = requestAnimationFrame(() => {
+			this._liveFrame = null;
+			if (this._liveRegion && this._pendingMessage !== null) {
+				this._liveRegion.textContent = this._pendingMessage;
+				this._pendingMessage = null;
+			}
+		});
+	}
+
+	private _formatValue(value: number | undefined, series: AnySeries | null = this._activeSeries()): string {
+		if (value === undefined) {
+			return this._messages.noValue;
+		}
+		if (this._options.priceFormatter) {
+			return this._options.priceFormatter(value);
+		}
+		// Honour a chart that is already localised (e.g. a currency formatter set on
+		// localization.priceFormatter) before falling back to the series formatter.
+		// Note: this also formats deltas and individual OHLC fields, not just prices.
+		const chartPriceFormatter = this._chart?.options().localization.priceFormatter;
+		if (chartPriceFormatter) {
+			return chartPriceFormatter(value as BarPrice);
+		}
+		try {
+			return series?.priceFormatter().format(value) ?? String(value);
+		} catch {
+			return String(value);
+		}
+	}
+
+	private _formatTime(time: Time): string {
+		if (this._options.timeFormatter) {
+			return this._options.timeFormatter(time);
+		}
+		const chartTimeFormatter = this._chart?.options().localization.timeFormatter;
+		if (chartTimeFormatter) {
+			return chartTimeFormatter(time);
+		}
+		return defaultTimeFormatter(time, this._locale());
+	}
+
+	private _activeSeriesLabel(): string {
+		const series = this._activeSeries();
+		return series ? this._seriesLabel(series, this._activeSeriesIndex) : '';
+	}
+
+	private _describePoint(index: number): string {
+		const point = this._points[index];
+		if (!point) {
+			return '';
+		}
+		// Position is reported against the whole series ("Point 247 of 500") so it
+		// is unambiguous and independent of the (asynchronously updated) viewport.
+		return this._messages.point({
+			position: index + 1,
+			total: this._points.length,
+			time: this._formatTime(point.time),
+			label: this._activeSeriesLabel(),
+			values: this._describeValues(point),
+		});
+	}
+
+	/**
+	 * Spoken value(s) for a point: the full open / high / low / close for OHLC
+	 * series (bar, candlestick), otherwise the single value. The OHLC assembly
+	 * (order, separators) is delegated to {@link AccessibilityMessages.ohlcValues}
+	 * so it is fully localisable.
+	 */
+	private _describeValues(point: SeriesDataPoint, series: AnySeries | null = this._activeSeries()): string {
+		if ('close' in point && typeof point.close === 'number') {
+			// `'close' in point` narrows to the OHLC data types (bar / candlestick).
+			const field = (value: number | undefined): string | null =>
+				typeof value === 'number' ? this._formatValue(value, series) : null;
+			return this._messages.ohlcValues({
+				labels: this._messages.ohlc,
+				open: field(point.open),
+				high: field(point.high),
+				low: field(point.low),
+				close: this._formatValue(point.close, series),
+			});
+		}
+		return this._formatValue(extractValue(point), series);
+	}
+
+	private _scopedPoints(points: readonly SeriesDataPoint[] = this._points): readonly SeriesDataPoint[] {
+		if (this._options.dataScope !== 'visible') {
+			return points;
+		}
+		const bounds = this._boundsForPoints(points);
+		return points.slice(bounds.from, bounds.to + 1);
+	}
+
+	private _describe(): string {
+		const label = this._activeSeriesLabel();
+		const scoped = this._scopedPoints();
+		if (this._options.describeChart) {
+			return this._options.describeChart(scoped, label);
+		}
+		const valued = scoped.filter(p => extractValue(p) !== undefined);
+		if (valued.length === 0) {
+			return this._messages.noData({ label });
+		}
+		const first = valued[0];
+		const last = valued[valued.length - 1];
+		let low = first;
+		let high = first;
+		for (const point of valued) {
+			const value = extractValue(point) as number;
+			if (value < (extractValue(low) as number)) {
+				low = point;
+			}
+			if (value > (extractValue(high) as number)) {
+				high = point;
+			}
+		}
+		const firstValue = extractValue(first) as number;
+		const lastValue = extractValue(last) as number;
+		const change = lastValue - firstValue;
+		// Percent is undefined when the series starts at zero (avoids a misleading
+		// "up by 12, 0 percent"); the summary drops the clause in that case.
+		const percent = firstValue !== 0 ? (change / firstValue) * 100 : null;
+		const direction: 'up' | 'down' | 'unchanged' = change > 0 ? 'up' : change < 0 ? 'down' : 'unchanged';
+
+		return this._messages.summary({
+			label,
+			count: valued.length,
+			scopeNote: this._scopeNote(),
+			firstValue: this._formatValue(firstValue),
+			firstTime: this._formatTime(first.time),
+			lastValue: this._formatValue(lastValue),
+			lastTime: this._formatTime(last.time),
+			direction,
+			directionLabel: this._messages.directions[direction],
+			changeValue: this._formatValue(Math.abs(change)),
+			percent: percent !== null ? this._formatPercent(Math.abs(percent)) : null,
+			lowValue: this._formatValue(extractValue(low)),
+			lowTime: this._formatTime(low.time),
+			highValue: this._formatValue(extractValue(high)),
+			highTime: this._formatTime(high.time),
+		});
+	}
+
+	// region Data synchronisation -------------------------------------------------------
+
+	/**
+	 * Reconciles our per-series `subscribeDataChanged` subscriptions with the
+	 * series currently in the pane. Cheap to call on every redraw: it only reads
+	 * the already-allocated series handles and returns early unless the set of
+	 * series changed, so scrolling and zooming never re-read or re-hash bar data.
+	 * Actual data-content changes are delivered by the subscriptions instead.
+	 */
+	private _syncSeries(): void {
+		const pane = this._pane();
+		if (!pane) {
+			return;
+		}
+		const current = pane.getSeries();
+		if (this._sameSeriesList(current)) {
+			return;
+		}
+		for (const [series, handler] of this._dataChangedHandlers) {
+			if (!current.includes(series)) {
+				series.unsubscribeDataChanged(handler);
+				this._dataChangedHandlers.delete(series);
+				this._dirtySeries.delete(series);
+			}
+		}
+		for (const series of current) {
+			if (!this._dataChangedHandlers.has(series)) {
+				const handler = (): void => this._handleSeriesDataChanged(series);
+				series.subscribeDataChanged(handler);
+				this._dataChangedHandlers.set(series, handler);
+			}
+		}
+		this._seriesList = current.slice();
+		if (this._activeSeriesIndex >= this._seriesList.length) {
+			this._activeSeriesIndex = Math.max(0, this._seriesList.length - 1);
+		}
+		this._readAllData();
+		this._refreshActivePoints();
+		this._updatePaneLabel();
+		this._updateDescription();
+		this._positionIndicator();
+	}
+
+	private _sameSeriesList(current: readonly AnySeries[]): boolean {
+		if (current.length !== this._seriesList.length) {
+			return false;
+		}
+		return current.every((series, index) => series === this._seriesList[index]);
+	}
+
+	private _readAllData(): void {
+		this._seriesData = this._seriesList.map(series => ({ series, data: series.data() }));
+	}
+
+	/**
+	 * Fired by the library when a series' data actually changes (set/update) – not
+	 * on scroll or zoom. Re-reads just that series and schedules a single debounced
+	 * polite announcement that coalesces simultaneous updates across series.
+	 */
+	private _handleSeriesDataChanged(series: AnySeries): void {
+		const index = this._seriesList.indexOf(series);
+		if (index < 0) {
+			return;
+		}
+		this._seriesData[index] = { series, data: series.data() };
+		if (index === this._activeSeriesIndex) {
+			this._refreshActivePoints();
+			this._positionIndicator();
+		}
+		if (this._options.announceDataUpdates) {
+			this._dirtySeries.add(series);
+			if (this._updateAnnouncer) {
+				// Shared region: the announcer owns the single debounce timer and
+				// pulls our summaries at flush time via the internal PluginLink.
+				this._updateAnnouncer.notifyDirty(this);
+			} else {
+				this._scheduleUpdateAnnouncement();
+			}
+		}
+	}
+
+	private _scheduleUpdateAnnouncement(): void {
+		if (this._announceUpdateHandle !== null) {
+			clearTimeout(this._announceUpdateHandle);
+		}
+		this._announceUpdateHandle = setTimeout(() => {
+			this._announceUpdateHandle = null;
+			this._flushUpdateAnnouncement();
+		}, UPDATE_DEBOUNCE_MS);
+	}
+
+	private _flushUpdateAnnouncement(): void {
+		const region = this._statusRegion;
+		if (!region) {
+			this._dirtySeries.clear();
+			return;
+		}
+		const message = formatUpdateMessage(this._collectPendingUpdateSummaries(), this._messages);
+		if (message.length > 0) {
+			region.textContent = message;
+		}
+	}
+
+	/**
+	 * Returns this pane's pending per-series update summaries and clears the dirty
+	 * set. Honours {@link AccessibilityOptions.announceDataUpdates} and
+	 * {@link AccessibilityOptions.dataScope}. Reached from the standalone flush and,
+	 * for the shared region, the {@link UpdateAnnouncer} via the internal PluginLink.
+	 */
+	private _collectPendingUpdateSummaries(): string[] {
+		if (!this._options.announceDataUpdates || this._dirtySeries.size === 0) {
+			this._dirtySeries.clear();
+			return [];
+		}
+		const changed = this._seriesData.filter(snapshot => this._dirtySeries.has(snapshot.series));
+		this._dirtySeries.clear();
+		return changed.map(snapshot => this._seriesUpdateSummary(snapshot));
+	}
+
+	private _unsubscribeAll(): void {
+		for (const [series, handler] of this._dataChangedHandlers) {
+			series.unsubscribeDataChanged(handler);
+		}
+		this._dataChangedHandlers.clear();
+		this._dirtySeries.clear();
+	}
+
+	private _refreshActivePoints(): void {
+		const snapshot = this._seriesData[this._activeSeriesIndex];
+		this._points = snapshot ? snapshot.data : [];
+		if (this._activePointIndex >= this._points.length) {
+			this._activePointIndex = this._points.length - 1;
+		}
+	}
+
+	private _seriesUpdateSummary(snapshot: SeriesSnapshot): string {
+		const scoped = this._scopedPoints(snapshot.data);
+		const value = extractValue(scoped[scoped.length - 1]);
+		const index = this._seriesData.indexOf(snapshot);
+		return this._messages.seriesUpdate({
+			label: this._seriesLabel(snapshot.series, index),
+			count: scoped.length,
+			scopeNote: this._scopeNote(),
+			latest: this._formatValue(value, snapshot.series),
+		});
+	}
+
+	// region Visible focus indicator ----------------------------------------------------
+
+	private _positionIndicator(): void {
+		const indicator = this._focusIndicator;
+		const chart = this._chart;
+		const series = this._activeSeries();
+		if (!indicator || !chart || !series) {
+			return;
+		}
+		if (!this._options.showFocusIndicator || !this._hasFocus || this._activePointIndex < 0) {
+			indicator.style.display = 'none';
+			return;
+		}
+		const point = this._points[this._activePointIndex];
+		const value = extractValue(point);
+		if (!point || value === undefined) {
+			indicator.style.display = 'none';
+			return;
+		}
+		const x = chart.timeScale().timeToCoordinate(point.time);
+		const y = series.priceToCoordinate(value);
+		if (x === null || y === null) {
+			// Off-screen (e.g. mid-scroll) – hide until it comes back into view.
+			indicator.style.display = 'none';
+			return;
+		}
+		// The indicator lives inside the pane's canvas wrapper, so both
+		// coordinates are already local to its positioning context.
+		indicator.style.left = `${x}px`;
+		indicator.style.top = `${y}px`;
+		indicator.style.display = 'block';
+	}
+}
+
+type UpdateAnnouncerMode = 'active' | 'combine';
+
+/**
+ * A single chart-level polite live region shared by all per-pane
+ * {@link AccessibilityPlugin} instances created by {@link addAccessibilityPlugin}.
+ *
+ * Each pane plugin keeps its own assertive region for navigation, but routing
+ * every background *data-update* announcement through one region avoids the case
+ * where several panes mutate their own polite regions in the same tick and a
+ * screen reader only voices the last one.
+ *
+ * - `'active'` mode announces only the last-focused pane (falling back to pane 0).
+ * - `'combine'` mode merges the changed series from every reporting pane into one
+ *   message, in pane order.
+ */
+class UpdateAnnouncer {
+	private _region: HTMLElement | null;
+	private _mode: UpdateAnnouncerMode;
+	private readonly _plugins: AccessibilityPlugin[] = [];
+	private readonly _dirty = new Set<AccessibilityPlugin>();
+	private _handle: ReturnType<typeof setTimeout> | null = null;
+	private _frame: ReturnType<typeof requestAnimationFrame> | null = null;
+	private _activePaneIndex = 0;
+	private _messages: AccessibilityMessages;
+
+	public constructor(host: HTMLElement, mode: UpdateAnnouncerMode, messages: AccessibilityMessages, lang?: string) {
+		this._mode = mode;
+		this._messages = messages;
+		const region = document.createElement('div');
+		region.className = 'lw-chart-a11y-shared-status-region';
+		region.setAttribute('aria-live', 'polite');
+		region.setAttribute('aria-atomic', 'true');
+		if (lang) {
+			region.setAttribute('lang', lang);
+		}
+		region.style.cssText = VISUALLY_HIDDEN;
+		host.appendChild(region);
+		this._region = region;
+	}
+
+	/** Registers a pane plugin; registration order is pane order. */
+	public register(plugin: AccessibilityPlugin): void {
+		this._plugins.push(plugin);
+	}
+
+	public setActivePane(paneIndex: number): void {
+		this._activePaneIndex = paneIndex;
+	}
+
+	/** Reconfigures the shared region at runtime (mode / messages / lang). */
+	public configure(mode: UpdateAnnouncerMode, messages: AccessibilityMessages, lang?: string): void {
+		this._mode = mode;
+		this._messages = messages;
+		if (this._region) {
+			if (lang) {
+				this._region.setAttribute('lang', lang);
+			} else {
+				this._region.removeAttribute('lang');
+			}
+		}
+	}
+
+	public notifyDirty(plugin: AccessibilityPlugin): void {
+		this._dirty.add(plugin);
+		// Start-once (do not reset): a sub-debounce-interval stream still announces
+		// periodically instead of having its timer pushed out indefinitely.
+		if (this._handle === null) {
+			this._handle = setTimeout(() => {
+				this._handle = null;
+				this._flush();
+			}, UPDATE_DEBOUNCE_MS);
+		}
+	}
+
+	public dispose(): void {
+		if (this._handle !== null) {
+			clearTimeout(this._handle);
+			this._handle = null;
+		}
+		if (this._frame !== null) {
+			cancelAnimationFrame(this._frame);
+			this._frame = null;
+		}
+		this._region?.remove();
+		this._region = null;
+		this._plugins.length = 0;
+		this._dirty.clear();
+	}
+
+	private _flush(): void {
+		const summaries: string[] = [];
+		// Iterate in registration (pane) order so the combined message is stable.
+		for (const plugin of this._plugins) {
+			if (!this._dirty.has(plugin)) {
+				continue;
+			}
+			// Always collect (and clear) the plugin's pending summaries; keep them
+			// only when combining or when this is the active pane.
+			const pending = pluginLinks.get(plugin)?.collectPendingUpdateSummaries() ?? [];
+			if (this._mode === 'combine' || plugin.options().paneIndex === this._activePaneIndex) {
+				summaries.push(...pending);
+			}
+		}
+		this._dirty.clear();
+		this._write(formatUpdateMessage(summaries, this._messages));
+	}
+
+	private _write(message: string): void {
+		const region = this._region;
+		if (!region || message.length === 0) {
+			return;
+		}
+		// Clear then set on the next frame so identical consecutive messages are
+		// still re-announced (mirrors AccessibilityPlugin._announce).
+		region.textContent = '';
+		if (this._frame !== null) {
+			cancelAnimationFrame(this._frame);
+		}
+		this._frame = requestAnimationFrame(() => {
+			this._frame = null;
+			if (this._region) {
+				this._region.textContent = message;
+			}
+		});
+	}
+}
+
+export interface AccessibilityPluginController {
+	readonly plugins: readonly AccessibilityPlugin[];
+	detach(): void;
+	focus(paneIndex?: number): void;
+	refresh(): void;
+	/**
+	 * Updates chart-level options at runtime, keeping the per-pane layers and the
+	 * shared update region in sync — including `announceDataUpdates` (active /
+	 * combine), `messages` and `lang`, which the per-pane `applyOptions` alone
+	 * cannot change on the shared region.
+	 */
+	applyOptions(options: AccessibilityChartOptions): void;
+}
+
+export type AccessibilityChartOptions = Omit<
+	Partial<AccessibilityOptions>,
+	'chartTitle' | 'paneIndex' | 'announceDataUpdates'
+> & {
+	chartTitle?: string | ((paneIndex: number) => string);
+	/**
+	 * Which panes announce background data updates.
+	 *
+	 * - `'active'` (default): only the last-focused pane (pane 0 until something is
+	 *   focused). Avoids several panes talking over each other.
+	 * - `true`: every pane; simultaneous updates merge into one announcement.
+	 * - `false`: none.
+	 * - `(paneIndex) => boolean`: choose per pane; the enabled panes are combined.
+	 */
+	announceDataUpdates?: boolean | 'active' | ((paneIndex: number) => boolean);
+};
+
+export function addAccessibilityPlugin(
+	chart: IChartApiBase<Time>,
+	options: AccessibilityChartOptions = {}
+): AccessibilityPluginController {
+	const entries: { pane: IPaneApi<Time>; plugin: AccessibilityPlugin }[] = [];
+	let announcer: UpdateAnnouncer | null = null;
+	// Mutable so the controller's applyOptions can reconfigure at runtime.
+	let current: AccessibilityChartOptions = { ...options };
+
+	// 'active' (default) announces only the focused pane; a boolean / predicate
+	// announces those panes and the announcer combines them into one message.
+	const announcerMode = (): UpdateAnnouncerMode =>
+		current.announceDataUpdates === undefined || current.announceDataUpdates === 'active' ? 'active' : 'combine';
+	const resolveAnnounce = (paneIndex: number): boolean => {
+		const announce = current.announceDataUpdates;
+		if (announce === undefined || announce === 'active') {
+			// All panes report; the announcer filters down to the active pane.
+			return true;
+		}
+		return typeof announce === 'function' ? announce(paneIndex) : announce;
+	};
+	const resolveLang = (): string | undefined =>
+		current.lang ?? (chart.options().localization.locale || undefined);
+
+	const resolveOptions = (paneIndex: number): Partial<AccessibilityOptions> => {
+		const { chartTitle, ...rest } = current;
+		const resolved: Partial<AccessibilityOptions> = {
+			...rest,
+			paneIndex,
+			announceDataUpdates: resolveAnnounce(paneIndex),
+		};
+		if (chartTitle !== undefined) {
+			resolved.chartTitle = typeof chartTitle === 'function'
+				? chartTitle(paneIndex)
+				: chartTitle;
+		}
+		return resolved;
+	};
+
+	const detach = (): void => {
+		const disposing = announcer;
+		announcer = null;
+		while (entries.length > 0) {
+			const entry = entries.pop();
+			if (entry) {
+				pluginLinks.get(entry.plugin)?.attachAnnouncer(null);
+				entry.pane.detachPrimitive(entry.plugin);
+			}
+		}
+		// Remove the shared region only after the per-pane plugins are torn down.
+		disposing?.dispose();
+	};
+
+	const attach = (): void => {
+		detach();
+		const sharedAnnouncer = new UpdateAnnouncer(
+			chart.chartElement(),
+			announcerMode(),
+			mergeMessages(defaultMessages, current.messages),
+			resolveLang()
+		);
+		announcer = sharedAnnouncer;
+		chart.panes().forEach((pane, paneIndex) => {
+			const plugin = new AccessibilityPlugin(resolveOptions(paneIndex));
+			pane.attachPrimitive(plugin);
+			pluginLinks.get(plugin)?.attachAnnouncer(sharedAnnouncer);
+			sharedAnnouncer.register(plugin);
+			entries.push({ pane, plugin });
+		});
+	};
+
+	const applyOptions = (next: AccessibilityChartOptions): void => {
+		current = { ...current, ...next };
+		// Keep the shared region (mode / messages / lang) and every pane in sync.
+		announcer?.configure(announcerMode(), mergeMessages(defaultMessages, current.messages), resolveLang());
+		entries.forEach(({ plugin }, paneIndex) => plugin.applyOptions(resolveOptions(paneIndex)));
+	};
+
+	attach();
+
+	return {
+		get plugins(): readonly AccessibilityPlugin[] {
+			return entries.map(entry => entry.plugin);
+		},
+		detach,
+		focus(paneIndex = 0): void {
+			entries[paneIndex]?.plugin.focus();
+		},
+		refresh: attach,
+		applyOptions,
+	};
+}

--- a/plugin-examples/src/plugins/accessibility/accessibility.ts
+++ b/plugin-examples/src/plugins/accessibility/accessibility.ts
@@ -180,6 +180,26 @@ export interface AccessibilityOptions {
 	 * `localization.locale`.
 	 */
 	lang?: string;
+	/**
+	 * Show a visible keyboard-shortcuts overlay for sighted keyboard users: a
+	 * "Press H" hint while the pane is focused, and an `H`-toggled panel listing
+	 * the controls (`Esc` closes it). Screen-reader users always get the spoken
+	 * `H` help regardless of this option. Defaults to `false`.
+	 */
+	showShortcuts: boolean;
+	/**
+	 * High-contrast styling for the plugin's own visuals (focus ring, focus outline
+	 * and the shortcuts overlay). `'auto'` (default) follows the OS
+	 * `prefers-contrast` / `forced-colors`; pass a predicate to wire it to your own
+	 * setting. This does not restyle the chart's series / grid / font — use
+	 * {@link onHighContrastChange} for that.
+	 */
+	highContrast: boolean | 'auto' | (() => boolean);
+	/**
+	 * Called when the resolved high-contrast state changes (and once on attach),
+	 * so the host can restyle the chart's own series / grid / font to match.
+	 */
+	onHighContrastChange?: (enabled: boolean) => void;
 }
 
 const defaultOptions: AccessibilityOptions = {
@@ -191,6 +211,8 @@ const defaultOptions: AccessibilityOptions = {
 	announceDataUpdates: true,
 	pageStep: 10,
 	dataScope: 'visible',
+	showShortcuts: false,
+	highContrast: 'auto',
 };
 
 /** Elements that can receive keyboard focus and so must be neutralised inside the hidden chart DOM. */
@@ -203,6 +225,17 @@ const VISUALLY_HIDDEN =
 
 function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(max, value));
+}
+
+/** The media queries whose changes flip the `'auto'` high-contrast state. */
+const HIGH_CONTRAST_QUERIES = ['(prefers-contrast: more)', '(forced-colors: active)'];
+
+/** Whether the OS asks for higher contrast (used by the `'auto'` high-contrast mode). */
+function prefersHighContrast(): boolean {
+	if (typeof window === 'undefined' || !window.matchMedia) {
+		return false;
+	}
+	return HIGH_CONTRAST_QUERIES.some(query => window.matchMedia(query).matches);
 }
 
 /**
@@ -371,6 +404,17 @@ export interface AccessibilityMessages {
 	description: (args: { multiSeries: boolean }) => string;
 	/** Announced on `H`. */
 	help: (args: { multiSeries: boolean; pageStep: number }) => string;
+	/** Hint shown on the visible overlay while the pane is focused (when `showShortcuts`). */
+	shortcutsHint: string;
+	/** Heading of the visible shortcuts panel. */
+	shortcutsTitle: string;
+	/**
+	 * Rows for the *visible* shortcuts panel (for sighted keyboard users), so list
+	 * only keys with an on-screen effect. Screen-reader-only actions — such as the
+	 * Enter / Space summary, which is spoken but produces nothing visible — belong
+	 * in {@link help}, not here.
+	 */
+	shortcuts: (args: { multiSeries: boolean; pageStep: number }) => readonly { keys: string; action: string }[];
 	/** Announced for the focused data point (`position` is 1-based). */
 	point: (args: { position: number; total: number; time: string; label: string; values: string }) => string;
 	/** Announced when switching series (`position` is 1-based; `point` is pre-spaced or `''`). */
@@ -416,7 +460,20 @@ export const defaultMessages: AccessibilityMessages = {
 			? 'Use the left and right arrow keys to move between data points, and the up and down arrows to switch series.'
 			: 'Use the left and right arrow keys to move between data points.',
 	help: ({ multiSeries, pageStep }): string =>
-		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up jumps ${pageStep} points forward, Page Down ${pageStep} points back. Home and End jump to the first and last points. Enter or Space reads a summary of the series.`,
+		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up jumps ${pageStep} points forward, Page Down ${pageStep} points back. Home and End jump to the first and last points. Plus and minus zoom the chart in and out. Enter or Space reads a summary of the series.`,
+	shortcutsHint: 'Press H for keyboard shortcuts',
+	shortcutsTitle: 'Keyboard shortcuts',
+	shortcuts: ({ multiSeries, pageStep }) => [
+		{ keys: '← / →', action: 'Move between data points' },
+		...(multiSeries ? [{ keys: '↑ / ↓', action: 'Switch between series' }] : []),
+		{ keys: 'Page Up / Page Down', action: `Jump ${pageStep} points` },
+		{ keys: 'Home / End', action: 'First / last point' },
+		{ keys: '+ / −', action: 'Zoom in / out' },
+		// Enter / Space (the spoken summary) is intentionally omitted: it has no
+		// on-screen effect, so it stays in `help` (for screen readers) only.
+		{ keys: 'H', action: 'Show or hide this panel' },
+		{ keys: 'Esc', action: 'Close this panel' },
+	],
 	// Most important information first: the value, then the date; the position
 	// counter is context, so it comes last.
 	point: ({ position, total, time, label, values }): string =>
@@ -487,6 +544,12 @@ const UPDATE_DEBOUNCE_MS = 150;
 /** Maximum number of changed series listed in a single update announcement. */
 const UPDATE_MAX_SERIES = 3;
 
+/** Fraction the visible range grows / shrinks per `+` / `-` zoom keypress. */
+const ZOOM_STEP = 0.2;
+
+/** Smallest visible logical span (in bars) that zooming-in will produce. */
+const MIN_ZOOM_SPAN = 2;
+
 /**
  * Builds the spoken text for a batch of changed-series summaries. Shared by the
  * standalone per-pane path and the chart-level {@link UpdateAnnouncer}. Returns
@@ -532,9 +595,10 @@ const pluginLinks = new WeakMap<AccessibilityPlugin, PluginLink>();
  * To keep the DOM lightweight regardless of the number of bars, the plugin uses
  * an "active-point-only" strategy: it never mirrors every data point into the
  * DOM, rendering only a small fixed set of nodes per pane (a semantic overlay, a
- * live region, a description and a focus indicator). Keyboard navigation always
- * covers the whole series; the default `dataScope: 'visible'` keeps the spoken
- * summaries scoped to the viewport on large data sets.
+ * live region, a description, a focus indicator and an optional shortcuts
+ * overlay). Keyboard navigation always covers the whole series; the default
+ * `dataScope: 'visible'` keeps the spoken summaries scoped to the viewport on
+ * large data sets.
  */
 export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	private _options: AccessibilityOptions;
@@ -545,6 +609,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	private _statusRegion: HTMLElement | null = null;
 	private _descriptionRegion: HTMLElement | null = null;
 	private _focusIndicator: HTMLElement | null = null;
+	// Visible (opt-in) keyboard-shortcuts overlay for sighted keyboard users.
+	private _shortcutsHint: HTMLElement | null = null;
+	private _shortcutsPanel: HTMLElement | null = null;
+	private _shortcutsOpen = false;
 	private _domObserver: MutationObserver | null = null;
 	private _requestUpdate: (() => void) | null = null;
 
@@ -580,6 +648,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	// Memoised percent formatter, rebuilt only when the chart's locale changes.
 	private _percentFormatter: Intl.NumberFormat | null = null;
 	private _percentLocale: string | undefined;
+	// Resolved high-contrast state, plus the OS media queries that drive `'auto'`.
+	private _highContrast = false;
+	private _highContrastInitialised = false;
+	private _contrastMedia: MediaQueryList[] = [];
 
 	public constructor(options: Partial<AccessibilityOptions> = {}) {
 		this._options = { ...defaultOptions, ...options };
@@ -649,6 +721,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		// Stop observing before restoring, so our own restores are not re-swept.
 		this._domObserver?.disconnect();
 		this._domObserver = null;
+		for (const media of this._contrastMedia) {
+			media.removeEventListener('change', this._onContrastChange);
+		}
+		this._contrastMedia = [];
 		this._restorePresentationRoles();
 		this._restoreHiddenCanvases();
 		this._restoreFocusables();
@@ -660,6 +736,11 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		this._statusRegion = null;
 		this._descriptionRegion = null;
 		this._focusIndicator = null;
+		this._shortcutsHint = null;
+		this._shortcutsPanel = null;
+		this._shortcutsOpen = false;
+		this._highContrast = false;
+		this._highContrastInitialised = false;
 		this._seriesList = [];
 		this._points = [];
 		this._activePointsStale = false;
@@ -701,6 +782,11 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		}
 		this._styleFocusOutline();
 		this._positionIndicator();
+		this._renderShortcuts();
+		// Re-resolve in case `highContrast` changed; always re-style the overlay in
+		// case `showShortcuts` / `messages` did.
+		this._refreshHighContrast();
+		this._styleShortcutsOverlay();
 	}
 
 	public options(): Readonly<AccessibilityOptions> {
@@ -848,8 +934,35 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		semanticLayer.appendChild(focusIndicator);
 		this._focusIndicator = focusIndicator;
 
+		this._buildShortcutsOverlay(semanticLayer);
+		this._setupContrastMedia();
+		// Resolve high contrast last: styles the nodes above and fires the initial
+		// onHighContrastChange so the host can set its matching chart theme.
+		this._refreshHighContrast();
+
 		this._applyLang();
 		this._watchForRecreatedElements(paneElement);
+	}
+
+	/**
+	 * Builds the visible keyboard-shortcuts overlay (a focus hint and an H-toggled
+	 * panel). Always created but only shown when {@link AccessibilityOptions.showShortcuts}
+	 * is set; `aria-hidden` because screen-reader users get the spoken `H` help.
+	 */
+	private _buildShortcutsOverlay(semanticLayer: HTMLElement): void {
+		const hint = document.createElement('div');
+		hint.className = 'lw-chart-a11y-shortcuts-hint';
+		hint.setAttribute('aria-hidden', 'true');
+		semanticLayer.appendChild(hint);
+		this._shortcutsHint = hint;
+
+		const panel = document.createElement('div');
+		panel.className = 'lw-chart-a11y-shortcuts-panel';
+		panel.setAttribute('aria-hidden', 'true');
+		semanticLayer.appendChild(panel);
+		this._shortcutsPanel = panel;
+
+		this._renderShortcuts();
 	}
 
 	private _markTableStructurePresentational(paneElement: HTMLElement): void {
@@ -867,14 +980,20 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 
 	private _styleFocusIndicator(element: HTMLElement): void {
 		const size = this._options.focusIndicatorSize;
+		const color = this._options.focusIndicatorColor;
+		// High contrast: a thicker ring with a white-then-black halo so it stands
+		// out on any background. (box-shadow is dropped in forced-colors mode, where
+		// the border itself still shows.)
+		const ring = this._highContrast
+			? [`border:3px solid ${color}`, 'box-shadow:0 0 0 2px #fff, 0 0 0 4px #000']
+			: [`border:2px solid ${color}`, 'box-shadow:0 0 0 2px rgba(255,255,255,0.9)'];
 		element.style.cssText = [
 			'position:absolute',
 			'box-sizing:border-box',
 			`width:${size}px`,
 			`height:${size}px`,
 			'border-radius:50%',
-			`border:2px solid ${this._options.focusIndicatorColor}`,
-			'box-shadow:0 0 0 2px rgba(255,255,255,0.9)',
+			...ring,
 			'transform:translate(-50%, -50%)',
 			'pointer-events:none',
 			'z-index:4',
@@ -886,9 +1005,119 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		if (!this._container) {
 			return;
 		}
+		const width = this._highContrast ? 4 : 3;
 		this._container.style.outline = this._hasFocus
-			? `3px solid ${this._options.focusIndicatorColor}`
+			? `${width}px solid ${this._options.focusIndicatorColor}`
 			: 'none';
+	}
+
+	// region High contrast & shortcuts overlay ------------------------------------------
+
+	private _setupContrastMedia(): void {
+		if (typeof window === 'undefined' || !window.matchMedia) {
+			return;
+		}
+		this._contrastMedia = HIGH_CONTRAST_QUERIES.map(query => window.matchMedia(query));
+		for (const media of this._contrastMedia) {
+			media.addEventListener('change', this._onContrastChange);
+		}
+	}
+
+	private _onContrastChange = (): void => {
+		this._refreshHighContrast();
+	};
+
+	private _resolveHighContrast(): boolean {
+		const highContrast = this._options.highContrast;
+		if (typeof highContrast === 'function') {
+			return highContrast();
+		}
+		if (highContrast === 'auto') {
+			return prefersHighContrast();
+		}
+		return highContrast;
+	}
+
+	/**
+	 * Recomputes the high-contrast state; on a change (or the first call) restyles
+	 * the plugin's own visuals and notifies the host through onHighContrastChange.
+	 */
+	private _refreshHighContrast(): void {
+		const next = this._resolveHighContrast();
+		if (this._highContrastInitialised && next === this._highContrast) {
+			return;
+		}
+		this._highContrast = next;
+		this._highContrastInitialised = true;
+		if (this._focusIndicator) {
+			this._styleFocusIndicator(this._focusIndicator);
+		}
+		this._styleFocusOutline();
+		this._positionIndicator();
+		this._styleShortcutsOverlay();
+		this._options.onHighContrastChange?.(next);
+	}
+
+	private _hintVisible(): boolean {
+		return this._options.showShortcuts && this._hasFocus && !this._shortcutsOpen;
+	}
+
+	private _setShortcutsOpen(open: boolean): void {
+		this._shortcutsOpen = open && this._options.showShortcuts;
+		this._styleShortcutsOverlay();
+	}
+
+	/** (Re)builds the hint and panel text from the current messages. */
+	private _renderShortcuts(): void {
+		if (this._shortcutsHint) {
+			this._shortcutsHint.textContent = this._messages.shortcutsHint;
+		}
+		const panel = this._shortcutsPanel;
+		if (!panel) {
+			return;
+		}
+		panel.textContent = '';
+		const title = document.createElement('div');
+		title.textContent = this._messages.shortcutsTitle;
+		title.style.cssText = 'font-weight:600;margin-bottom:6px;';
+		panel.appendChild(title);
+		const rows = this._messages.shortcuts({
+			multiSeries: this._seriesList.length > 1,
+			pageStep: this._options.pageStep,
+		});
+		for (const { keys, action } of rows) {
+			const row = document.createElement('div');
+			row.style.cssText = 'display:flex;gap:10px;align-items:baseline;margin-top:3px;';
+			const keyEl = document.createElement('kbd');
+			keyEl.textContent = keys;
+			// `currentColor` keeps the key border in step with the (contrast-aware) text colour.
+			keyEl.style.cssText = 'flex:0 0 auto;border:1px solid currentColor;border-radius:3px;padding:0 5px;font-family:monospace;white-space:nowrap;';
+			const actionEl = document.createElement('span');
+			actionEl.textContent = action;
+			row.appendChild(keyEl);
+			row.appendChild(actionEl);
+			panel.appendChild(row);
+		}
+	}
+
+	/** Positions / shows / hides the overlay and applies the contrast palette. */
+	private _styleShortcutsOverlay(): void {
+		const base = 'position:absolute;z-index:6;color:#fff;font-size:0.8125rem;line-height:1.45;pointer-events:none;';
+		const surface = this._highContrast
+			? 'background:#000;border:2px solid #fff;'
+			: 'background:rgba(20,24,28,0.9);border:1px solid rgba(255,255,255,0.25);';
+		if (this._shortcutsHint) {
+			this._shortcutsHint.style.cssText = base + surface +
+				'left:8px;bottom:8px;padding:3px 8px;border-radius:4px;white-space:nowrap;' +
+				(this._hintVisible() ? '' : 'display:none;');
+		}
+		if (this._shortcutsPanel) {
+			const panelVisible = this._options.showShortcuts && this._shortcutsOpen;
+			this._shortcutsPanel.style.cssText = base + surface +
+				'left:8px;top:8px;max-width:calc(100% - 16px);padding:8px 11px;border-radius:6px;' +
+				(this._highContrast ? '' : 'box-shadow:0 2px 10px rgba(0,0,0,0.45);') +
+				(panelVisible ? '' : 'display:none;');
+		}
 	}
 
 	private _neutraliseFocusables(root: HTMLElement): void {
@@ -1052,6 +1281,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		}
 		this._styleFocusOutline();
 		this._positionIndicator();
+		this._styleShortcutsOverlay();
 		// Tell the shared announcer this pane is now the active one, so in the
 		// default 'active' mode its data updates are the ones that get announced.
 		this._updateAnnouncer?.setActivePlugin(this);
@@ -1067,7 +1297,9 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 			return;
 		}
 		this._hasFocus = false;
+		this._shortcutsOpen = false;
 		this._styleFocusOutline();
+		this._styleShortcutsOverlay();
 		if (this._focusIndicator) {
 			this._focusIndicator.style.display = 'none';
 		}
@@ -1119,6 +1351,16 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 					this._setActivePoint(this._points.length - 1);
 				}
 				break;
+			case '+':
+			case '=':
+				event.preventDefault();
+				this._zoom(true);
+				break;
+			case '-':
+			case '_':
+				event.preventDefault();
+				this._zoom(false);
+				break;
 			case 'Enter':
 			case ' ':
 				event.preventDefault();
@@ -1128,6 +1370,13 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 			case 'H':
 				event.preventDefault();
 				this._announce(this._helpText());
+				this._setShortcutsOpen(!this._shortcutsOpen);
+				break;
+			case 'Escape':
+				if (this._shortcutsOpen) {
+					event.preventDefault();
+					this._setShortcutsOpen(false);
+				}
 				break;
 			default:
 				break;
@@ -1313,6 +1562,36 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		const lastLogical = this._logicalIndexOf(this._points[this._points.length - 1]) ?? index;
 		from = clamp(from, 0, Math.max(0, lastLogical));
 		timeScale.setVisibleLogicalRange({ from, to: from + span });
+	}
+
+	/**
+	 * Zooms the time scale in / out (the `+` / `-` keys), as the keyboard tutorial
+	 * does, by shrinking / growing the visible logical span. The focused point is
+	 * kept at the same position on screen so the user does not lose their place.
+	 */
+	private _zoom(zoomIn: boolean): void {
+		const chart = this._chart;
+		if (!chart) {
+			return;
+		}
+		const timeScale = chart.timeScale();
+		const range = timeScale.getVisibleLogicalRange();
+		if (!range) {
+			return;
+		}
+		const span = range.to - range.from;
+		if (span <= 0) {
+			return;
+		}
+		const newSpan = Math.max(MIN_ZOOM_SPAN, span * (zoomIn ? 1 - ZOOM_STEP : 1 + ZOOM_STEP));
+		// Anchor on the focused point (else the viewport centre) and keep it at the
+		// same relative position, so zooming does not scroll the point off screen.
+		const point = this._points[this._activePointIndex];
+		const anchor = (point ? this._logicalIndexOf(point) : null) ?? (range.from + range.to) / 2;
+		const ratio = (anchor - range.from) / span;
+		const from = anchor - ratio * newSpan;
+		timeScale.setVisibleLogicalRange({ from, to: from + newSpan });
+		this._positionIndicator();
 	}
 
 	// region Announcements --------------------------------------------------------------

--- a/plugin-examples/src/plugins/accessibility/accessibility.ts
+++ b/plugin-examples/src/plugins/accessibility/accessibility.ts
@@ -1774,6 +1774,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		this._refreshActivePoints();
 		this._updatePaneLabel();
 		this._updateDescription();
+		this._renderShortcuts();
 		this._positionIndicator();
 	}
 

--- a/plugin-examples/src/plugins/accessibility/accessibility.ts
+++ b/plugin-examples/src/plugins/accessibility/accessibility.ts
@@ -22,11 +22,6 @@ type AnySeries = ISeriesApi<SeriesType, Time>;
  */
 type SeriesDataPoint = SeriesDataItemTypeMap<Time>[SeriesType];
 
-interface SeriesSnapshot {
-	series: AnySeries;
-	data: readonly SeriesDataPoint[];
-}
-
 interface PresentationRoleState {
 	count: number;
 	previousValue: string | null;
@@ -198,12 +193,58 @@ const defaultOptions: AccessibilityOptions = {
 	dataScope: 'visible',
 };
 
+/** Elements that can receive keyboard focus and so must be neutralised inside the hidden chart DOM. */
+const FOCUSABLE_SELECTOR =
+	'a[href],button,input,select,textarea,iframe,[tabindex],[contenteditable="true"],audio[controls],video[controls]';
+
 /** CSS applied to elements that should be available to assistive technology but invisible on screen. */
 const VISUALLY_HIDDEN =
 	'position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;border:0;';
 
 function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Writes messages to an `aria-live` element by clearing it and setting the text
+ * on the next animation frame. Re-setting textContent across a frame boundary
+ * forces assistive technology to re-announce even when the message is identical
+ * to the previous one (e.g. Home pressed twice, or two equal update summaries);
+ * a synchronous clear-and-set does not reliably do that.
+ */
+class LiveRegionWriter {
+	private readonly _region: () => HTMLElement | null;
+	private _frame: ReturnType<typeof requestAnimationFrame> | null = null;
+
+	public constructor(region: () => HTMLElement | null) {
+		this._region = region;
+	}
+
+	public write(message: string): void {
+		const region = this._region();
+		if (!region || message.length === 0) {
+			return;
+		}
+		region.textContent = '';
+		if (this._frame !== null) {
+			cancelAnimationFrame(this._frame);
+		}
+		this._frame = requestAnimationFrame(() => {
+			this._frame = null;
+			const target = this._region();
+			if (target) {
+				target.textContent = message;
+			}
+		});
+	}
+
+	/** Cancels a pending write (used at teardown). */
+	public dispose(): void {
+		if (this._frame !== null) {
+			cancelAnimationFrame(this._frame);
+			this._frame = null;
+		}
+	}
 }
 
 /**
@@ -242,11 +283,14 @@ function defaultTimeFormatter(time: Time, locale?: string): string {
 		date = new Date(Date.UTC(year, month - 1, day));
 	}
 	// `locale || undefined` guards against the empty-string locale used server-side,
-	// which is not a valid Intl locale.
+	// which is not a valid Intl locale. Formatting must be in UTC: the library
+	// renders the time axis in UTC, and the dates built above are UTC-midnight
+	// instants that would otherwise shift a day in timezones west of UTC.
 	return date.toLocaleDateString(locale || undefined, {
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',
+		timeZone: 'UTC',
 	});
 }
 
@@ -335,8 +379,8 @@ export interface AccessibilityMessages {
 	ohlcValues: (args: OhlcValueArgs) => string;
 	/** The `Enter` / `Space` summary. Bypassed entirely when {@link AccessibilityOptions.describeChart} is set. */
 	summary: (args: SummaryArgs) => string;
-	/** Summary when the active series has no valued points. */
-	noData: (args: { label: string }) => string;
+	/** Summary when the active series has no valued points in scope (`scopeNote` as in {@link summary}). */
+	noData: (args: { label: string; scopeNote: string }) => string;
 	/** One series' contribution to a data-update announcement. */
 	seriesUpdate: (args: { label: string; count: number; scopeNote: string; latest: string }) => string;
 	/** Wraps the per-series update summaries into one announcement (`total` >= 1). */
@@ -371,8 +415,8 @@ export const defaultMessages: AccessibilityMessages = {
 		multiSeries
 			? 'Use the left and right arrow keys to move between data points, and the up and down arrows to switch series.'
 			: 'Use the left and right arrow keys to move between data points.',
-	help: ({ multiSeries }): string =>
-		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up jumps ten points forward, Page Down ten points back. Home and End jump to the first and last points. Enter or Space reads a summary of the series.`,
+	help: ({ multiSeries, pageStep }): string =>
+		`Keyboard controls. Left and right arrows move between data points. ${multiSeries ? 'Up and down arrows switch between series. ' : ''}Page Up jumps ${pageStep} points forward, Page Down ${pageStep} points back. Home and End jump to the first and last points. Enter or Space reads a summary of the series.`,
 	// Most important information first: the value, then the date; the position
 	// counter is context, so it comes last.
 	point: ({ position, total, time, label, values }): string =>
@@ -395,7 +439,7 @@ export const defaultMessages: AccessibilityMessages = {
 	},
 	summary: ({ label, count, scopeNote, firstValue, firstTime, lastValue, lastTime, directionLabel, changeValue, percent, lowValue, lowTime, highValue, highTime }): string =>
 		`${label} with ${count} data points${scopeNote}. From ${firstValue} on ${firstTime} to ${lastValue} on ${lastTime}. Overall ${directionLabel} by ${changeValue}${percent !== null ? `, ${percent} percent` : ''}. Lowest ${lowValue} on ${lowTime}, highest ${highValue} on ${highTime}.`,
-	noData: ({ label }): string => `${label}: no data available.`,
+	noData: ({ label, scopeNote }): string => `${label}: no data available${scopeNote}.`,
 	seriesUpdate: ({ label, count, scopeNote, latest }): string =>
 		`${label}, ${count} data points${scopeNote}. Latest ${latest}`,
 	dataUpdated: ({ summaries, total, shownMax }): string => {
@@ -501,6 +545,8 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	private _statusRegion: HTMLElement | null = null;
 	private _descriptionRegion: HTMLElement | null = null;
 	private _focusIndicator: HTMLElement | null = null;
+	private _domObserver: MutationObserver | null = null;
+	private _requestUpdate: (() => void) | null = null;
 
 	// Restored on detach so we leave the host DOM exactly as we found it.
 	// Descendants of the pane element whose attributes we changed, paired with
@@ -510,8 +556,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	private _neutralised: [HTMLElement, string | null, string | null][] = [];
 
 	private _seriesList: AnySeries[] = [];
-	private _seriesData: SeriesSnapshot[] = [];
 	private _points: readonly SeriesDataPoint[] = [];
+	// Set when the active series changes while the pane is unfocused, so the
+	// (O(n)-copy) re-read of `_points` is deferred until the pane is used again.
+	private _activePointsStale = false;
 	private _activeSeriesIndex = 0;
 	private _activePointIndex = -1;
 	// One `subscribeDataChanged` handler per series, so we react to real data
@@ -519,8 +567,8 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	private _dataChangedHandlers = new Map<AnySeries, () => void>();
 	private _dirtySeries = new Set<AnySeries>();
 	private _announceUpdateHandle: ReturnType<typeof setTimeout> | null = null;
-	private _liveFrame: ReturnType<typeof requestAnimationFrame> | null = null;
-	private _pendingMessage: string | null = null;
+	private readonly _liveWriter = new LiveRegionWriter(() => this._liveRegion);
+	private readonly _statusWriter = new LiveRegionWriter(() => this._statusRegion);
 	// When attached via addAccessibilityPlugin, data-update announcements are
 	// routed through one shared region instead of this pane's own polite region.
 	private _updateAnnouncer: UpdateAnnouncer | null = null;
@@ -547,12 +595,15 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 
 	public attached(param: PaneAttachedParameter<Time>): void {
 		this._chart = param.chart;
+		this._requestUpdate = param.requestUpdate;
 		this._tryInit();
 	}
 
 	/**
-	 * A freshly created pane may not have its HTML element yet, so initialisation
-	 * is retried on subsequent animation frames until the element is available.
+	 * A freshly created pane may not have its HTML element yet. The pane widget
+	 * is built by the next redraw, so request one – the resulting updateAllViews
+	 * retries this init. The animation-frame fallback covers the window in which
+	 * the chart is still processing the invalidation.
 	 */
 	private _tryInit(): void {
 		if (this._built || !this._chart) {
@@ -561,6 +612,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		const paneElement = this._pane()?.getHTMLElement() ?? null;
 		const paneContent = paneElement ? this._paneContentElement(paneElement) : null;
 		if (!paneElement || !paneContent) {
+			this._requestUpdate?.();
 			if (this._initAttempts++ < 60) {
 				requestAnimationFrame(() => this._tryInit());
 			}
@@ -581,10 +633,8 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 			clearTimeout(this._announceUpdateHandle);
 			this._announceUpdateHandle = null;
 		}
-		if (this._liveFrame !== null) {
-			cancelAnimationFrame(this._liveFrame);
-			this._liveFrame = null;
-		}
+		this._liveWriter.dispose();
+		this._statusWriter.dispose();
 		this._unsubscribeAll();
 		// The announcer itself is owned and disposed by addAccessibilityPlugin;
 		// here we just drop our reference to it.
@@ -596,20 +646,23 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 			container.removeEventListener('focusout', this._handleFocusOut);
 			container.remove();
 		}
+		// Stop observing before restoring, so our own restores are not re-swept.
+		this._domObserver?.disconnect();
+		this._domObserver = null;
 		this._restorePresentationRoles();
 		this._restoreHiddenCanvases();
 		this._restoreFocusables();
 
 		this._chart = null;
+		this._requestUpdate = null;
 		this._container = null;
 		this._liveRegion = null;
 		this._statusRegion = null;
 		this._descriptionRegion = null;
 		this._focusIndicator = null;
-		this._pendingMessage = null;
 		this._seriesList = [];
-		this._seriesData = [];
 		this._points = [];
+		this._activePointsStale = false;
 		this._activePointIndex = -1;
 		this._activeSeriesIndex = 0;
 		this._built = false;
@@ -675,7 +728,16 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	// region Pane / series resolution ---------------------------------------------------
 
 	private _pane(): IPaneApi<Time> | null {
-		return this._chart?.panes()[this._options.paneIndex] ?? null;
+		const panes = this._chart?.panes() ?? [];
+		// Pane indices shift when panes are added or removed, so once our DOM is
+		// in place, identify the pane by the row that actually hosts our layer;
+		// the configured index is only the initial (pre-build) lookup. Built but
+		// hosted nowhere means our pane was removed – return null rather than
+		// silently re-binding to whatever pane holds the index now.
+		if (this._container) {
+			return panes.find(pane => pane.getHTMLElement()?.contains(this._container) ?? false) ?? null;
+		}
+		return panes[this._options.paneIndex] ?? null;
 	}
 
 	private _activeSeries(): AnySeries | null {
@@ -720,10 +782,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		// focusable descendant (e.g. the attribution link) out of the tab order –
 		// a focusable element inside an aria-hidden subtree is a WCAG failure.
 		const chartTable = paneElement.closest('table') ?? paneElement;
-		chartTable.querySelectorAll<HTMLElement>('canvas').forEach(element => {
-			retainAriaHidden(element);
-			this._hiddenCanvases.push(element);
-		});
+		this._hideCanvases(chartTable);
 		this._neutraliseFocusables(paneElement);
 
 		const semanticLayer = document.createElement('div');
@@ -790,6 +849,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		this._focusIndicator = focusIndicator;
 
 		this._applyLang();
+		this._watchForRecreatedElements(paneElement);
 	}
 
 	private _markTableStructurePresentational(paneElement: HTMLElement): void {
@@ -832,9 +892,14 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	}
 
 	private _neutraliseFocusables(root: HTMLElement): void {
-		const selector =
-			'a[href],button,input,select,textarea,iframe,[tabindex],[contenteditable="true"],audio[controls],video[controls]';
-		root.querySelectorAll<HTMLElement>(selector).forEach(element => {
+		const descendants = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+		const targets = root.matches(FOCUSABLE_SELECTOR) ? [root, ...descendants] : descendants;
+		for (const element of targets) {
+			// Idempotent: re-sweeps (from the mutation observer) must not record
+			// our own tabindex="-1" as the value to restore.
+			if (this._neutralised.some(([neutralised]) => neutralised === element)) {
+				continue;
+			}
 			this._neutralised.push([
 				element,
 				element.getAttribute('tabindex'),
@@ -842,7 +907,43 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 			]);
 			element.setAttribute('tabindex', '-1');
 			element.setAttribute('aria-hidden', 'true');
+		}
+	}
+
+	private _hideCanvases(root: HTMLElement): void {
+		const targets = root instanceof HTMLCanvasElement
+			? [root]
+			: Array.from(root.querySelectorAll<HTMLElement>('canvas'));
+		for (const element of targets) {
+			if (this._hiddenCanvases.includes(element)) {
+				continue;
+			}
+			retainAriaHidden(element);
+			this._hiddenCanvases.push(element);
+		}
+	}
+
+	/**
+	 * The library re-creates parts of the pane DOM after we attach – e.g. the
+	 * attribution link is rebuilt whenever the layout theme changes – which would
+	 * put a fresh focusable element back into the tab order inside our
+	 * presentational subtree, and fresh canvases back into the accessibility
+	 * tree. Watch this pane's row and re-apply the treatment to anything that
+	 * reappears.
+	 */
+	private _watchForRecreatedElements(paneElement: HTMLElement): void {
+		this._domObserver = new MutationObserver(mutations => {
+			for (const mutation of mutations) {
+				for (const node of Array.from(mutation.addedNodes)) {
+					if (!(node instanceof HTMLElement) || this._container?.contains(node)) {
+						continue;
+					}
+					this._neutraliseFocusables(node);
+					this._hideCanvases(node);
+				}
+			}
 		});
+		this._domObserver.observe(paneElement, { childList: true, subtree: true });
 	}
 
 	private _restoreFocusables(): void {
@@ -944,11 +1045,16 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 
 	private _handleFocusIn = (): void => {
 		this._hasFocus = true;
+		// Data may have streamed in while the pane was unfocused; catch up before
+		// anything reads the navigation cache.
+		if (this._activePointsStale) {
+			this._refreshActivePoints();
+		}
 		this._styleFocusOutline();
 		this._positionIndicator();
 		// Tell the shared announcer this pane is now the active one, so in the
 		// default 'active' mode its data updates are the ones that get announced.
-		this._updateAnnouncer?.setActivePane(this._options.paneIndex);
+		this._updateAnnouncer?.setActivePlugin(this);
 		// No live-region announcement on focus: the accessible name (aria-label) and
 		// the aria-describedby hint are spoken when focus lands. An assertive message
 		// here would interrupt the name (e.g. VoiceOver cuts off the title); the H key
@@ -1037,17 +1143,6 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 
 	// region Navigation -----------------------------------------------------------------
 
-	private _boundsForPoints(points: readonly SeriesDataPoint[]): { from: number; to: number } {
-		const last = points.length - 1;
-		if (this._options.dataScope === 'visible') {
-			const visible = this._visibleBounds(points);
-			if (visible) {
-				return visible;
-			}
-		}
-		return { from: 0, to: last };
-	}
-
 	/**
 	 * Logical index of a data point on the chart's shared time scale. A series'
 	 * own data indices need not match the scale (a series can start later or
@@ -1097,13 +1192,16 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		if (!range || last < 0) {
 			return null;
 		}
-		const from = clamp(this._lowerBoundByLogical(points, Math.ceil(range.from)), 0, last);
+		const from = this._lowerBoundByLogical(points, Math.ceil(range.from));
 		// Last point whose logical index is <= floor(range.to).
 		const to = this._lowerBoundByLogical(points, Math.floor(range.to) + 1) - 1;
-		if (to < from) {
+		// `from > last`: every point is left of the viewport; `to < from`: every
+		// point is right of it. Both mean nothing is visible – do not clamp the
+		// result into a fake one-point range.
+		if (from > last || to < from) {
 			return null;
 		}
-		return { from, to: clamp(to, 0, last) };
+		return { from, to };
 	}
 
 	private _movePoint(delta: number): void {
@@ -1220,25 +1318,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	// region Announcements --------------------------------------------------------------
 
 	private _announce(message: string): void {
-		if (!this._liveRegion) {
-			return;
-		}
-		// Clear now, then write on the next frame. Re-setting textContent across a
-		// frame boundary forces assistive technology to re-announce even when the
-		// message is identical to the previous one (e.g. Home pressed twice); a
-		// synchronous clear-and-set does not reliably do that.
-		this._liveRegion.textContent = '';
-		this._pendingMessage = message;
-		if (this._liveFrame !== null) {
-			cancelAnimationFrame(this._liveFrame);
-		}
-		this._liveFrame = requestAnimationFrame(() => {
-			this._liveFrame = null;
-			if (this._liveRegion && this._pendingMessage !== null) {
-				this._liveRegion.textContent = this._pendingMessage;
-				this._pendingMessage = null;
-			}
-		});
+		this._liveWriter.write(message);
 	}
 
 	private _formatValue(value: number | undefined, series: AnySeries | null = this._activeSeries()): string {
@@ -1320,8 +1400,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		if (this._options.dataScope !== 'visible') {
 			return points;
 		}
-		const bounds = this._boundsForPoints(points);
-		return points.slice(bounds.from, bounds.to + 1);
+		// A viewport scrolled fully past the data is an empty scope, not the
+		// whole series.
+		const bounds = this._visibleBounds(points);
+		return bounds ? points.slice(bounds.from, bounds.to + 1) : [];
 	}
 
 	private _describe(): string {
@@ -1332,7 +1414,7 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		}
 		const valued = scoped.filter(p => extractValue(p) !== undefined);
 		if (valued.length === 0) {
-			return this._messages.noData({ label });
+			return this._messages.noData({ label, scopeNote: this._scopeNote() });
 		}
 		const first = valued[0];
 		const last = valued[valued.length - 1];
@@ -1410,7 +1492,6 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		if (this._activeSeriesIndex >= this._seriesList.length) {
 			this._activeSeriesIndex = Math.max(0, this._seriesList.length - 1);
 		}
-		this._readAllData();
 		this._refreshActivePoints();
 		this._updatePaneLabel();
 		this._updateDescription();
@@ -1424,24 +1505,24 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		return current.every((series, index) => series === this._seriesList[index]);
 	}
 
-	private _readAllData(): void {
-		this._seriesData = this._seriesList.map(series => ({ series, data: series.data() }));
-	}
-
 	/**
 	 * Fired by the library when a series' data actually changes (set/update) – not
-	 * on scroll or zoom. Re-reads just that series and schedules a single debounced
-	 * polite announcement that coalesces simultaneous updates across series.
+	 * on scroll or zoom. Nothing is read or copied here: the active series'
+	 * navigation cache is refreshed only while the pane is in use, and update
+	 * announcements read the changed series once per debounced flush.
 	 */
 	private _handleSeriesDataChanged(series: AnySeries): void {
 		const index = this._seriesList.indexOf(series);
 		if (index < 0) {
 			return;
 		}
-		this._seriesData[index] = { series, data: series.data() };
 		if (index === this._activeSeriesIndex) {
-			this._refreshActivePoints();
-			this._positionIndicator();
+			if (this._hasFocus) {
+				this._refreshActivePoints();
+				this._positionIndicator();
+			} else {
+				this._activePointsStale = true;
+			}
 		}
 		if (this._options.announceDataUpdates) {
 			this._dirtySeries.add(series);
@@ -1466,15 +1547,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 	}
 
 	private _flushUpdateAnnouncement(): void {
-		const region = this._statusRegion;
-		if (!region) {
-			this._dirtySeries.clear();
-			return;
-		}
+		// _collectPendingUpdateSummaries always clears the dirty set; the writer
+		// no-ops when the region is gone or the message is empty.
 		const message = formatUpdateMessage(this._collectPendingUpdateSummaries(), this._messages);
-		if (message.length > 0) {
-			region.textContent = message;
-		}
+		this._statusWriter.write(message);
 	}
 
 	/**
@@ -1488,9 +1564,10 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 			this._dirtySeries.clear();
 			return [];
 		}
-		const changed = this._seriesData.filter(snapshot => this._dirtySeries.has(snapshot.series));
+		// Iterate _seriesList so the summaries keep the pane's series order.
+		const changed = this._seriesList.filter(series => this._dirtySeries.has(series));
 		this._dirtySeries.clear();
-		return changed.map(snapshot => this._seriesUpdateSummary(snapshot));
+		return changed.map(series => this._seriesUpdateSummary(series));
 	}
 
 	private _unsubscribeAll(): void {
@@ -1501,23 +1578,30 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 		this._dirtySeries.clear();
 	}
 
+	/** Re-reads the active series' data into the navigation cache. */
 	private _refreshActivePoints(): void {
-		const snapshot = this._seriesData[this._activeSeriesIndex];
-		this._points = snapshot ? snapshot.data : [];
+		const series = this._activeSeries();
+		this._points = series ? series.data() : [];
+		this._activePointsStale = false;
 		if (this._activePointIndex >= this._points.length) {
 			this._activePointIndex = this._points.length - 1;
 		}
 	}
 
-	private _seriesUpdateSummary(snapshot: SeriesSnapshot): string {
-		const scoped = this._scopedPoints(snapshot.data);
-		const value = extractValue(scoped[scoped.length - 1]);
-		const index = this._seriesData.indexOf(snapshot);
+	private _seriesUpdateSummary(series: AnySeries): string {
+		const data = series.data();
+		const scoped = this._scopedPoints(data);
+		// 'Latest' reports the newest bar – the one the update actually changed –
+		// which can sit outside the visible range; only the count is scoped.
+		let value: number | undefined;
+		for (let i = data.length - 1; i >= 0 && value === undefined; i--) {
+			value = extractValue(data[i]);
+		}
 		return this._messages.seriesUpdate({
-			label: this._seriesLabel(snapshot.series, index),
+			label: this._seriesLabel(series, this._seriesList.indexOf(series)),
 			count: scoped.length,
 			scopeNote: this._scopeNote(),
-			latest: this._formatValue(value, snapshot.series),
+			latest: this._formatValue(value, series),
 		});
 	}
 
@@ -1525,18 +1609,23 @@ export class AccessibilityPlugin implements IPanePrimitive<Time> {
 
 	private _positionIndicator(): void {
 		const indicator = this._focusIndicator;
+		if (!indicator) {
+			return;
+		}
 		const chart = this._chart;
 		const series = this._activeSeries();
-		if (!indicator || !chart || !series) {
-			return;
-		}
-		if (!this._options.showFocusIndicator || !this._hasFocus || this._activePointIndex < 0) {
-			indicator.style.display = 'none';
-			return;
-		}
 		const point = this._points[this._activePointIndex];
 		const value = extractValue(point);
-		if (!point || value === undefined) {
+		// Hide on any missing prerequisite – including "all series were removed"
+		// – so the ring never lingers at stale coordinates.
+		if (
+			!chart ||
+			!series ||
+			!point ||
+			value === undefined ||
+			!this._options.showFocusIndicator ||
+			!this._hasFocus
+		) {
 			indicator.style.display = 'none';
 			return;
 		}
@@ -1576,8 +1665,10 @@ class UpdateAnnouncer {
 	private readonly _plugins: AccessibilityPlugin[] = [];
 	private readonly _dirty = new Set<AccessibilityPlugin>();
 	private _handle: ReturnType<typeof setTimeout> | null = null;
-	private _frame: ReturnType<typeof requestAnimationFrame> | null = null;
-	private _activePaneIndex = 0;
+	private readonly _writer = new LiveRegionWriter(() => this._region);
+	// The plugin whose pane was focused last. Tracked by identity, not by pane
+	// index – indices shift when panes are added or removed.
+	private _activePlugin: AccessibilityPlugin | null = null;
 	private _messages: AccessibilityMessages;
 
 	public constructor(host: HTMLElement, mode: UpdateAnnouncerMode, messages: AccessibilityMessages, lang?: string) {
@@ -1600,8 +1691,8 @@ class UpdateAnnouncer {
 		this._plugins.push(plugin);
 	}
 
-	public setActivePane(paneIndex: number): void {
-		this._activePaneIndex = paneIndex;
+	public setActivePlugin(plugin: AccessibilityPlugin): void {
+		this._activePlugin = plugin;
 	}
 
 	/** Reconfigures the shared region at runtime (mode / messages / lang). */
@@ -1634,18 +1725,18 @@ class UpdateAnnouncer {
 			clearTimeout(this._handle);
 			this._handle = null;
 		}
-		if (this._frame !== null) {
-			cancelAnimationFrame(this._frame);
-			this._frame = null;
-		}
+		this._writer.dispose();
 		this._region?.remove();
 		this._region = null;
 		this._plugins.length = 0;
 		this._dirty.clear();
+		this._activePlugin = null;
 	}
 
 	private _flush(): void {
 		const summaries: string[] = [];
+		// Nothing focused yet falls back to the first registered pane (pane 0).
+		const active = this._activePlugin ?? this._plugins[0];
 		// Iterate in registration (pane) order so the combined message is stable.
 		for (const plugin of this._plugins) {
 			if (!this._dirty.has(plugin)) {
@@ -1654,31 +1745,12 @@ class UpdateAnnouncer {
 			// Always collect (and clear) the plugin's pending summaries; keep them
 			// only when combining or when this is the active pane.
 			const pending = pluginLinks.get(plugin)?.collectPendingUpdateSummaries() ?? [];
-			if (this._mode === 'combine' || plugin.options().paneIndex === this._activePaneIndex) {
+			if (this._mode === 'combine' || plugin === active) {
 				summaries.push(...pending);
 			}
 		}
 		this._dirty.clear();
-		this._write(formatUpdateMessage(summaries, this._messages));
-	}
-
-	private _write(message: string): void {
-		const region = this._region;
-		if (!region || message.length === 0) {
-			return;
-		}
-		// Clear then set on the next frame so identical consecutive messages are
-		// still re-announced (mirrors AccessibilityPlugin._announce).
-		region.textContent = '';
-		if (this._frame !== null) {
-			cancelAnimationFrame(this._frame);
-		}
-		this._frame = requestAnimationFrame(() => {
-			this._frame = null;
-			if (this._region) {
-				this._region.textContent = message;
-			}
-		});
+		this._writer.write(formatUpdateMessage(summaries, this._messages));
 	}
 }
 

--- a/plugin-examples/src/plugins/accessibility/example/example.es.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.es.ts
@@ -35,7 +35,19 @@ const esMessages: PartialAccessibilityMessages = {
 			? 'Use las flechas izquierda y derecha para moverse entre los puntos de datos, y las flechas arriba y abajo para cambiar de serie.'
 			: 'Use las flechas izquierda y derecha para moverse entre los puntos de datos.',
 	help: ({ multiSeries, pageStep }) =>
-		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág salta ${pageStep} puntos adelante, Av Pág ${pageStep} puntos atrás. Inicio y Fin saltan al primer y al último punto. Intro o Espacio lee un resumen de la serie.`,
+		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág salta ${pageStep} puntos adelante, Av Pág ${pageStep} puntos atrás. Inicio y Fin saltan al primer y al último punto. Más y menos acercan y alejan el gráfico. Intro o Espacio lee un resumen de la serie.`,
+	shortcutsHint: 'Pulse H para ver los atajos de teclado',
+	shortcutsTitle: 'Atajos de teclado',
+	shortcuts: ({ multiSeries, pageStep }) => [
+		{ keys: '← / →', action: 'Moverse entre los puntos de datos' },
+		...(multiSeries ? [{ keys: '↑ / ↓', action: 'Cambiar de serie' }] : []),
+		{ keys: 'Re Pág / Av Pág', action: `Saltar ${pageStep} puntos` },
+		{ keys: 'Inicio / Fin', action: 'Primer / último punto' },
+		{ keys: '+ / −', action: 'Acercar / alejar' },
+		// Intro / Espacio (el resumen hablado) se omite: no tiene efecto visible.
+		{ keys: 'H', action: 'Mostrar u ocultar este panel' },
+		{ keys: 'Esc', action: 'Cerrar este panel' },
+	],
 	point: ({ position, total, time, label, values }) =>
 		`${label} ${values}, ${time}. Punto ${position} de ${total}.`,
 	seriesPosition: ({ label, position, total, point }) =>
@@ -116,6 +128,8 @@ const accessibility = addAccessibilityPlugin(chart, {
 	chartTitle: paneIndex => paneIndex === 0 ? 'Gráfico de precios' : 'Gráfico de volumen',
 	messages: esMessages,
 	lang: 'es',
+	// Show the (translated) visible shortcuts overlay; focus the chart and press H.
+	showShortcuts: true,
 });
 
 document.querySelector('#focus-button')?.addEventListener('click', () => {

--- a/plugin-examples/src/plugins/accessibility/example/example.es.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.es.ts
@@ -46,7 +46,6 @@ const esMessages: PartialAccessibilityMessages = {
 		{ keys: '+ / −', action: 'Acercar / alejar' },
 		// Intro / Espacio (el resumen hablado) se omite: no tiene efecto visible.
 		{ keys: 'H', action: 'Mostrar u ocultar este panel' },
-		{ keys: 'Esc', action: 'Cerrar este panel' },
 	],
 	point: ({ position, total, time, label, values }) =>
 		`${label} ${values}, ${time}. Punto ${position} de ${total}.`,

--- a/plugin-examples/src/plugins/accessibility/example/example.es.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.es.ts
@@ -35,9 +35,9 @@ const esMessages: PartialAccessibilityMessages = {
 			? 'Use las flechas izquierda y derecha para moverse entre los puntos de datos, y las flechas arriba y abajo para cambiar de serie.'
 			: 'Use las flechas izquierda y derecha para moverse entre los puntos de datos.',
 	help: ({ multiSeries }) =>
-		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág y Av Pág saltan diez puntos. Inicio y Fin saltan al primer y al último punto. Intro o Espacio lee un resumen de la serie.`,
+		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág salta diez puntos adelante, Av Pág diez puntos atrás. Inicio y Fin saltan al primer y al último punto. Intro o Espacio lee un resumen de la serie.`,
 	point: ({ position, total, time, label, values }) =>
-		`Punto ${position} de ${total}. ${time}, ${label} ${values}.`,
+		`${label} ${values}, ${time}. Punto ${position} de ${total}.`,
 	seriesPosition: ({ label, position, total, point }) =>
 		`${label}, serie ${position} de ${total}.${point}`,
 	summary: ({ label, count, scopeNote, firstValue, firstTime, lastValue, lastTime, directionLabel, changeValue, percent, lowValue, lowTime, highValue, highTime }) =>
@@ -57,7 +57,7 @@ const esMessages: PartialAccessibilityMessages = {
 	},
 };
 
-const chart = ((window as unknown as any).chart = createChart('chart', {
+const chart = createChart('chart', {
 	autoSize: true,
 	timeScale: {
 		rightOffset: 10,
@@ -72,7 +72,7 @@ const chart = ((window as unknown as any).chart = createChart('chart', {
 		priceFormatter: (price: number) =>
 			new Intl.NumberFormat('es', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(price),
 	},
-}));
+});
 
 // --- Panel 0: dos series de precio (arriba/abajo cambia entre ellas) ---
 const priceSeries = chart.addSeries(AreaSeries, {
@@ -90,7 +90,17 @@ const averageSeries = chart.addSeries(LineSeries, {
 	lineWidth: 2,
 	title: 'Media móvil',
 });
-const averageData = generateLineData();
+// Una media móvil real de la serie de precios: empieza más tarde, así que las
+// dos series no comparten todas las marcas de tiempo (al cambiar de serie se
+// mantiene el *tiempo* enfocado seleccionando el punto más cercano).
+const averagePeriod = 20;
+const averageData = priceData.slice(averagePeriod - 1).map((point, index) => {
+	let sum = 0;
+	for (let i = index; i < index + averagePeriod; i++) {
+		sum += priceData[i].value;
+	}
+	return { time: point.time, value: sum / averagePeriod };
+});
 averageSeries.setData(averageData);
 
 // --- Panel 1: una serie de volumen en su propio panel ---

--- a/plugin-examples/src/plugins/accessibility/example/example.es.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.es.ts
@@ -1,0 +1,160 @@
+import {
+	AreaSeries,
+	HistogramSeries,
+	LineSeries,
+	Time,
+	createChart,
+} from 'lightweight-charts';
+import { generateLineData } from '../../../sample-data';
+import {
+	PartialAccessibilityMessages,
+	addAccessibilityPlugin,
+} from '../accessibility';
+
+// Spanish translation of the announced strings. Only the wording lives here –
+// numbers and dates are localised by the chart's `localization.locale` below.
+// (Illustrative translations for the demo.)
+const esMessages: PartialAccessibilityMessages = {
+	roleDescription: 'Panel de gráfico interactivo',
+	noValue: 'sin valor',
+	inView: 'en vista',
+	ohlc: { open: 'apertura', high: 'máximo', low: 'mínimo', close: 'cierre' },
+	directions: { up: 'sube', down: 'baja', unchanged: 'sin cambios' },
+	defaultSeriesLabel: position => `Serie ${position}`,
+	paneLabel: ({ title, seriesCount, seriesLabel }) => {
+		const seriesPart =
+			seriesCount > 1
+				? `${seriesCount} series. `
+				: seriesLabel
+					? `${seriesLabel}. `
+					: '';
+		return `${title}. ${seriesPart}Pulse H para ver la ayuda de teclado.`;
+	},
+	description: ({ multiSeries }) =>
+		multiSeries
+			? 'Use las flechas izquierda y derecha para moverse entre los puntos de datos, y las flechas arriba y abajo para cambiar de serie.'
+			: 'Use las flechas izquierda y derecha para moverse entre los puntos de datos.',
+	help: ({ multiSeries }) =>
+		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág y Av Pág saltan diez puntos. Inicio y Fin saltan al primer y al último punto. Intro o Espacio lee un resumen de la serie.`,
+	point: ({ position, total, time, label, values }) =>
+		`Punto ${position} de ${total}. ${time}, ${label} ${values}.`,
+	seriesPosition: ({ label, position, total, point }) =>
+		`${label}, serie ${position} de ${total}.${point}`,
+	summary: ({ label, count, scopeNote, firstValue, firstTime, lastValue, lastTime, directionLabel, changeValue, percent, lowValue, lowTime, highValue, highTime }) =>
+		`${label} con ${count} puntos de datos${scopeNote}. Desde ${firstValue} el ${firstTime} hasta ${lastValue} el ${lastTime}. En conjunto ${directionLabel} ${changeValue}${percent !== null ? `, ${percent} por ciento` : ''}. Mínimo ${lowValue} el ${lowTime}, máximo ${highValue} el ${highTime}.`,
+	noData: ({ label }) => `${label}: no hay datos disponibles.`,
+	seriesUpdate: ({ label, count, scopeNote, latest }) =>
+		`${label}, ${count} puntos de datos${scopeNote}. Último ${latest}`,
+	dataUpdated: ({ summaries, total, shownMax }) => {
+		if (total === 1) {
+			return `Datos del gráfico actualizados. ${summaries[0]}.`;
+		}
+		const shown = summaries.slice(0, shownMax);
+		const remaining = total > shown.length
+			? ` ${total - shown.length} series más cambiaron.`
+			: '';
+		return `Datos del gráfico actualizados. ${total} series cambiaron. ${shown.join(' ')}.${remaining}`;
+	},
+};
+
+const chart = ((window as unknown as any).chart = createChart('chart', {
+	autoSize: true,
+	timeScale: {
+		rightOffset: 10,
+		barSpacing: 8,
+	},
+	// Drives the localised dates and the percent's decimal separator in the
+	// announcements (and the plugin's default `lang`). The price formatter makes
+	// the spoken values Spanish too — the plugin reads it automatically, so an
+	// already-localised chart gets localised announcements for free.
+	localization: {
+		locale: 'es',
+		priceFormatter: (price: number) =>
+			new Intl.NumberFormat('es', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(price),
+	},
+}));
+
+// --- Panel 0: dos series de precio (arriba/abajo cambia entre ellas) ---
+const priceSeries = chart.addSeries(AreaSeries, {
+	lineColor: 'rgb(41, 98, 255)',
+	topColor: 'rgba(41, 98, 255, 0.4)',
+	bottomColor: 'rgba(41, 98, 255, 0)',
+	lineWidth: 2,
+	title: 'Precio',
+});
+const priceData = generateLineData();
+priceSeries.setData(priceData);
+
+const averageSeries = chart.addSeries(LineSeries, {
+	color: 'rgb(225, 87, 90)',
+	lineWidth: 2,
+	title: 'Media móvil',
+});
+const averageData = generateLineData();
+averageSeries.setData(averageData);
+
+// --- Panel 1: una serie de volumen en su propio panel ---
+const volumeSeries = chart.addSeries(
+	HistogramSeries,
+	{ color: 'rgb(38, 166, 154)', title: 'Volumen' },
+	1 // paneIndex – crea un segundo panel
+);
+volumeSeries.setData(
+	priceData.map(point => ({ time: point.time, value: point.value * 10 }))
+);
+
+// Una sola llamada a nivel de gráfico: cada panel se anuncia en español.
+const accessibility = addAccessibilityPlugin(chart, {
+	chartTitle: paneIndex => paneIndex === 0 ? 'Gráfico de precios' : 'Gráfico de volumen',
+	messages: esMessages,
+	lang: 'es',
+});
+
+document.querySelector('#focus-button')?.addEventListener('click', () => {
+	accessibility.focus(0);
+});
+
+// --- Actualizaciones de datos en vivo ------------------------------------
+const ONE_DAY = 24 * 60 * 60;
+let lastTime = priceData[priceData.length - 1].time as number;
+let lastPrice = priceData[priceData.length - 1].value;
+let lastAverage = averageData[averageData.length - 1].value;
+let liveTimer: number | undefined;
+
+function streamNextPoint(): void {
+	lastTime += ONE_DAY;
+	lastPrice = Math.max(1, lastPrice + (Math.random() - 0.5) * 20);
+	lastAverage += (lastPrice - lastAverage) * 0.1;
+	const time = lastTime as Time;
+	priceSeries.update({ time, value: lastPrice });
+	averageSeries.update({ time, value: lastAverage });
+	volumeSeries.update({ time, value: lastPrice * 10 });
+}
+
+const liveButton = document.querySelector('#live-button');
+liveButton?.addEventListener('click', () => {
+	if (liveTimer === undefined) {
+		liveTimer = window.setInterval(streamNextPoint, 3000);
+		liveButton.textContent = 'Detener actualizaciones en vivo';
+	} else {
+		window.clearInterval(liveTimer);
+		liveTimer = undefined;
+		liveButton.textContent = 'Iniciar actualizaciones en vivo';
+	}
+});
+
+// Cambia si los resúmenes describen el rango visible o todos los datos.
+let visibleScope = true;
+const scopeButton = document.querySelector('#scope-button');
+scopeButton?.addEventListener('click', () => {
+	visibleScope = !visibleScope;
+	const dataScope = visibleScope ? 'visible' : 'all';
+	for (const plugin of accessibility.plugins) {
+		plugin.applyOptions({ dataScope });
+	}
+	if (scopeButton) {
+		scopeButton.textContent = visibleScope
+			? 'Anunciar: rango visible'
+			: 'Anunciar: todos los datos';
+	}
+});

--- a/plugin-examples/src/plugins/accessibility/example/example.es.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.es.ts
@@ -34,15 +34,15 @@ const esMessages: PartialAccessibilityMessages = {
 		multiSeries
 			? 'Use las flechas izquierda y derecha para moverse entre los puntos de datos, y las flechas arriba y abajo para cambiar de serie.'
 			: 'Use las flechas izquierda y derecha para moverse entre los puntos de datos.',
-	help: ({ multiSeries }) =>
-		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág salta diez puntos adelante, Av Pág diez puntos atrás. Inicio y Fin saltan al primer y al último punto. Intro o Espacio lee un resumen de la serie.`,
+	help: ({ multiSeries, pageStep }) =>
+		`Controles de teclado. Las flechas izquierda y derecha se mueven entre los puntos de datos. ${multiSeries ? 'Las flechas arriba y abajo cambian de serie. ' : ''}Re Pág salta ${pageStep} puntos adelante, Av Pág ${pageStep} puntos atrás. Inicio y Fin saltan al primer y al último punto. Intro o Espacio lee un resumen de la serie.`,
 	point: ({ position, total, time, label, values }) =>
 		`${label} ${values}, ${time}. Punto ${position} de ${total}.`,
 	seriesPosition: ({ label, position, total, point }) =>
 		`${label}, serie ${position} de ${total}.${point}`,
 	summary: ({ label, count, scopeNote, firstValue, firstTime, lastValue, lastTime, directionLabel, changeValue, percent, lowValue, lowTime, highValue, highTime }) =>
 		`${label} con ${count} puntos de datos${scopeNote}. Desde ${firstValue} el ${firstTime} hasta ${lastValue} el ${lastTime}. En conjunto ${directionLabel} ${changeValue}${percent !== null ? `, ${percent} por ciento` : ''}. Mínimo ${lowValue} el ${lowTime}, máximo ${highValue} el ${highTime}.`,
-	noData: ({ label }) => `${label}: no hay datos disponibles.`,
+	noData: ({ label, scopeNote }) => `${label}: no hay datos disponibles${scopeNote}.`,
 	seriesUpdate: ({ label, count, scopeNote, latest }) =>
 		`${label}, ${count} puntos de datos${scopeNote}. Último ${latest}`,
 	dataUpdated: ({ summaries, total, shownMax }) => {
@@ -90,9 +90,7 @@ const averageSeries = chart.addSeries(LineSeries, {
 	lineWidth: 2,
 	title: 'Media móvil',
 });
-// Una media móvil real de la serie de precios: empieza más tarde, así que las
-// dos series no comparten todas las marcas de tiempo (al cambiar de serie se
-// mantiene el *tiempo* enfocado seleccionando el punto más cercano).
+
 const averagePeriod = 20;
 const averageData = priceData.slice(averagePeriod - 1).map((point, index) => {
 	let sum = 0;

--- a/plugin-examples/src/plugins/accessibility/example/example.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.ts
@@ -2,6 +2,7 @@ import {
 	AreaSeries,
 	HistogramSeries,
 	LineSeries,
+	LineWidth,
 	Time,
 	createChart,
 } from 'lightweight-charts';
@@ -53,13 +54,66 @@ volumeSeries.setData(
 	priceData.map(point => ({ time: point.time, value: point.value * 10 }))
 );
 
-// One chart-level call: each pane becomes its own accessible region.
+// Restyles the chart's own series / grid / text for high contrast. The plugin
+// only restyles its own overlay; it tells us via onHighContrastChange so we can
+// match the chart itself (as the Readability tutorial describes).
+function applyChartContrast(highContrast: boolean): void {
+	chart.applyOptions({
+		layout: { textColor: highContrast ? '#000000' : '#222222' },
+		grid: {
+			vertLines: { color: highContrast ? '#5b5b5b' : '#e6e9ec' },
+			horzLines: { color: highContrast ? '#5b5b5b' : '#e6e9ec' },
+		},
+	});
+	priceSeries.applyOptions({
+		lineColor: highContrast ? '#0033cc' : 'rgb(41, 98, 255)',
+		lineWidth: (highContrast ? 4 : 2) as LineWidth,
+		topColor: highContrast ? 'rgba(0, 51, 204, 0.5)' : 'rgba(41, 98, 255, 0.4)',
+		bottomColor: highContrast ? 'rgba(0, 51, 204, 0)' : 'rgba(41, 98, 255, 0)',
+	});
+	averageSeries.applyOptions({
+		color: highContrast ? '#a3000e' : 'rgb(225, 87, 90)',
+		lineWidth: (highContrast ? 4 : 2) as LineWidth,
+	});
+	volumeSeries.applyOptions({ color: highContrast ? '#00524a' : 'rgb(38, 166, 154)' });
+}
+
+// One chart-level call: each pane becomes its own accessible region. The visible
+// shortcuts overlay (showShortcuts) and high-contrast handling help sighted
+// keyboard users and low-vision users who do not use a screen reader.
+let highContrast = false;
+const contrastButton = document.querySelector('#contrast-button');
 const accessibility = addAccessibilityPlugin(chart, {
 	chartTitle: paneIndex => paneIndex === 0 ? 'Sample price chart' : 'Sample volume chart',
+	showShortcuts: true,
+	// highContrast defaults to 'auto' (follows the OS); the button below overrides it.
+	onHighContrastChange: enabled => {
+		highContrast = enabled;
+		applyChartContrast(enabled);
+		if (contrastButton) {
+			contrastButton.textContent = enabled ? 'Disable high contrast' : 'Enable high contrast';
+		}
+	},
 });
 
 document.querySelector('#focus-button')?.addEventListener('click', () => {
 	accessibility.focus(0);
+});
+
+contrastButton?.addEventListener('click', () => {
+	accessibility.applyOptions({ highContrast: !highContrast });
+});
+
+// Larger chart text – the chart's own font is the developer's responsibility (the
+// plugin's overlay already scales with the page font). See the Readability tutorial.
+let largeFont = false;
+const fontButton = document.querySelector('#font-button');
+fontButton?.addEventListener('click', () => {
+	largeFont = !largeFont;
+	chart.applyOptions({ layout: { fontSize: largeFont ? 16 : 12 } });
+	if (fontButton) {
+		fontButton.textContent = largeFont ? 'Normal font' : 'Large font';
+	}
 });
 
 // --- Live data updates ---------------------------------------------------

--- a/plugin-examples/src/plugins/accessibility/example/example.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.ts
@@ -1,0 +1,105 @@
+import {
+	AreaSeries,
+	HistogramSeries,
+	LineSeries,
+	Time,
+	createChart,
+} from 'lightweight-charts';
+import { generateLineData } from '../../../sample-data';
+import { addAccessibilityPlugin } from '../accessibility';
+
+const chart = ((window as unknown as any).chart = createChart('chart', {
+	autoSize: true,
+	timeScale: {
+		rightOffset: 10,
+		barSpacing: 8,
+	},
+}));
+
+// --- Pane 0: two price series (so Up/Down can switch between them) ---
+const priceSeries = chart.addSeries(AreaSeries, {
+	lineColor: 'rgb(41, 98, 255)',
+	topColor: 'rgba(41, 98, 255, 0.4)',
+	bottomColor: 'rgba(41, 98, 255, 0)',
+	lineWidth: 2,
+	title: 'Price',
+});
+const priceData = generateLineData();
+priceSeries.setData(priceData);
+
+const averageSeries = chart.addSeries(LineSeries, {
+	color: 'rgb(225, 87, 90)',
+	lineWidth: 2,
+	title: 'Moving average',
+});
+const averageData = generateLineData();
+averageSeries.setData(averageData);
+
+// --- Pane 1: a volume series in its own pane ---
+const volumeSeries = chart.addSeries(
+	HistogramSeries,
+	{ color: 'rgb(38, 166, 154)', title: 'Volume' },
+	1 // paneIndex – creates a second pane
+);
+volumeSeries.setData(
+	priceData.map(point => ({ time: point.time, value: point.value * 10 }))
+);
+
+// One chart-level call: each pane becomes its own accessible region.
+const accessibility = addAccessibilityPlugin(chart, {
+	chartTitle: paneIndex => paneIndex === 0 ? 'Sample price chart' : 'Sample volume chart',
+});
+
+document.querySelector('#focus-button')?.addEventListener('click', () => {
+	accessibility.focus(0);
+});
+
+// --- Live data updates ---------------------------------------------------
+// Stream a new bar into every series on an interval, exactly like a real-time
+// feed. Each `series.update()` triggers the plugin, which announces the change
+// through a polite aria-live region (by default, only the active pane).
+const ONE_DAY = 24 * 60 * 60;
+let lastTime = priceData[priceData.length - 1].time as number;
+let lastPrice = priceData[priceData.length - 1].value;
+let lastAverage = averageData[averageData.length - 1].value;
+let liveTimer: number | undefined;
+
+function streamNextPoint(): void {
+	lastTime += ONE_DAY;
+	// A small random walk so the updates are visibly "live".
+	lastPrice = Math.max(1, lastPrice + (Math.random() - 0.5) * 20);
+	lastAverage += (lastPrice - lastAverage) * 0.1;
+	const time = lastTime as Time;
+	priceSeries.update({ time, value: lastPrice });
+	averageSeries.update({ time, value: lastAverage });
+	volumeSeries.update({ time, value: lastPrice * 10 });
+}
+
+const liveButton = document.querySelector('#live-button');
+liveButton?.addEventListener('click', () => {
+	if (liveTimer === undefined) {
+		liveTimer = window.setInterval(streamNextPoint, 3000);
+		liveButton.textContent = 'Stop live updates';
+	} else {
+		window.clearInterval(liveTimer);
+		liveTimer = undefined;
+		liveButton.textContent = 'Start live updates';
+	}
+});
+
+// Toggle whether announcements describe the default visible range or the whole
+// data set.
+let visibleScope = true;
+const scopeButton = document.querySelector('#scope-button');
+scopeButton?.addEventListener('click', () => {
+	visibleScope = !visibleScope;
+	const dataScope = visibleScope ? 'visible' : 'all';
+	for (const plugin of accessibility.plugins) {
+		plugin.applyOptions({ dataScope });
+	}
+	if (scopeButton) {
+		scopeButton.textContent = visibleScope
+			? 'Announce: visible range'
+			: 'Announce: all data';
+	}
+});

--- a/plugin-examples/src/plugins/accessibility/example/example.ts
+++ b/plugin-examples/src/plugins/accessibility/example/example.ts
@@ -8,13 +8,13 @@ import {
 import { generateLineData } from '../../../sample-data';
 import { addAccessibilityPlugin } from '../accessibility';
 
-const chart = ((window as unknown as any).chart = createChart('chart', {
+const chart = createChart('chart', {
 	autoSize: true,
 	timeScale: {
 		rightOffset: 10,
 		barSpacing: 8,
 	},
-}));
+});
 
 // --- Pane 0: two price series (so Up/Down can switch between them) ---
 const priceSeries = chart.addSeries(AreaSeries, {
@@ -32,7 +32,15 @@ const averageSeries = chart.addSeries(LineSeries, {
 	lineWidth: 2,
 	title: 'Moving average',
 });
-const averageData = generateLineData();
+
+const averagePeriod = 20;
+const averageData = priceData.slice(averagePeriod - 1).map((point, index) => {
+	let sum = 0;
+	for (let i = index; i < index + averagePeriod; i++) {
+		sum += priceData[i].value;
+	}
+	return { time: point.time, value: sum / averagePeriod };
+});
 averageSeries.setData(averageData);
 
 // --- Pane 1: a volume series in its own pane ---

--- a/plugin-examples/src/plugins/accessibility/example/index.es.html
+++ b/plugin-examples/src/plugins/accessibility/example/index.es.html
@@ -55,6 +55,7 @@
 				<li><kbd>↑</kbd> / <kbd>↓</kbd> — cambiar entre las series del panel</li>
 				<li><kbd>Re Pág</kbd> / <kbd>Av Pág</kbd> — saltar diez puntos</li>
 				<li><kbd>Inicio</kbd> / <kbd>Fin</kbd> — primer / último punto</li>
+				<li><kbd>+</kbd> / <kbd>−</kbd> — acercar / alejar el gráfico</li>
 				<li><kbd>Intro</kbd> / <kbd>Espacio</kbd> — leer un resumen de la serie</li>
 				<li><kbd>H</kbd> — enumerar los controles de teclado</li>
 			</ul>

--- a/plugin-examples/src/plugins/accessibility/example/index.es.html
+++ b/plugin-examples/src/plugins/accessibility/example/index.es.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="es">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Lightweight Charts - Complemento de accesibilidad: demostración de traducción</title>
+		<link href="../../../examples-base.css" rel="stylesheet" />
+		<style>
+			#chart {
+				height: 450px;
+				position: relative;
+			}
+			/*
+			 * The shared examples stylesheet resets buttons with `all: initial`,
+			 * which also removes their default focus ring.
+			 */
+			#buttons button:focus-visible {
+				outline: 3px solid #2962ff;
+				outline-offset: 2px;
+			}
+			#buttons {
+				display: flex;
+				gap: 10px;
+				margin-top: 10px;
+				margin-bottom: 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="buttons" class="column">
+			<button id="focus-button">Enfocar el gráfico</button>
+			<button id="live-button">Iniciar actualizaciones en vivo</button>
+			<button id="scope-button">Anunciar: rango visible</button>
+		</div>
+		<div id="chart"></div>
+		<div id="description">
+			<h1>Complemento de accesibilidad: demostración de traducción</h1>
+			<p>
+				Esta página existe únicamente para demostrar que los anuncios del
+				complemento de accesibilidad son <strong>totalmente traducibles</strong>.
+				Es exactamente el mismo ejemplo que la versión en inglés; lo único que
+				cambia es que el complemento recibe un paquete de mensajes en español
+				(<code>messages</code>), <code>lang: 'es'</code> y
+				<code>localization.locale: 'es'</code>, de modo que el lector de pantalla
+				anuncia todo en español y las fechas y los números siguen la
+				configuración regional española. Las traducciones que se muestran aquí
+				son solo ilustrativas.
+			</p>
+			<p>
+				Pulse <kbd>Tab</kbd> para moverse entre los paneles (o haga clic en
+				<strong>Enfocar el gráfico</strong>) y luego use el teclado:
+			</p>
+			<ul>
+				<li><kbd>←</kbd> / <kbd>→</kbd> — moverse entre los puntos de datos</li>
+				<li><kbd>↑</kbd> / <kbd>↓</kbd> — cambiar entre las series del panel</li>
+				<li><kbd>Re Pág</kbd> / <kbd>Av Pág</kbd> — saltar diez puntos</li>
+				<li><kbd>Inicio</kbd> / <kbd>Fin</kbd> — primer / último punto</li>
+				<li><kbd>Intro</kbd> / <kbd>Espacio</kbd> — leer un resumen de la serie</li>
+				<li><kbd>H</kbd> — enumerar los controles de teclado</li>
+			</ul>
+			<p>
+				Un anillo de enfoque visible sigue al punto activo y se mantiene
+				alineado con el lienzo al desplazar o ampliar. Use un lector de
+				pantalla (VoiceOver, NVDA) configurado en español para oír cada punto
+				anunciado con una voz española.
+			</p>
+			<p>
+				<strong>Iniciar actualizaciones en vivo</strong> envía una nueva barra
+				a cada serie cada pocos segundos, simulando un flujo en tiempo real.
+				Las actualizaciones se anuncian mediante una única región
+				<code>aria-live</code> educada compartida. De forma predeterminada solo
+				se anuncia el panel <em>activo</em> (el último enfocado): se oye el
+				panel de precios hasta que enfoca el panel de volumen.
+			</p>
+			<p>
+				Use <strong>Anunciar: rango visible / todos los datos</strong> para
+				cambiar la opción <code>dataScope</code>. Las flechas siempre recorren
+				toda la serie; esta opción solo cambia los resúmenes hablados.
+			</p>
+		</div>
+		<script type="module" src="./example.es.ts"></script>
+	</body>
+</html>

--- a/plugin-examples/src/plugins/accessibility/example/index.html
+++ b/plugin-examples/src/plugins/accessibility/example/index.html
@@ -20,6 +20,7 @@
 			}
 			#buttons {
 				display: flex;
+				flex-wrap: wrap;
 				gap: 10px;
 				margin-top: 10px;
 				margin-bottom: 10px;

--- a/plugin-examples/src/plugins/accessibility/example/index.html
+++ b/plugin-examples/src/plugins/accessibility/example/index.html
@@ -31,6 +31,8 @@
 			<button id="focus-button">Focus the chart</button>
 			<button id="live-button">Start live updates</button>
 			<button id="scope-button">Announce: visible range</button>
+			<button id="contrast-button">Enable high contrast</button>
+			<button id="font-button">Large font</button>
 		</div>
 		<div id="chart"></div>
 		<div id="description">
@@ -50,8 +52,9 @@
 				<li><kbd>↑</kbd> / <kbd>↓</kbd> — switch between series in the pane</li>
 				<li><kbd>Page Up</kbd> / <kbd>Page Down</kbd> — jump ten points</li>
 				<li><kbd>Home</kbd> / <kbd>End</kbd> — first / last point</li>
+				<li><kbd>+</kbd> / <kbd>−</kbd> — zoom the chart in / out</li>
 				<li><kbd>Enter</kbd> / <kbd>Space</kbd> — read a summary of the series</li>
-				<li><kbd>H</kbd> — list the keyboard controls</li>
+				<li><kbd>H</kbd> — show / hide the shortcuts panel (and announce the controls)</li>
 			</ul>
 			<p>
 				A visible focus ring tracks the active point and stays aligned with the
@@ -77,6 +80,19 @@
 				summary and the live-update announcements describe only the points
 				currently on screen; in <em>all data</em> mode they describe the full
 				data set.
+			</p>
+			<p>
+				This example also opts into the <strong>visible shortcuts overlay</strong>
+				(<code>showShortcuts: true</code>): focus the chart to see a
+				<em>Press H for keyboard shortcuts</em> hint, then press <kbd>H</kbd> to
+				toggle an on-screen list (<kbd>Esc</kbd> closes it) — for sighted
+				keyboard users. <strong>Enable high contrast</strong> flips the plugin's
+				<code>highContrast</code> option: the plugin restyles its own focus ring
+				and overlay and calls <code>onHighContrastChange</code>, which this
+				example uses to restyle the chart's own series and grid to match.
+				<strong>Large font</strong> increases the chart's text size. By default
+				<code>highContrast</code> is <code>'auto'</code>, following the operating
+				system's contrast setting.
 			</p>
 		</div>
 		<script type="module" src="./example.ts"></script>

--- a/plugin-examples/src/plugins/accessibility/example/index.html
+++ b/plugin-examples/src/plugins/accessibility/example/index.html
@@ -86,8 +86,7 @@
 				This example also opts into the <strong>visible shortcuts overlay</strong>
 				(<code>showShortcuts: true</code>): focus the chart to see a
 				<em>Press H for keyboard shortcuts</em> hint, then press <kbd>H</kbd> to
-				toggle an on-screen list (<kbd>Esc</kbd> closes it) — for sighted
-				keyboard users. <strong>Enable high contrast</strong> flips the plugin's
+				toggle an on-screen list — for sighted keyboard users. <strong>Enable high contrast</strong> flips the plugin's
 				<code>highContrast</code> option: the plugin restyles its own focus ring
 				and overlay and calls <code>onHighContrastChange</code>, which this
 				example uses to restyle the chart's own series and grid to match.

--- a/plugin-examples/src/plugins/accessibility/example/index.html
+++ b/plugin-examples/src/plugins/accessibility/example/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Lightweight Charts - Accessibility Plugin Example</title>
+		<link href="../../../examples-base.css" rel="stylesheet" />
+		<style>
+			#chart {
+				height: 450px;
+				position: relative;
+			}
+			/*
+			 * The shared examples stylesheet resets buttons with `all: initial`,
+			 * which also removes their default focus ring.
+			 */
+			#buttons button:focus-visible {
+				outline: 3px solid #2962ff;
+				outline-offset: 2px;
+			}
+			#buttons {
+				display: flex;
+				gap: 10px;
+				margin-top: 10px;
+				margin-bottom: 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="buttons" class="column">
+			<button id="focus-button">Focus the chart</button>
+			<button id="live-button">Start live updates</button>
+			<button id="scope-button">Announce: visible range</button>
+		</div>
+		<div id="chart"></div>
+		<div id="description">
+			<h1>Accessibility Plugin</h1>
+			<p>
+				A drop-in plugin that adds a semantic accessibility layer to a chart.
+				One instance is attached per pane, so each pane becomes its own
+				keyboard-focusable region. This example has a price pane (with two
+				series) and a separate volume pane.
+			</p>
+			<p>
+				Press <kbd>Tab</kbd> to move between the panes (or click
+				<strong>Focus the chart</strong>), then use the keyboard:
+			</p>
+			<ul>
+				<li><kbd>←</kbd> / <kbd>→</kbd> — move between data points</li>
+				<li><kbd>↑</kbd> / <kbd>↓</kbd> — switch between series in the pane</li>
+				<li><kbd>Page Up</kbd> / <kbd>Page Down</kbd> — jump ten points</li>
+				<li><kbd>Home</kbd> / <kbd>End</kbd> — first / last point</li>
+				<li><kbd>Enter</kbd> / <kbd>Space</kbd> — read a summary of the series</li>
+				<li><kbd>H</kbd> — list the keyboard controls</li>
+			</ul>
+			<p>
+				A visible focus ring tracks the active point and stays aligned with the
+				canvas as you scroll or zoom. Use a screen reader (VoiceOver, NVDA) to
+				hear each point announced.
+			</p>
+			<p>
+				<strong>Start live updates</strong> streams a new bar into every series
+				every couple of seconds, simulating a real-time feed. Updates are
+				announced through one shared polite <code>aria-live</code> region. By
+				default only the <em>active</em> (last-focused) pane is announced — you
+				hear the price pane until you focus the volume pane — which stops a
+				multi-pane chart talking over itself. Pass
+				<code>announceDataUpdates: true</code> to
+				<code>addAccessibilityPlugin</code> to hear every pane combined into one
+				announcement.
+			</p>
+			<p>
+				Use <strong>Announce: visible range / all data</strong> to switch the
+				<code>dataScope</code> option. The arrow keys always page through the
+				whole series; this option only changes the spoken summaries. In
+				<em>visible range</em> mode the <kbd>Enter</kbd> / <kbd>Space</kbd>
+				summary and the live-update announcements describe only the points
+				currently on screen; in <em>all data</em> mode they describe the full
+				data set.
+			</p>
+		</div>
+		<script type="module" src="./example.ts"></script>
+	</body>
+</html>

--- a/website/tutorials/a11y/conclusion.mdx
+++ b/website/tutorials/a11y/conclusion.mdx
@@ -46,6 +46,30 @@ discussed in this tutorial.
 
 :::
 
+:::info Ready-made plugin
+
+If you would rather not wire these techniques up by hand, the
+[Accessibility plugin](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples/src/plugins/accessibility)
+in the plugin examples packages the keyboard navigation and ARIA layer described
+here into a chart-level helper built on pane primitives:
+
+```js
+addAccessibilityPlugin(chart, { chartTitle: 'My chart' });
+```
+
+Keyboard navigation always covers the whole series (the arrow keys page the
+chart as needed). The plugin defaults to `dataScope: 'visible'`, which scopes the
+spoken *summaries* to the current viewport – the recommended mode for charts with
+large data sets. Use `dataScope: 'all'` when you want those summaries to describe
+the full history.
+
+It is also fully translatable: numbers and dates follow the chart's
+`localization.locale`, and every announced string can be overridden through a
+`messages` bundle (with a `lang` attribute so screen readers use the right
+voice). See the plugin's README and its Spanish example.
+
+:::
+
 This tutorial aimed to foster a better understanding of these practices,
 promoting an inclusive web where applications are made with everyone in mind.
 Thank you for following along and continue putting accessibility at the

--- a/website/tutorials/a11y/intro.mdx
+++ b/website/tutorials/a11y/intro.mdx
@@ -34,6 +34,23 @@ intended to be a comprehensive tutorial.**
 
 :::
 
+:::tip Ready-made plugin
+
+If you would rather not wire these techniques up by hand, the
+[Accessibility plugin](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples/src/plugins/accessibility)
+in the plugin examples packages the keyboard navigation, ARIA markup and
+screen-reader announcements covered in this tutorial into a single chart-level
+helper:
+
+```js
+addAccessibilityPlugin(chart, { chartTitle: 'My chart' });
+```
+
+The tutorial is still the best way to understand what such a layer does under
+the hood, and a guide for building your own integration.
+
+:::
+
 Graphical data representation, although visually appealing and informative, can
 sometimes pose challenges to individuals with varying abilities and needs. In
 line with the principles of inclusivity and universal design, we aim to


### PR DESCRIPTION
## Summary

Adds a drop-in Accessibility plugin under `plugin-examples/`
 
It attaches one labelled, focusable primitive per pane, so multi-pane / multi-series charts work out of the box. detach() restores the DOM to exactly how it was found.

### What it does


- Semantic layer — each pane gets a focusable overlay (role="application", aria-label, aria-roledescription, aria-describedby); the canvases are hidden from assistive tech (aria-hidden), the layout table is marked presentational, and focusable chart internals (e.g. the attribution link) are taken out of the tab order.
- Keyboard navigation — ←/→ move between data points (the viewport pages so the whole series is reachable), ↑/↓ switch series, Page Up/Down jump, Home/End first/last, Enter/Space read a summary, H lists the controls.
- ARIA-live announcements — a per-pane assertive region for navigation, and a single shared polite region for background data updates so multi-pane updates never talk over each other (default announces only the active/last-focused pane; configurable to combine all panes).
- Visible focus indicator — an optional ring that tracks the active point and stays aligned with the canvas while scrolling/zooming (WCAG 2.4.7).
- Localization — every announced string is overridable via a messages bundle; dates/numbers follow the chart's localization.locale (and its priceFormatter/timeFormatter if set); a lang attribute is set on the regions so screen readers use the right voice.
- Lightweight & event-driven — "active-point-only" strategy (never mirrors data points into the DOM); data sync is driven by subscribeDataChanged, so scrolling/zooming does no data work.

### Notes & tradeoffs

- `role="application"` is used so arrow keys drive data navigation under screen readers; this intentionally suspends the SR virtual cursor while focused on the chart (press Tab to move on — it is not a focus trap). Documented in the README.
