### PR TITLE
Fix arrow marker tip drifting from anchor price at `size > 1`

### DIFF
--- a/src/plugins/series-markers/utils.ts
+++ b/src/plugins/series-markers/utils.ts
@@ -15,7 +15,7 @@ function size(barSpacing: number, coeff: number): number {
 
 export function shapeSize(shape: SeriesMarkerShape, originalSize: number): number {
 	const coeff = shape === 'circle' ? 0.8 : (shape === 'square' ? 0.7 : 1);
-	return ceiledOdd(originalSize * coeff);
+	return ceiledOdd(Math.max(originalSize, Constants.MinShapeSize) * coeff);
 }
 
 export function calculateShapeHeight(barSpacing: number): number {

--- a/src/plugins/series-markers/utils.ts
+++ b/src/plugins/series-markers/utils.ts
@@ -14,15 +14,8 @@ function size(barSpacing: number, coeff: number): number {
 }
 
 export function shapeSize(shape: SeriesMarkerShape, originalSize: number): number {
-	switch (shape) {
-		case 'arrowDown':
-		case 'arrowUp':
-			return size(originalSize, 1);
-		case 'circle':
-			return size(originalSize, 0.8);
-		case 'square':
-			return size(originalSize, 0.7);
-	}
+	const coeff = shape === 'circle' ? 0.8 : (shape === 'square' ? 0.7 : 1);
+	return ceiledOdd(originalSize * coeff);
 }
 
 export function calculateShapeHeight(barSpacing: number): number {

--- a/tests/e2e/graphics/test-cases/series-markers/series-markers-price-positioned-sized.js
+++ b/tests/e2e/graphics/test-cases/series-markers/series-markers-price-positioned-sized.js
@@ -1,0 +1,109 @@
+// Arrow markers positioned with `atPriceBottom` / `atPriceTop` and `size > 1`
+// must keep their tip anchored to the requested price, not just at size 1.
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container, {
+		layout: { attributionLogo: false },
+	}));
+
+	const line = chart.addSeries(LightweightCharts.LineSeries);
+	line.setData([
+		{ time: '2017-04-11', value: 80.01 },
+		{ time: '2017-04-12', value: 80.01 },
+		{ time: '2017-04-13', value: 80.01 },
+		{ time: '2017-04-14', value: 80.01 },
+		{ time: '2017-04-15', value: 80.01 },
+		{ time: '2017-04-19', value: 80.01 },
+		{ time: '2017-04-20', value: 80.01 },
+		{ time: '2017-04-21', value: 80.01 },
+		{ time: '2017-04-22', value: 80.01 },
+		{ time: '2017-04-23', value: 80.01 },
+	]);
+
+	// Reference line at the exact anchor price: every arrow tip should touch it.
+	line.createPriceLine({ price: 80.01, color: 'red', lineWidth: 1 });
+
+	LightweightCharts.createSeriesMarkers(line, [
+		{
+			time: '2017-04-11',
+			position: 'atPriceBottom',
+			color: 'orange',
+			shape: 'arrowUp',
+			price: 80.01,
+			size: 1,
+		},
+		{
+			time: '2017-04-11',
+			position: 'atPriceTop',
+			color: 'green',
+			shape: 'arrowDown',
+			price: 80.01,
+			size: 1,
+		},
+		{
+			time: '2017-04-13',
+			position: 'atPriceBottom',
+			color: 'orange',
+			shape: 'arrowUp',
+			price: 80.01,
+			size: 2,
+		},
+		{
+			time: '2017-04-13',
+			position: 'atPriceTop',
+			color: 'green',
+			shape: 'arrowDown',
+			price: 80.01,
+			size: 2,
+		},
+		{
+			time: '2017-04-15',
+			position: 'atPriceBottom',
+			color: 'orange',
+			shape: 'arrowUp',
+			price: 80.01,
+			size: 3,
+		},
+		{
+			time: '2017-04-15',
+			position: 'atPriceTop',
+			color: 'green',
+			shape: 'arrowDown',
+			price: 80.01,
+			size: 3,
+		},
+		{
+			time: '2017-04-20',
+			position: 'atPriceBottom',
+			color: 'orange',
+			shape: 'arrowUp',
+			price: 80.01,
+			size: 4,
+		},
+		{
+			time: '2017-04-20',
+			position: 'atPriceTop',
+			color: 'green',
+			shape: 'arrowDown',
+			price: 80.01,
+			size: 4,
+		},
+		{
+			time: '2017-04-22',
+			position: 'atPriceBottom',
+			color: 'orange',
+			shape: 'arrowUp',
+			price: 80.01,
+			size: 5,
+		},
+		{
+			time: '2017-04-22',
+			position: 'atPriceTop',
+			color: 'green',
+			shape: 'arrowDown',
+			price: 80.01,
+			size: 5,
+		},
+	]);
+
+	chart.timeScale().fitContent();
+}


### PR DESCRIPTION
Double clamping via shapeSize resulted in rendering issue for markers with size setting greater than 1

**Type of PR:** bugfix

**PR checklist:**

- [x] Addresses an existing issue: fixes #2002
- [x] Includes tests

---

## Overview of change:

### Root cause
For price-anchored markers (`atPriceBottom` / `atPriceTop`), the marker's center is positioned in `pane-view.ts` at `calculateShapeHeight(barSpacing) * sizeMultiplier`, so the offset from the anchor price grows linearly with the marker's `size`.

The renderer, however, fed that already-resolved size back through `shapeSize()`, which **re-clamped it to `[12, 30]` px**. That clamp only makes sense when deriving the base height from bar spacing — applying it again caps the *drawn* shape at ~30px while the positioning offset keeps growing. The result: the arrow tip falls increasingly short of the anchor price as `size` increases (at `size = 1` the two roughly match, which is why it looked correct).

### Fix
`shapeSize()` previously clamped the resolved size to `[12, 30]`. The upper bound was the bug — it's removed so the drawn shape scales with `size`. The **lower** bound (`MinShapeSize`, 12px) is kept as a minimum-size floor, since `calculateShapeHeight` can resolve below 12px at tight bar spacing and default markers rely on that floor. The `[12, 30]` clamp still applies in `calculateShapeHeight` / `shapeMargin` where the base height is derived from bar spacing. This also fixes large circle/square markers being capped at 30px.

Default-size markers render identically to master (verified across all bar spacings); only sizes that resolve above 30px change.

### Tests
Added graphics test case `series-markers-price-positioned-sized` covering `atPriceBottom`/`atPriceTop` arrows across sizes 1–5 with a reference price line at the anchor price.