### PR TITLE
DOCS (examples): fix old incorrect usage of priceScale() on the chart instance

### DIFF
--- a/website/tutorials/customization/assets/step10.html
+++ b/website/tutorials/customization/assets/step10.html
@@ -1098,7 +1098,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step2.html
+++ b/website/tutorials/customization/assets/step2.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step3.html
+++ b/website/tutorials/customization/assets/step3.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step4.html
+++ b/website/tutorials/customization/assets/step4.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step5.html
+++ b/website/tutorials/customization/assets/step5.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step6.html
+++ b/website/tutorials/customization/assets/step6.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step7.html
+++ b/website/tutorials/customization/assets/step7.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step8.html
+++ b/website/tutorials/customization/assets/step8.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/assets/step9.html
+++ b/website/tutorials/customization/assets/step9.html
@@ -1093,7 +1093,7 @@
       );
 
       // Setting the border color for the vertical axis
-      chart.priceScale().applyOptions({
+      chart.priceScale('right').applyOptions({
         borderColor: "#71649C",
       });
 

--- a/website/tutorials/customization/chart-colors.mdx
+++ b/website/tutorials/customization/chart-colors.mdx
@@ -105,7 +105,7 @@ You can add the following code beneath the `createChart` method call.
 
 ```js
 // Setting the border color for the vertical axis
-chart.priceScale().applyOptions({
+chart.priceScale('right').applyOptions({
     borderColor: '#71649C',
 });
 

--- a/website/tutorials/how_to/inverted-price-scale.mdx
+++ b/website/tutorials/how_to/inverted-price-scale.mdx
@@ -28,7 +28,7 @@ chart.applyOptions({
 });
 
 // or (for a specific price scale)
-const priceScale = chart.priceScale();
+const priceScale = chart.priceScale('right');
 priceScale.applyOptions({
     invertScale: true,
 });

--- a/website/tutorials/vuejs/01-wrapper.mdx
+++ b/website/tutorials/vuejs/01-wrapper.mdx
@@ -243,7 +243,7 @@ watch(
         if (!chart) {
             return;
         }
-        chart.priceScale().applyOptions(newOptions);
+        chart.priceScale('right').applyOptions(newOptions);
     }
 );
 ```

--- a/website/tutorials/vuejs/assets/composition-api.vue
+++ b/website/tutorials/vuejs/assets/composition-api.vue
@@ -100,7 +100,7 @@ onMounted(() => {
 	addSeriesAndData(props);
 
 	if (props.priceScaleOptions) {
-		chart.priceScale().applyOptions(props.priceScaleOptions);
+		chart.priceScale('right').applyOptions(props.priceScaleOptions);
 	}
 
 	if (props.timeScaleOptions) {
@@ -185,7 +185,7 @@ watch(
 	() => props.priceScaleOptions,
 	newOptions => {
 		if (!chart) return;
-		chart.priceScale().applyOptions(newOptions);
+		chart.priceScale('right').applyOptions(newOptions);
 	}
 );
 

--- a/website/tutorials/vuejs/assets/options-api.vue
+++ b/website/tutorials/vuejs/assets/options-api.vue
@@ -79,7 +79,7 @@ export default {
 		addSeriesAndData(this.type, this.seriesOptions, this.data);
 
 		if (this.priceScaleOptions) {
-			chart.priceScale().applyOptions(this.priceScaleOptions);
+			chart.priceScale('right').applyOptions(this.priceScaleOptions);
 		}
 
 		if (this.timeScaleOptions) {
@@ -147,7 +147,7 @@ export default {
 		},
 		priceScaleOptions(newOptions) {
 			if (!chart) return;
-			chart.priceScale().applyOptions(newOptions);
+			chart.priceScale('right').applyOptions(newOptions);
 		},
 		timeScaleOptions(newOptions) {
 			if (!chart) return;

--- a/website/tutorials/vuejs/assets/web-component.js
+++ b/website/tutorials/vuejs/assets/web-component.js
@@ -85,7 +85,7 @@ const LWChart = {
 		addSeriesAndData(this.type, this.seriesOptions, this.data);
 
 		if (this.priceScaleOptions) {
-			chart.priceScale().applyOptions(this.priceScaleOptions);
+			chart.priceScale('right').applyOptions(this.priceScaleOptions);
 		}
 
 		if (this.timeScaleOptions) {
@@ -149,7 +149,7 @@ const LWChart = {
 			if (!chart) {
 				return;
 			}
-			chart.priceScale().applyOptions(newOptions);
+			chart.priceScale('right').applyOptions(newOptions);
 		},
 		timeScaleOptions(newOptions) {
 			if (!chart) {

--- a/website/tutorials/webcomponents/assets/lw-chart.js
+++ b/website/tutorials/webcomponents/assets/lw-chart.js
@@ -236,12 +236,12 @@ import { createChart, LineSeries, AreaSeries, CandlestickSeries, BaselineSeries,
 
 		set priceScaleOptions(value) {
 			if (!this.chart) {return;}
-			this.chart.priceScale().applyOptions(value);
+			this.chart.priceScale('right').applyOptions(value);
 		}
 
 		get priceScaleOptions() {
 			if (!this.series) {return null;}
-			return this.chart.priceScale().options();
+			return this.chart.priceScale('right').options();
 		}
 
 		set timeScaleOptions(value) {


### PR DESCRIPTION
**Type of PR:** fix typo

**PR checklist:**

- [x] Addresses an existing issue: fixes #2101
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**
Some documentation examples (tutorials) don't specify the price scale id when using `priceScale()` on the chart instance. When using `priceScale` on the chart instance then the id is required (unlike when evoked on the ISeriesApi)
