### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,37 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly on Monday at 06:00 UTC - catches new advisories between pushes
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite CLI dependency audit workflow to lightweight-charts's CI pipeline.

A scan of the current `package-lock.json` found **1 critical-severity** and **15 high-severity** advisories, including 3 direct dependencies with available fixes:

**Direct high-severity findings:**
- `markdown-it@12.x` - ReDoS via crafted input (GHSA-6vfc-qv3f-vr6c) - fix: `npm install -D markdown-it@14.2.0`
- `rollup@3.x` - prototype pollution via code generation (GHSA-gcx4-mw62-g8wm) - fix: `npm install -D rollup@4.59.0`
- `@rollup/plugin-terser@0.4.x` - `serialize-javascript` prototype pollution (GHSA-h4j5-c7cj-74xg) - fix: `npm install -D @rollup/plugin-terser@1.0.0`
- `glob@8.x` - ReDoS - fix included in the `rollup` upgrade path

The workflow runs on push, pull request, and weekly schedule. Findings are uploaded to GitHub's Security tab as SARIF.

**Tool:** [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli) is an OWASP Lab Project. It reads the lockfile locally, queries the OSV database, and surfaces direct dependency findings with actionable fix commands.
