### PR TITLE
perf: avoid full series data copy on every series-markers update

### DIFF
--- a/src/plugins/series-markers/pane-view.ts
+++ b/src/plugins/series-markers/pane-view.ts
@@ -229,7 +229,7 @@ export class SeriesMarkersPaneView<HorzScaleItem> implements IPrimitivePaneView 
 			return;
 		}
 		const visibleBarsRange = new RangeImpl(Math.floor(visibleBars.from) as TimePointIndex, Math.ceil(visibleBars.to) as TimePointIndex);
-		const firstValue = this._series.dataByIndex(0);
+		const firstValue = this._series.dataByIndex(0, MismatchDirection.NearestRight);
 		if (firstValue === null) {
 			return;
 		}

--- a/src/plugins/series-markers/pane-view.ts
+++ b/src/plugins/series-markers/pane-view.ts
@@ -229,7 +229,7 @@ export class SeriesMarkersPaneView<HorzScaleItem> implements IPrimitivePaneView 
 			return;
 		}
 		const visibleBarsRange = new RangeImpl(Math.floor(visibleBars.from) as TimePointIndex, Math.ceil(visibleBars.to) as TimePointIndex);
-		const firstValue = this._series.data()[0];
+		const firstValue = this._series.dataByIndex(0);
 		if (firstValue === null) {
 			return;
 		}


### PR DESCRIPTION
## Type of change

- [x] Performance improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Problem

Hovering over a chart that has series markers together with a large dataset is
very janky — the frame rate drops sharply and gets worse as the number of data
points grows. Zooming in does not help, because the cost is proportional to the
total dataset size, not to the visible range.

## Root cause

`SeriesMarkersPaneView._makeValid()` reads the first series point with:

```ts
const firstValue = this._series.data()[0];
```

`ISeriesApi.data()` clones the whole data set on every call:

```ts
data(): readonly SeriesDataItemTypeMap<HorzScaleItem>[SeriesType][] {
    const seriesCreator = getSeriesDataCreator(this.seriesType());
    const rows = this._series.bars().rows();
    return rows.map((row) => seriesCreator(row)); // O(n) allocation
}
```

`_makeValid()` is invoked on every crosshair move through two paths:

1. hit-testing — `setAndSaveCurrentPosition` → `hitTestPane` → the markers
   primitive `hitTest` → `paneView.renderer()` → `_makeValid()`;
2. repaint — `cursorUpdate` → `drawImpl` → `drawSources` →
   `paneView.renderer()` → `_makeValid()`.

So a full O(n) copy of the entire dataset is allocated on every mouse move just
to read a single element.

## Fix

Replace `this._series.data()[0]` with `this._series.dataByIndex(0)`, which
resolves the point with a lookup instead of rebuilding and cloning the whole
array. The value is only used as a presence guard, so the observable behavior
is unchanged.

```diff
- const firstValue = this._series.data()[0];
+ const firstValue = this._series.dataByIndex(0);
```

## Impact

- No public API change.
- Crosshair/hover performance on large datasets with markers is restored;
  the per-move cost no longer scales with the total number of points.

## How I tested

- Reproduced with a large series plus markers; profiled crosshair movement
  before and after — `data()` no longer appears on the hover hot path and the
  frame rate is smooth.
- Verified markers still render and position correctly, and the empty-series
  guard still holds.
