### PR TITLE
fix: better curved line rendering

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -95,7 +95,7 @@ export default [
 		path: 'dist/lightweight-charts.production.mjs',
 		import: '{ BaselineSeries }',
 		ignore: ['fancy-canvas'],
-		limit: '4.5 KB',
+		limit: '4.56 KB',
 		brotli: true,
 	},
 	{

--- a/src/renderers/line-hit-test.ts
+++ b/src/renderers/line-hit-test.ts
@@ -52,7 +52,7 @@ function lineSegmentHorizontalBounds(
 ): [number, number] {
 	switch (lineType) {
 		case LineType.Curved: {
-			const [firstControlPoint, secondControlPoint] = getControlPoints(items, toItemIndex - 1, toItemIndex);
+			const [firstControlPoint, secondControlPoint] = getControlPoints(items, toItemIndex);
 			const minX = Math.min(firstItem.x, secondItem.x, firstControlPoint.x, secondControlPoint.x);
 			const maxX = Math.max(firstItem.x, secondItem.x, firstControlPoint.x, secondControlPoint.x);
 			return [minX, maxX];
@@ -87,7 +87,7 @@ function hitTestLineSegment(
 				return minDistance <= radius ? minDistance : null;
 			}
 		case LineType.Curved: {
-			const [firstControlPoint, secondControlPoint] = getControlPoints(items, toItemIndex - 1, toItemIndex);
+			const [firstControlPoint, secondControlPoint] = getControlPoints(items, toItemIndex);
 			const distance = distanceToBezierCurve(x, y, [firstItem, firstControlPoint, secondControlPoint, secondItem]);
 			return distance <= radius ? distance : null;
 		}

--- a/src/renderers/walk-line.ts
+++ b/src/renderers/walk-line.ts
@@ -105,7 +105,7 @@ export function walkLine<TItem extends LinePoint, TStyle extends CanvasRendering
 					break;
 				}
 				case LineType.Curved: {
-					const [cp1, cp2] = getControlPoints(items, i - 1, i);
+					const [cp1, cp2] = getControlPoints(items, i);
 					const cp1x = cp1.x * horizontalPixelRatio;
 					const cp1y = cp1.y * verticalPixelRatio;
 					const cp2x = cp2.x * horizontalPixelRatio;
@@ -149,28 +149,83 @@ export function walkLine<TItem extends LinePoint, TStyle extends CanvasRendering
 	}
 }
 
-const curveTension = 6;
-
-function subtract(p1: LinePoint, p2: LinePoint): LinePoint {
-	return { x: p1.x - p2.x as Coordinate, y: p1.y - p2.y as Coordinate };
-}
-
-function add(p1: LinePoint, p2: LinePoint): LinePoint {
-	return { x: p1.x + p2.x as Coordinate, y: p1.y + p2.y as Coordinate };
-}
-
-function divide(p1: LinePoint, n: number): LinePoint {
-	return { x: p1.x / n as Coordinate, y: p1.y / n as Coordinate };
+function segmentSlope(p1: LinePoint, p2: LinePoint): number {
+	const width = p2.x - p1.x;
+	return width !== 0 ? (p2.y - p1.y) / width : 0;
 }
 
 /**
- * @returns Two control points that can be used as arguments to {@link CanvasRenderingContext2D.bezierCurveTo} to draw a curved line between `points[fromPointIndex]` and `points[toPointIndex]`.
+ * This is the Fritsch-Carlson formula for monotone interpolation.
+ * https://en.wikipedia.org/wiki/Monotone_cubic_interpolation
  */
-export function getControlPoints(points: readonly LinePoint[], fromPointIndex: number, toPointIndex: number): [LinePoint, LinePoint] {
-	const beforeFromPointIndex = Math.max(0, fromPointIndex - 1);
-	const afterToPointIndex = Math.min(points.length - 1, toPointIndex + 1);
-	const cp1 = add(points[fromPointIndex], divide(subtract(points[toPointIndex], points[beforeFromPointIndex]), curveTension));
-	const cp2 = subtract(points[toPointIndex], divide(subtract(points[afterToPointIndex], points[fromPointIndex]), curveTension));
+function monotoneSlope(
+	leftWidth: number,
+	leftSlope: number,
+	rightWidth: number,
+	rightSlope: number
+): number {
+	// Points on a line always have increasing x coordinates, so segments always have a width that is greater than zero.
+	// If the input does not obey this rule a slope calculation is not possible so we make the curve horizontal at the shared point.
+	if (leftWidth <= 0 || rightWidth <= 0) {
+		return 0;
+	}
+
+	// The slope of a segment is a good estimate of the slope of the curve at the center of that
+	// segment. Thus the two segment slopes give the slope of the curve at two known positions.
+	// A linear interpolation between the two known slopes gives the slope at the shared point.
+	// The center of the narrow segment is nearer to the shared point than the center of the wide
+	// segment. Thus the slope of the narrow segment must get the larger weight. This is the
+	// reason that each slope is multiplied by the width of the other segment.
+	const weightedSlope =
+		(leftSlope * rightWidth + rightSlope * leftWidth) /
+		(leftWidth + rightWidth);
+	// `Math.sign(left) + Math.sign(right)` is +2 or -2 when the slopes are in the same up/down direction, and 0 when they don't.
+	return (
+		(Math.sign(leftSlope) + Math.sign(rightSlope)) *
+		Math.min(Math.abs(leftSlope), Math.abs(rightSlope), 0.5 * Math.abs(weightedSlope))
+	);
+}
+
+/**
+ * Calculates the control points needed to draw the curve between the point at `endPointIndex - 1` and the point at `endPointIndex`.
+ *
+ * @returns Two control points that can be used as arguments to {@link CanvasRenderingContext2D.bezierCurveTo} to draw the curve segment.
+ */
+export function getControlPoints(
+	points: readonly LinePoint[],
+	endPointIndex: number
+): [LinePoint, LinePoint] {
+	// The segment (line between two points) being drawn...
+	const startPoint = points[endPointIndex - 1];
+	const endPoint = points[endPointIndex];
+	const width = endPoint.x - startPoint.x;
+	const slope = segmentSlope(startPoint, endPoint);
+
+	// ...and its neighbouring points. Where the line begins or ends there is no neighbouring segment so
+	// we pretend the line continues with a copy of the drawn segment, which makes `monotoneSlope` return
+	// the drawn segment's slope, so the curve enters/leaves the line pointing straight along its first/last
+	// segment (and a two point series is a straight line).
+	const pointBeforeStart = endPointIndex > 1 ? points[endPointIndex - 2] : null;
+	const pointAfterEnd = endPointIndex < points.length - 1 ? points[endPointIndex + 1] : null;
+	const widthBefore = pointBeforeStart !== null ? startPoint.x - pointBeforeStart.x : width;
+	const slopeBefore = pointBeforeStart !== null ? segmentSlope(pointBeforeStart, startPoint) : slope;
+	const widthAfter = pointAfterEnd !== null ? pointAfterEnd.x - endPoint.x : width;
+	const slopeAfter = pointAfterEnd !== null ? segmentSlope(endPoint, pointAfterEnd) : slope;
+
+	// The slope the curve has as it passes through each end of the segment.
+	const startPointSlope = monotoneSlope(widthBefore, slopeBefore, width, slope);
+	const endPointSlope = monotoneSlope(width, slope, widthAfter, slopeAfter);
+
+	// Each control point sits a third of the way into the segment, shifted vertically so that the
+	// curve leaves `startPoint` and arrives at `endPoint` with the slopes chosen above.
+	const cp1: LinePoint = {
+		x: (startPoint.x + width / 3) as Coordinate,
+		y: (startPoint.y + (startPointSlope * width) / 3) as Coordinate,
+	};
+	const cp2: LinePoint = {
+		x: (endPoint.x - width / 3) as Coordinate,
+		y: (endPoint.y - (endPointSlope * width) / 3) as Coordinate,
+	};
 
 	return [cp1, cp2];
 }

--- a/tests/e2e/graphics/test-cases/series/curved-line-plateau.js
+++ b/tests/e2e/graphics/test-cases/series/curved-line-plateau.js
@@ -1,0 +1,48 @@
+// Data from https://github.com/tradingview/lightweight-charts/issues/1680
+
+function runTestCase(container) {
+	const chart = (window.chart = LightweightCharts.createChart(container, {
+		layout: { attributionLogo: false },
+	}));
+
+	const plateauSeries = chart.addSeries(LightweightCharts.LineSeries, {
+		lineType: LightweightCharts.LineType.Curved,
+	});
+
+	const day = 24 * 60 * 60;
+	const firstDay = new Date(2000, 0, 1).getTime() / 1000;
+
+	plateauSeries.setData([
+		{ time: firstDay, value: 100 },
+		{ time: firstDay + day, value: 100 },
+		{ time: firstDay + 2 * day, value: 20 },
+	]);
+
+	const spikesSeries = chart.addSeries(LightweightCharts.LineSeries, {
+		lineType: LightweightCharts.LineType.Curved,
+		color: 'red',
+	});
+
+	spikesSeries.setData(
+		[3, 3, 3, 1, 1, 3, 1, 1, 3, 1, 1].map((value, index) => ({
+			time: firstDay + (index * day) / 4,
+			value: value * 20,
+		}))
+	);
+
+	// A zigzag where every point is a local extreme - should be drawn as smooth waves with
+	// level crests and troughs.
+	const zigzagSeries = chart.addSeries(LightweightCharts.LineSeries, {
+		lineType: LightweightCharts.LineType.Curved,
+		color: 'green',
+	});
+
+	zigzagSeries.setData(
+		[150, 200, 150, 200, 150, 200, 150, 200, 150].map((value, index) => ({
+			time: firstDay + (index * day) / 4,
+			value,
+		}))
+	);
+
+	chart.timeScale().fitContent();
+}

--- a/tests/unittests/walk-line.spec.ts
+++ b/tests/unittests/walk-line.spec.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+
+import { Coordinate } from '../../src/model/coordinate';
+import { LinePoint } from '../../src/renderers/draw-line';
+import { getControlPoints } from '../../src/renderers/walk-line';
+
+function point(x: number, y: number): LinePoint {
+	return { x: x as Coordinate, y: y as Coordinate };
+}
+
+function expectControlPointsWithinYRange(
+	points: readonly LinePoint[],
+	endPointIndex: number
+): void {
+	const [cp1, cp2] = getControlPoints(points, endPointIndex);
+	const minY = Math.min(points[endPointIndex - 1].y, points[endPointIndex].y);
+	const maxY = Math.max(points[endPointIndex - 1].y, points[endPointIndex].y);
+
+	expect(cp1.y).to.be.within(
+		minY,
+		maxY,
+		`segment ${endPointIndex - 1} -> ${endPointIndex}`
+	);
+	expect(cp2.y).to.be.within(
+		minY,
+		maxY,
+		`segment ${endPointIndex - 1} -> ${endPointIndex}`
+	);
+}
+
+describe('getControlPoints', () => {
+	it('should keep a flat segment flat when the next segment drops sharply', () => {
+		// Data from https://github.com/tradingview/lightweight-charts/issues/1680
+		const points = [point(0, 100), point(10, 100), point(20, 20)];
+
+		const [cp1, cp2] = getControlPoints(points, 1);
+		expect(cp1.y).to.equal(100);
+		expect(cp2.y).to.equal(100);
+	});
+
+	it('should not overshoot the y-range of segment end points - plateau with drop', () => {
+		const points = [point(0, 100), point(10, 100), point(20, 20)];
+
+		for (let i = 1; i < points.length; i++) {
+			expectControlPointsWithinYRange(points, i);
+		}
+	});
+
+	it('should not overshoot the y-range of segment end points - spikes', () => {
+		const points = [
+			point(0, 3),
+			point(10, 3),
+			point(20, 1),
+			point(30, 1),
+			point(40, 3),
+			point(50, 1),
+		];
+
+		for (let i = 1; i < points.length; i++) {
+			expectControlPointsWithinYRange(points, i);
+		}
+	});
+
+	it('should have a horizontal tangent at a local extreme', () => {
+		const points = [point(0, 0), point(10, 10), point(20, 0)];
+
+		const [, cp2First] = getControlPoints(points, 1);
+		const [cp1Second] = getControlPoints(points, 2);
+
+		expect(cp2First.y).to.equal(10);
+		expect(cp1Second.y).to.equal(10);
+	});
+
+	it('should produce a straight line for a two point series', () => {
+		const points = [point(0, 0), point(30, 15)];
+
+		const [cp1, cp2] = getControlPoints(points, 1);
+
+		expect(cp1.y).to.be.closeTo(cp1.x / 2, 1e-9);
+		expect(cp2.y).to.be.closeTo(cp2.x / 2, 1e-9);
+	});
+
+	it('should not produce NaN when neighbouring points share an x coordinate', () => {
+		const points = [point(0, 0), point(0, 10), point(10, 5), point(10, 20)];
+
+		for (let i = 1; i < points.length; i++) {
+			const [cp1, cp2] = getControlPoints(points, i);
+
+			expect(Number.isFinite(cp1.x), `cp1.x of segment ending at ${i}`).to.equal(true);
+			expect(Number.isFinite(cp1.y), `cp1.y of segment ending at ${i}`).to.equal(true);
+			expect(Number.isFinite(cp2.x), `cp2.x of segment ending at ${i}`).to.equal(true);
+			expect(Number.isFinite(cp2.y), `cp2.y of segment ending at ${i}`).to.equal(true);
+		}
+	});
+
+	it('should keep control point x coordinates within the segment', () => {
+		const points = [
+			point(0, 5),
+			point(10, 15),
+			point(20, 7.5),
+			point(30, 30),
+		];
+
+		for (let i = 1; i < points.length; i++) {
+			const [cp1, cp2] = getControlPoints(points, i);
+
+			expect(cp1.x).to.be.greaterThan(points[i - 1].x);
+			expect(cp1.x).to.be.lessThan(points[i].x);
+			expect(cp2.x).to.be.greaterThan(points[i - 1].x);
+			expect(cp2.x).to.be.lessThan(points[i].x);
+		}
+	});
+});


### PR DESCRIPTION
Replace the Catmull-Rom logic used for curved lines with Fritsch-Carlson monotone, the algorithm used for d3-shape's curveMonotoneX and Chart.js's 'monotone' mode.


| Golden | Test |
|--------|--------|
| <img width="600" height="600" alt="1 golden" src="https://github.com/user-attachments/assets/b4febd52-9d99-43be-a7ef-04a8df974757" /> | <img width="600" height="600" alt="2 test" src="https://github.com/user-attachments/assets/ccacfedc-88b1-47b1-9d91-0863fa240679" />  |

**Type of PR:** bugfix, enhancement

**PR checklist:**

- [x] Addresses an existing issue: fixes #1680
- [x] Includes tests
- [ ] Documentation update

**Overview of change:**

Note: a segment is a line between two points.

With the monotone algorithm the curve never leaves the y-range of each segment's end points, so plateaus stay flat without spikes. At the beginning (end) of the series the missing neighbour segment is replaced with a copy of the first (last) segment, so the curve enters and leaves the line pointing along its first (last) segment, and a two point series is a straight line.

The signature of getControlPoints has been simplified to take the index of the segment's end point instead of two point arguments. `getControlPoints(points, endPointIndex)` calculates control points for the segment from `points[endPointIndex - 1]` to `points[endPointIndex]`. The old signature allowed arbitrary point pairs, but the neighbour lookups only make sense for adjacent indices, so non-adjacent input would produce rubbish.

The existing curved-line graphics tests will have diffs as expected. The new curved-line-plateau case covers the specific GitHub issue data, a spiky plateau, and a zigzag.

The BaselineSeries size limit increased slightly from 4.5KB to ~4.56 KB.

<!-- optional -->
