### PR TITLE
Fix series invalidation during time scale updates

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -411,6 +411,11 @@ export class ChartApi<HorzScaleItem> implements IChartApiBase<HorzScaleItem>, Da
 	private _sendUpdateToChart(update: DataUpdateResponse): void {
 		const model = this._chartWidget.model();
 
+		for (const series of update.series.keys()) {
+			// Updating the time scale can synchronously recalculate the crosshair.
+			// Invalidate cached pane items before their logical indexes change.
+			series.invalidatePaneViewData();
+		}
 		model.updateTimeScale(update.timeScale.baseIndex, update.timeScale.points, update.timeScale.firstChangedPointIndex);
 		update.series.forEach((value: SeriesChanges, series: Series<SeriesType>) => series.setData(value.data, value.info));
 

--- a/src/model/series.ts
+++ b/src/model/series.ts
@@ -285,7 +285,7 @@ export class Series<T extends SeriesType> extends PriceDataSource implements IDe
 			this._precomputeConflationLevels(tsOptions.precomputeConflationPriority);
 		}
 
-		this._paneView.update('data');
+		this.invalidatePaneViewData();
 
 		if (this._lastPriceAnimationPaneView !== null) {
 			if (updateInfo && updateInfo.lastBarUpdatedOrNewBarsAddedToTheRight) {
@@ -300,6 +300,10 @@ export class Series<T extends SeriesType> extends PriceDataSource implements IDe
 		this.model().updateSource(this);
 		this.model().updateCrosshair();
 		this.model().lightUpdate();
+	}
+
+	public invalidatePaneViewData(): void {
+		this._paneView.update('data');
 	}
 
 	public createPriceLine(options: PriceLineOptions): CustomPriceLine {

--- a/tests/e2e/interactions/test-cases/api/set-data-after-timescale-compaction.js
+++ b/tests/e2e/interactions/test-cases/api/set-data-after-timescale-compaction.js
@@ -1,3 +1,13 @@
+// Regression test for https://github.com/tradingview/lightweight-charts/issues/2044.
+//
+// Replacing all series with shorter datasets compacts the time scale's logical
+// indexes. `updateTimeScale` runs before `Series.setData` and, with fixed edges,
+// synchronously recalculates the hovered crosshair — if a pane view still holds
+// items cached against the old indexes, the bar colorer throws `Value is null`.
+//
+// The test hovers a data point, then compacts both series. It passes if no
+// exception reaches the page.
+
 const initialData = [
 	{ time: '2025-01-01', value: 10 },
 	{ time: '2025-01-02', value: 20 },
@@ -56,7 +66,7 @@ function beforeInteractions(container) {
 
 function afterInitialInteractions() {
 	firstSeries.setData(compactedData);
-	firstSeries.applyOptions({});
+	firstSeries.applyOptions({}); // forces a crosshair update that rebuilds the pane-view item cache with pre-compaction indexes. Required for reproducing the #2044 bug.
 	secondSeries.setData(compactedData);
 
 	return new Promise(resolve => requestAnimationFrame(resolve));

--- a/tests/e2e/interactions/test-cases/api/set-data-after-timescale-compaction.js
+++ b/tests/e2e/interactions/test-cases/api/set-data-after-timescale-compaction.js
@@ -1,0 +1,67 @@
+const initialData = [
+	{ time: '2025-01-01', value: 10 },
+	{ time: '2025-01-02', value: 20 },
+	{ time: '2025-01-03', value: 30 },
+	{ time: '2025-01-04', value: 40 },
+];
+
+const compactedData = initialData.slice(1);
+
+let hoverPoint = null;
+let firstSeries = null;
+let secondSeries = null;
+
+function initialInteractionsToPerform() {
+	if (hoverPoint === null) {
+		throw new Error('Expected hover coordinates to be available.');
+	}
+
+	return [{
+		action: 'moveMouseXY',
+		options: hoverPoint,
+	}];
+}
+
+function finalInteractionsToPerform() {
+	return [];
+}
+
+function beforeInteractions(container) {
+	const chart = LightweightCharts.createChart(container, {
+		timeScale: {
+			fixLeftEdge: true,
+			fixRightEdge: true,
+		},
+	});
+
+	firstSeries = chart.addSeries(LightweightCharts.LineSeries);
+	secondSeries = chart.addSeries(LightweightCharts.LineSeries);
+	firstSeries.setData(initialData);
+	secondSeries.setData(initialData);
+	chart.timeScale().fitContent();
+
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			const x = chart.timeScale().timeToCoordinate(initialData[1].time);
+			const y = firstSeries.priceToCoordinate(initialData[1].value);
+			if (x === null || y === null) {
+				throw new Error('Expected coordinates for the hovered data point.');
+			}
+
+			hoverPoint = { x: Math.round(x), y: Math.round(y) };
+			resolve();
+		});
+	});
+}
+
+function afterInitialInteractions() {
+	firstSeries.setData(compactedData);
+	firstSeries.applyOptions({});
+	secondSeries.setData(compactedData);
+
+	return new Promise(resolve => requestAnimationFrame(resolve));
+}
+
+function afterFinalInteractions() {
+	return Promise.resolve();
+}


### PR DESCRIPTION
## Summary

- invalidate affected series pane-view data before applying time-scale changes
- reuse the explicit pane-view invalidation method from the normal series data update path
- add an interaction regression test for compacting two series while the crosshair is hovering data

## Root cause

When multiple series are replaced with shorter datasets, the data layer can compact their logical indexes. `updateTimeScale` may synchronously recalculate a fixed edge and the hovered crosshair before `Series.setData` invalidates the affected pane views. Those views can therefore reuse cached items containing the old logical indexes while their underlying rows already contain the new indexes, causing the bar colorer to receive a missing row and throw `Value is null`.

Invalidating each affected pane view before updating the time scale ensures any synchronous recalculation rebuilds its items against the current row indexes.

Fixes #2044.

## Validation

- `npm run tsc-verify`
- `npm run build`
- `npm run lint:eslint`
- `npm run e2e:interactions` (26 passing)
