### PR TITLE
Docs add llms txt and docs map

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -48,6 +48,19 @@ _Note_: API documentation will not be generated unless you have already built th
 
 This will build the website into static files and push the files to the `gh-pages` branch.
 
+## Markdown export for LLMs
+
+Every build also writes a Markdown copy of the documentation next to the pages it is generated from, for LLMs and other tools that read the docs as text rather than as a website (`plugins/docs-markdown`):
+
+- `<page URL>.md` — the page as Markdown, with the MDX stripped (imports and JSX removed, `<CodeBlock>` samples inlined as fenced code, partials expanded) and every link rewritten to an absolute URL.
+- `llms.txt` — the index of every exported page, following the sidebar (pages that sit at the root of a section are listed before its categories, so that every page falls under the heading it belongs to).
+- `docs_map.md` — the same index, with each page's headings listed under it.
+- `lightweight-charts.d.ts` — the TypeScript declarations of the released version, published in place of the generated API reference pages.
+
+Only the released version of the documentation and the tutorials are exported; the API reference is not, since the declarations above cover it in one file.
+
+The exported files are generated in `postBuild`, so they exist only in a full `npm run build` — not when running the development server.
+
 ## Adding a new version
 
 Run the following command replacing $VERSION with the name of a version you would like to create. $VERSION should match one of the available versions of the package on [unpkg.com](https://unpkg.com)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,6 +9,7 @@ import pluginDocusaurus from 'docusaurus-plugin-typedoc';
 import logger from '@docusaurus/logger';
 
 import versions from './versions.json';
+import { docsMarkdownPlugin } from './plugins/docs-markdown/index.js';
 
 /* Configuration Constants */
 const organizationName = process.env.GITHUB_ORGANIZATION_NAME || 'tradingview';
@@ -422,6 +423,7 @@ const getConfig = async () => {
 			...versions.map(typedocPluginForVersion),
 			'./plugins/enhanced-codeblock',
 			'./plugins/suppress-resize-observer-error',
+			docsMarkdownPlugin,
 		],
 	};
 

--- a/website/package.json
+++ b/website/package.json
@@ -40,6 +40,9 @@
   },
   "devDependencies": {
     "@tsconfig/docusaurus": "2.0.3",
+    "mdast-util-from-markdown": "2.0.2",
+    "mdast-util-mdx": "3.0.0",
+    "micromark-extension-mdxjs": "3.0.0",
     "typedoc-plugin-frontmatter": "1.0.0"
   }
 }

--- a/website/plugins/docs-markdown/components.js
+++ b/website/plugins/docs-markdown/components.js
@@ -1,0 +1,784 @@
+// @ts-check
+
+import { readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
+
+import { themeColors } from '../../theme-colors.js';
+
+// ---------------------------------------------------------------------------
+// Markdown for the content our MDX components render.
+//
+// The per-page Markdown export cleans the page *source*, so anything a React
+// component draws (code blocks fed from a variable, navigation cards, tabs)
+// never reaches the .md file. Instead of converting the built HTML back to
+// Markdown, we rebuild that content from the component's own inputs:
+// `mdast-util-mdx` hands us a parsed ESTree for every prop and for every
+// `{expression}` child, so a `<CodeBlock>{example}</CodeBlock>` can be resolved
+// back to the string the page assembles it from.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal mdast/MDX node shape, covering the fields the cleaner and the
+ * renderers read. Offsets are always present because from-markdown emits
+ * positions by default.
+ *
+ * @typedef {object} MdastNode
+ * @property {string} type
+ * @property {string | null} [name]
+ * @property {number} [depth]
+ * @property {string} [value]
+ * @property {MdastNode[]} [children]
+ * @property {any[]} [attributes]
+ * @property {{ estree?: any }} [data]
+ * @property {{ start: { offset?: number }, end: { offset?: number } }} [position]
+ */
+
+/**
+ * What a name declared on the page refers to: the module it is imported from,
+ * or the expression the const it names is assigned.
+ *
+ * @typedef {{ module?: string, expression?: any }} Binding
+ */
+
+/**
+ * Everything a renderer needs from the page being processed.
+ *
+ * @typedef {object} MdxComponentContext
+ * @property {string} pageDir Absolute directory of the page source, used to resolve its imports.
+ * @property {string} siteDir Absolute path the `@site` import alias points at.
+ * @property {Map<string, Binding>} bindings Local name -> import/const declared on the page.
+ * @property {string} docsRootUrl
+ * @property {(path: string) => string | undefined} emittedAssetUrl URL of the build's copy of a file the page embeds.
+ * @property {(path: string) => string | undefined} repositoryFileUrl URL of a file of the site as it sits in the repository.
+ * @property {Set<string>} linkedAssets Assets already linked from this page, so an embed and the link next to it do not both appear.
+ * @property {(node: MdastNode) => string} textOf
+ * @property {(depth: number, text: string) => void} addHeading
+ * @property {(path: string) => string} renderPartial Cleans an imported .mdx/.md partial and returns its Markdown.
+ * @property {(message: string) => void} warn
+ */
+
+/**
+ * How a component contributes to the page. `text` replaces the whole element
+ * and drops its children; `before`/`after` replace the tags and keep them.
+ *
+ * @typedef {{ text?: string, before?: string, after?: string }} ComponentReplacement
+ */
+
+// ---------------------------------------------------------------------------
+// Static evaluation of component props and `{expression}` children
+// ---------------------------------------------------------------------------
+
+// Calls whose argument is the value we want: `useBaseUrl('/img/x.svg')` is a
+// site-absolute path, `require('!!raw-loader!./x.js')` a module we resolve like
+// an import.
+const PASSTHROUGH_CALLS = new Set(['useBaseUrl', 'require']);
+
+/**
+ * @param {any} node
+ * @param {MdxComponentContext} ctx
+ * @returns {any}
+ */
+function evaluateTemplate(node, ctx) {
+	// A template with substitutions is assembled at runtime; only the literal
+	// ones are content we can reproduce.
+	if (node.expressions.length > 0) {
+		return undefined;
+	}
+	return node.quasis.map((/** @type {any} */ quasi) => quasi.value.cooked ?? '').join('');
+}
+
+/**
+ * @param {any} node
+ * @param {MdxComponentContext} ctx
+ * @returns {any[]}
+ */
+function evaluateArray(node, ctx) {
+	const values = [];
+	for (const element of node.elements) {
+		const value = evaluateExpression(element, ctx);
+		if (value !== undefined) {
+			values.push(value);
+		}
+	}
+	return values;
+}
+
+/**
+ * @param {any} node
+ * @param {MdxComponentContext} ctx
+ * @returns {Record<string, any>}
+ */
+function evaluateObject(node, ctx) {
+	/** @type {Record<string, any>} */
+	const result = {};
+	for (const property of node.properties) {
+		if (property.type !== 'Property' || property.computed === true) {
+			continue;
+		}
+		const key = propertyKey(property.key);
+		const value = evaluateExpression(property.value, ctx);
+		if (key !== undefined && value !== undefined) {
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+/**
+ * `require('./x.html').default`: the interop wrapper around an asset import,
+ * where the value we want is the module itself.
+ *
+ * @param {any} node
+ * @param {MdxComponentContext} ctx
+ * @returns {any}
+ */
+function evaluateMember(node, ctx) {
+	if (node.computed === true || node.property?.type !== 'Identifier' || node.property.name !== 'default') {
+		return undefined;
+	}
+	return evaluateExpression(node.object, ctx);
+}
+
+/**
+ * @param {any} node
+ * @param {MdxComponentContext} ctx
+ * @returns {any}
+ */
+function evaluateCall(node, ctx) {
+	if (node.callee?.type !== 'Identifier' || !PASSTHROUGH_CALLS.has(node.callee.name)) {
+		return undefined;
+	}
+	const argument = (node.arguments ?? [])[0];
+	if (node.callee.name === 'require' && argument?.type === 'Literal' && typeof argument.value === 'string') {
+		return resolveModule(argument.value, ctx);
+	}
+	return evaluateExpression(argument, ctx);
+}
+
+/** @type {Record<string, (node: any, ctx: MdxComponentContext) => any>} */
+const EXPRESSION_EVALUATORS = {
+	Literal: node => (node.value === undefined ? undefined : node.value),
+	TemplateLiteral: evaluateTemplate,
+	ArrayExpression: evaluateArray,
+	ObjectExpression: evaluateObject,
+	Identifier: (node, ctx) => resolveBinding(node.name, ctx),
+	MemberExpression: evaluateMember,
+	CallExpression: evaluateCall,
+};
+
+/**
+ * Evaluates the literal parts of an expression. Anything dynamic (JSX icons,
+ * CSS-module lookups, function calls we don't know) yields `undefined` and is
+ * simply left out of the rendered Markdown.
+ *
+ * @param {any} node
+ * @param {MdxComponentContext} ctx
+ * @returns {any}
+ */
+function evaluateExpression(node, ctx) {
+	const evaluate = node === undefined || node === null ? undefined : EXPRESSION_EVALUATORS[node.type];
+	return evaluate === undefined ? undefined : evaluate(node, ctx);
+}
+
+/**
+ * @param {any} key
+ * @returns {string | undefined}
+ */
+function propertyKey(key) {
+	if (key?.type === 'Identifier') {
+		return key.name;
+	}
+	if (key?.type === 'Literal') {
+		return typeof key.value === 'string' ? key.value : undefined;
+	}
+	return undefined;
+}
+
+/**
+ * A name used as a prop (or as a `{child}`) is either a const declared on the
+ * page — `export const example = \`…\`` — or an import of content that sits next
+ * to it, so both are resolved to the value they stand for.
+ *
+ * @param {string} name
+ * @param {MdxComponentContext} ctx
+ * @returns {any}
+ */
+function resolveBinding(name, ctx) {
+	const binding = ctx.bindings.get(name);
+	if (binding === undefined) {
+		return undefined;
+	}
+	if (binding.module === undefined) {
+		return evaluateExpression(binding.expression, ctx);
+	}
+	return resolveModule(binding.module, ctx);
+}
+
+// Webpack inline-loader syntax: `!!raw-loader!./x.js` imports the file as text,
+// `!!file-loader!./x.html` as an emitted URL. Only the path after the loaders
+// identifies the file.
+const INLINE_LOADER = /^!!?([\w-]+!)+/;
+
+/**
+ * Reads the content a module specifier stands for: the text of a raw-loaded
+ * file, or a parsed JSON table. Anything else (a real JS module, a stylesheet)
+ * has no content we can put in Markdown.
+ *
+ * @param {string} specifier
+ * @param {MdxComponentContext} ctx
+ * @returns {any}
+ */
+function resolveModule(specifier, ctx) {
+	const path = specifier.replace(INLINE_LOADER, '');
+	const isRawText = /^!!?raw-loader!/.test(specifier);
+	// `!!file-loader!./demo.html` publishes the file and hands the page its URL,
+	// so what the import stands for is the file itself, not its text.
+	if (INLINE_LOADER.test(specifier) && !isRawText) {
+		return { asset: resolveSpecifier(path, ctx) };
+	}
+	if (!isRawText && !path.endsWith('.json')) {
+		return undefined;
+	}
+	const content = readFirstExisting(resolveSpecifier(path, ctx));
+	if (content === undefined) {
+		ctx.warn(`could not read ${specifier}`);
+		return undefined;
+	}
+	if (isRawText) {
+		return content;
+	}
+	try {
+		return JSON.parse(content);
+	} catch (error) {
+		ctx.warn(`could not parse ${specifier}: ${/** @type {Error} */ (error).message}`);
+		return undefined;
+	}
+}
+
+// An import can leave the extension to the bundler
+// (`!!raw-loader!@site/src/components/x`), so the file is looked for the way
+// webpack would resolve it.
+const IMPLIED_EXTENSIONS = ['', '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.vue', '.json'];
+
+/**
+ * @param {string} path
+ * @returns {string | undefined}
+ */
+function readFirstExisting(path) {
+	for (const extension of IMPLIED_EXTENSIONS) {
+		try {
+			return readFileSync(`${path}${extension}`, 'utf-8');
+		} catch {
+			continue;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Resolves a module specifier used by a page to an absolute path. Only the
+ * relative form and the `@site` alias can point at content we own.
+ *
+ * @param {string} specifier
+ * @param {MdxComponentContext} ctx
+ * @returns {string}
+ */
+function resolveSpecifier(specifier, ctx) {
+	if (specifier.startsWith('@site/')) {
+		return join(ctx.siteDir, specifier.slice('@site/'.length));
+	}
+	return isAbsolute(specifier) ? specifier : join(ctx.pageDir, specifier);
+}
+
+/**
+ * @param {MdastNode} node
+ * @param {MdxComponentContext} ctx
+ * @returns {Record<string, any>}
+ */
+function readProps(node, ctx) {
+	/** @type {Record<string, any>} */
+	const props = {};
+	for (const attribute of node.attributes ?? []) {
+		if (attribute.type !== 'mdxJsxAttribute' || attribute.name === undefined) {
+			continue;
+		}
+		const value = attribute.value;
+		if (value === null || value === undefined) {
+			props[attribute.name] = true; // boolean shorthand, e.g. `chart`
+		} else if (typeof value === 'string') {
+			props[attribute.name] = value;
+		} else {
+			props[attribute.name] = evaluateExpression(value.data?.estree?.body[0]?.expression, ctx);
+		}
+	}
+	return props;
+}
+
+/**
+ * @param {any} value
+ * @returns {string | undefined}
+ */
+function asString(value) {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Code blocks
+// ---------------------------------------------------------------------------
+
+// Comments the site uses to style a code sample (see the `magicComments`
+// configuration and the enhanced-codeblock plugin). They mark up the rendered
+// block and are not part of the sample itself. The lines they mark stay: the
+// highlighted ones are shown as they are, and the hidden ones are one click
+// away behind the "Show all code" toggle.
+const MAGIC_COMMENT_NAMES = [
+	'highlight-next-line', 'highlight-start', 'highlight-end',
+	'highlight-fade-start', 'highlight-fade-end', 'highlight-fade',
+	'hide-start', 'hide-end', 'hide-line',
+];
+
+const MAGIC_COMMENT_PATTERN = `(?:\\/\\/|\\/\\*|<!--|#)[ \\t]*(?:${MAGIC_COMMENT_NAMES.join('|')})[ \\t]*(?:\\*\\/|-->)?`;
+
+// `delete-start` … `delete-end` marks code the site strips before showing the
+// block (see `removeUnwantedLines`), so it never reaches a reader.
+const DELETED_SECTION = /^[^\n]*\bdelete-start\b[\s\S]*?\bdelete-end\b[^\n]*\n?/gm;
+
+// `remove-*` marks the sample's scaffolding — the file's title comment, a type
+// annotation the live example needs. Unlike `hide-*`, the site has no way to
+// reveal it (`.code-block-remove-line` is `display: none` with no counterpart
+// to the toggle), so it is not part of the sample a reader ever sees.
+const MARKER_ONLY = (/** @type {string} */ name) =>
+	new RegExp(`^[ \\t]*(?:\\/\\/|\\/\\*|<!--|#)[ \\t]*${name}[ \\t]*(?:\\*\\/|-->)?[ \\t]*$`);
+const REMOVE_START = MARKER_ONLY('remove-start');
+const REMOVE_END = MARKER_ONLY('remove-end');
+const REMOVE_LINE = MARKER_ONLY('remove-line');
+const TRAILING_REMOVE_LINE = /(?:\/\/|\/\*|<!--|#)[ \t]*remove-line\b/;
+
+/**
+ * Drops the lines the site removes from a sample. A marker on a line of its own
+ * takes the line that follows it — the line it marks — with it; one at the end
+ * of a line of code takes that line, the way the magic comments are read.
+ *
+ * @param {string} code
+ * @returns {string}
+ */
+function dropRemovedLines(code) {
+	const lines = code.split('\n');
+	/** @type {string[]} */
+	const kept = [];
+	let inRemovedSection = false;
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (REMOVE_START.test(line)) {
+			inRemovedSection = true;
+		} else if (REMOVE_END.test(line)) {
+			inRemovedSection = false;
+		} else if (inRemovedSection) {
+			continue;
+		} else if (REMOVE_LINE.test(line)) {
+			index += 1;
+		} else if (!TRAILING_REMOVE_LINE.test(line)) {
+			kept.push(line);
+		}
+	}
+	return kept.join('\n');
+}
+
+/** @type {Record<string, string>} */
+const LIGHT_THEME_COLORS = themeColors.LIGHT;
+const THEME_COLOR_NAMES = Object.keys(LIGHT_THEME_COLORS);
+
+/**
+ * Cleans a code sample the way the site does before showing it: drops the
+ * sections marked as deleted and the lines marked as removed, strips the magic
+ * comments that only style the rendered block, and — for the samples rendered
+ * next to a live chart — substitutes the colour constants with their values.
+ *
+ * @param {string} code
+ * @param {boolean} replaceThemeConstants
+ * @returns {string}
+ */
+export function cleanCodeSample(code, replaceThemeConstants) {
+	let result = code.replace(DELETED_SECTION, '');
+	if (replaceThemeConstants) {
+		// The light palette stands in for both themes, the same way a themed
+		// image is exported in its light variant only.
+		for (const name of THEME_COLOR_NAMES) {
+			// Bounded, so a longer identifier that merely contains a colour name
+			// (`CHART_BACKGROUND_RGB_COLOR`) is not rewritten from the inside out.
+			result = result.replace(new RegExp(`\\b${name}\\b`, 'g'), `'${LIGHT_THEME_COLORS[name]}'`);
+		}
+	}
+	const markerOnly = new RegExp(`^[ \\t]*${MAGIC_COMMENT_PATTERN}[ \\t]*$`);
+	const marker = new RegExp(MAGIC_COMMENT_PATTERN, 'g');
+	return dropRemovedLines(result)
+		.split('\n')
+		// A marker on a line of its own goes with the line, so the sample keeps
+		// its shape; one at the end of a line of code goes on its own.
+		.filter((/** @type {string} */ line) => !markerOnly.test(line))
+		.map((/** @type {string} */ line) => line.replace(marker, '').replace(/[ \t]+$/, ''))
+		.join('\n');
+}
+
+// A fence long enough to hold the sample, so a code block that itself contains
+// a fenced block (the HTML samples embed Markdown-free code, but a Vue file can
+// contain anything) is not cut short.
+/**
+ * @param {string} code
+ * @returns {string}
+ */
+function fenceFor(code) {
+	const longest = (code.match(/^[ \t]*(`{3,})/gm) ?? []).reduce(
+		(/** @type {number} */ max, /** @type {string} */ match) => Math.max(max, match.trim().length),
+		0
+	);
+	return '`'.repeat(Math.max(3, longest + 1));
+}
+
+/**
+ * `<CodeBlock className="language-js">{example}</CodeBlock>` — the sample lives
+ * in a const or an imported file, so the tag is replaced by a fenced block
+ * holding the code it displays.
+ *
+ * @param {Record<string, any>} props
+ * @param {MdastNode} node
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+function renderCodeBlock(props, node, ctx) {
+	const code = codeOf(node, ctx);
+	if (code === undefined) {
+		ctx.warn('CodeBlock: could not resolve the code it shows');
+		return null;
+	}
+	const language = languageOf(props);
+	const cleaned = cleanCodeSample(code, props.replaceThemeConstants === true).trim();
+	const fence = fenceFor(cleaned);
+	// A `chartOnly` block is shown on the page as a live chart with its code
+	// hidden. The chart cannot survive the export, so its code stands in for it,
+	// introduced for what it is — the page's own text promises a picture.
+	const lead = props.chartOnly === true ? '_Source of the interactive example shown on this page:_\n\n' : '';
+	return { text: `\n\n${lead}${fence}${language}\n${cleaned}\n${fence}\n\n` };
+}
+
+/**
+ * @param {MdastNode} node
+ * @param {MdxComponentContext} ctx
+ * @returns {string | undefined}
+ */
+function codeOf(node, ctx) {
+	for (const child of node.children ?? []) {
+		if (child.type === 'mdxFlowExpression' || child.type === 'mdxTextExpression') {
+			const value = evaluateExpression(child.data?.estree?.body[0]?.expression, ctx);
+			if (typeof value === 'string') {
+				return value;
+			}
+		}
+	}
+	// A block written with its code inline (rather than passed as a value).
+	const text = ctx.textOf(node);
+	return text.trim().length > 0 ? text : undefined;
+}
+
+/**
+ * @param {Record<string, any>} props
+ * @returns {string}
+ */
+function languageOf(props) {
+	const className = asString(props.className) ?? '';
+	const match = /language-([\w-]+)/.exec(className);
+	return match === null ? '' : match[1];
+}
+
+// ---------------------------------------------------------------------------
+// Component renderers
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Record<string, any>} props
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+function renderCardLinkList(props, ctx) {
+	const items = props.items;
+	if (!Array.isArray(items)) {
+		ctx.warn('CardLinkList: could not resolve its items');
+		return null;
+	}
+	const lines = [];
+	for (const item of items) {
+		if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+			continue;
+		}
+		const href = asString(item.href);
+		const title = asString(item.title);
+		if (href === undefined || title === undefined) {
+			continue;
+		}
+		const description = asString(item.description);
+		lines.push(`- [${title}](${href})${description === undefined ? '' : ` - ${description}`}`);
+	}
+	if (lines.length === 0) {
+		ctx.warn('CardLinkList: none of its items could be resolved');
+		return null;
+	}
+	return { text: `\n\n${lines.join('\n')}\n\n` };
+}
+
+/**
+ * Images are occasionally written as JSX, which the source cleaning would drop
+ * along with the tag.
+ *
+ * @param {Record<string, any>} props
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+function renderImage(props, ctx) {
+	const src = asString(props.src);
+	if (src === undefined) {
+		return null;
+	}
+	return { text: `\n\n![${asString(props.alt) ?? ''}](${absoluteUrl(src, ctx)})\n\n` };
+}
+
+/**
+ * The tutorials show each step as a runnable page inside an iframe. That page is
+ * published with the site, so the embed becomes a link to it — the one thing a
+ * reader of the Markdown can still follow.
+ *
+ * @param {Record<string, any>} props
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+function renderIframe(props, ctx) {
+	const url = embeddedUrl(props.src, ctx);
+	if (url === undefined) {
+		return { text: '' };
+	}
+	ctx.linkedAssets.add(url);
+	return { text: `\n\n[${asString(props.title) ?? 'Interactive example'}](${url})\n\n` };
+}
+
+/**
+ * A link written as JSX keeps its target only if that target resolves. The
+ * "View in a new window" link next to an embedded example points at the very
+ * page the embed above it already links to, and its label says nothing on its
+ * own, so it goes rather than repeating the link.
+ *
+ * @param {Record<string, any>} props
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+function renderAnchor(props, ctx) {
+	const href = asString(props.href);
+	if (href !== undefined && /^(https?:|\/|#)/.test(href)) {
+		return { before: '[', after: `](${absoluteUrl(href, ctx)})` };
+	}
+	const url = embeddedUrl(props.href, ctx);
+	if (url === undefined || ctx.linkedAssets.has(url)) {
+		return { text: '' };
+	}
+	ctx.linkedAssets.add(url);
+	return { before: '[', after: `](${url})` };
+}
+
+/**
+ * @param {Record<string, any>} props
+ * @returns {ComponentReplacement | null}
+ */
+function renderTabItem(props) {
+	const label = asString(props.label);
+	// The label is the only part of a tab that lives outside its children.
+	return label === undefined ? null : { before: `\n\n**${label}**\n\n` };
+}
+
+/**
+ * The summary of a collapsed section is its title; in Markdown it reads as one.
+ *
+ * @param {MdastNode} node
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+function renderSummary(node, ctx) {
+	const text = ctx.textOf(node).replace(/\s+/g, ' ').trim();
+	return text.length === 0 ? { text: '' } : { text: `\n\n**${text}**\n\n` };
+}
+
+/**
+ * Site-absolute paths (`/img/x.png`) are resolved against the documentation
+ * root so the Markdown works wherever it is read.
+ *
+ * @param {string} path
+ * @param {MdxComponentContext} ctx
+ * @returns {string}
+ */
+function absoluteUrl(path, ctx) {
+	return path.startsWith('/') ? `${ctx.docsRootUrl}${path}` : path;
+}
+
+/**
+ * The URL an embedded example is reachable at: a runnable page the build
+ * publishes under a content-hashed name, or a plain URL written as-is.
+ *
+ * @param {any} value
+ * @param {MdxComponentContext} ctx
+ * @returns {string | undefined}
+ */
+function embeddedUrl(value, ctx) {
+	if (typeof value === 'string') {
+		return /^(https?:|\/)/.test(value) ? absoluteUrl(value, ctx) : undefined;
+	}
+	const path = value === null || typeof value !== 'object' ? undefined : value.asset;
+	if (typeof path !== 'string') {
+		return undefined;
+	}
+	// The build publishes most embedded files verbatim, which is what lets them
+	// be found at all. The few it rewrites on the way out (it minifies the
+	// JavaScript ones) are linked in the repository instead.
+	const url = ctx.emittedAssetUrl(path) ?? ctx.repositoryFileUrl(path);
+	if (url === undefined) {
+		ctx.warn(`no published copy of ${path}; the example embedded from it is left out`);
+	}
+	return url;
+}
+
+/** @type {Record<string, (props: Record<string, any>, node: MdastNode, ctx: MdxComponentContext) => ComponentReplacement | null>} */
+const RENDERERS = {
+	CodeBlock: renderCodeBlock,
+	CardLinkList: (props, _node, ctx) => renderCardLinkList(props, ctx),
+	TabItem: props => renderTabItem(props),
+	summary: (_props, node, ctx) => renderSummary(node, ctx),
+	img: (props, _node, ctx) => renderImage(props, ctx),
+	a: (props, _node, ctx) => renderAnchor(props, ctx),
+	iframe: (props, _node, ctx) => renderIframe(props, ctx),
+};
+
+// Components that draw nothing a reader of the Markdown could use: the live
+// chart demos (a canvas) and the banner that depends on which version the
+// reader has selected. Listing them keeps the unhandled-component warning
+// meaningful.
+// The two list components on the tutorials landing page are also left out:
+// each one renders the links of one sidebar category, and every page they
+// would list is already in `llms.txt` and `docs_map.md` under that category.
+const NO_CONTENT_COMPONENTS = new Set([
+	'HowToList',
+	'ExamplesList',
+	'Chart',
+	'ChartContainer',
+	'ThemedChart',
+	'BrowserOnly',
+	'VersionWarningAdmonition',
+]);
+
+const PARTIAL_EXTENSIONS = /\.mdx?$/;
+
+/**
+ * Returns the Markdown for a JSX element, or `null` to let the caller fall back
+ * to unwrapping it (dropping the tags, keeping the children).
+ *
+ * @param {MdastNode} node
+ * @param {MdxComponentContext} ctx
+ * @returns {ComponentReplacement | null}
+ */
+export function renderMdxComponent(node, ctx) {
+	const name = node.name;
+	if (name === null || name === undefined) {
+		return null;
+	}
+
+	// A component imported from an .mdx/.md file is a content partial: its text
+	// is part of the page a reader sees, so it is inlined here.
+	const specifier = ctx.bindings.get(name)?.module;
+	if (specifier !== undefined && PARTIAL_EXTENSIONS.test(specifier)) {
+		const partial = ctx.renderPartial(resolveSpecifier(specifier, ctx)).trim();
+		return partial.length > 0 ? { text: `\n\n${partial}\n\n` } : { text: '' };
+	}
+
+	if (NO_CONTENT_COMPONENTS.has(name)) {
+		return { text: '' };
+	}
+
+	const props = readProps(node, ctx);
+	const renderer = RENDERERS[name];
+	if (renderer !== undefined) {
+		return renderer(props, node, ctx);
+	}
+
+	// A component with children still contributes them; one without children
+	// disappears silently, which is exactly the loss this module exists to stop.
+	// (Plain HTML tags are left to the generic unwrapping.)
+	if (/^[A-Z]/.test(name) && (node.children ?? []).length === 0) {
+		ctx.warn(`no Markdown for <${name}>; its content is missing from the export`);
+	}
+	return null;
+}
+
+/**
+ * @param {any} statement
+ * @param {Map<string, Binding>} bindings
+ */
+function collectImportBindings(statement, bindings) {
+	const source = statement.source?.value;
+	if (typeof source !== 'string') {
+		return;
+	}
+	for (const specifier of statement.specifiers ?? []) {
+		if (specifier.local?.name !== undefined) {
+			bindings.set(specifier.local.name, { module: source });
+		}
+	}
+}
+
+/**
+ * @param {any} statement
+ * @param {Map<string, Binding>} bindings
+ */
+function collectConstBindings(statement, bindings) {
+	const declaration = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+	if (declaration?.type !== 'VariableDeclaration') {
+		return;
+	}
+	for (const declarator of declaration.declarations ?? []) {
+		if (declarator.id?.type === 'Identifier' && declarator.init !== null) {
+			bindings.set(declarator.id.name, { expression: declarator.init });
+		}
+	}
+}
+
+/**
+ * Collects the names a page declares — every ESM import, and the expression
+ * behind every top-level const — so a prop or a `{child}` referring to one can
+ * be resolved to its value.
+ *
+ * @param {MdastNode} tree
+ * @returns {Map<string, Binding>}
+ */
+export function collectBindings(tree) {
+	/** @type {Map<string, Binding>} */
+	const bindings = new Map();
+	for (const node of tree.children ?? []) {
+		if (node.type !== 'mdxjsEsm') {
+			continue;
+		}
+		for (const statement of node.data?.estree?.body ?? []) {
+			if (statement.type === 'ImportDeclaration') {
+				collectImportBindings(statement, bindings);
+			} else {
+				collectConstBindings(statement, bindings);
+			}
+		}
+	}
+	return bindings;
+}
+
+/**
+ * Absolute directory of a page source (`@site/versioned_docs/version-5.2/a.md`),
+ * used to resolve the relative imports on that page.
+ *
+ * @param {string} source
+ * @param {string} siteDir
+ * @returns {string}
+ */
+export function pageDirectory(source, siteDir) {
+	return dirname(join(siteDir, source.replace(/^@site[\\/]?/, '')));
+}

--- a/website/plugins/docs-markdown/index.js
+++ b/website/plugins/docs-markdown/index.js
@@ -1,0 +1,1329 @@
+// @ts-check
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, posix, relative as relativePath } from 'node:path';
+
+import logger from '@docusaurus/logger';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { mdxFromMarkdown } from 'mdast-util-mdx';
+import { mdxjs } from 'micromark-extension-mdxjs';
+
+import { cleanCodeSample, collectBindings, pageDirectory, renderMdxComponent } from './components.js';
+
+/**
+ * @typedef {import('./components.js').MdastNode} MdastNode
+ * @typedef {import('./components.js').ComponentReplacement} ComponentReplacement
+ * @typedef {import('./components.js').MdxComponentContext} MdxComponentContext
+ */
+
+const DOCS_PLUGIN_NAME = 'docusaurus-plugin-content-docs';
+
+/**
+ * The parts of the site that are exported as Markdown, in the order they appear
+ * in the map. Each one names the content-docs instance it comes from, the
+ * sidebar that gives its structure (the API reference has its own
+ * `typedocSidebar`, which we intentionally ignore), and how its version is
+ * chosen: the documentation is versioned and only the released version is
+ * exported, while the tutorials have a single version.
+ *
+ * @typedef {object} ExportedSection
+ * @property {string} pluginId
+ * @property {string} sidebar
+ * @property {string} heading
+ * @property {(version: LoadedVersion) => boolean} pickVersion
+ */
+
+/** @type {ExportedSection[]} */
+const EXPORTED_SECTIONS = [
+	{
+		pluginId: 'default',
+		sidebar: 'docsSidebar',
+		heading: 'Documentation',
+		pickVersion: version => version.isLast === true,
+	},
+	{
+		pluginId: 'tutorials',
+		sidebar: 'tutorialsSidebar',
+		heading: 'Tutorials',
+		pickVersion: version => version.versionName === 'current',
+	},
+];
+
+// The API reference is generated from the type definitions by TypeDoc, page per
+// symbol. Those pages are left out of the export; the definitions they are
+// generated from are published whole instead (see below), which is both smaller
+// and more complete for a machine reader.
+const API_ROUTE_SEGMENT = 'api';
+
+// TypeScript definitions of the released version, downloaded by the site config
+// and used to generate the API reference. Copied to the site root under a name
+// that says what it is.
+const TYPE_DEFINITIONS_FILE = 'lightweight-charts.d.ts';
+const TYPINGS_CACHE_DIR = '.previous-typings-cache';
+
+// The branch the repository serves its files from, for the few embedded files
+// the build rewrites and so cannot be linked in the site itself.
+const DEFAULT_BRANCH = 'master';
+
+/**
+ * Public site root (e.g. `https://tradingview.github.io/lightweight-charts`),
+ * derived from the build config so local builds emit their own URLs rather than
+ * production ones.
+ *
+ * @param {string} siteUrl
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+function siteRootUrl(siteUrl, baseUrl) {
+	return `${siteUrl.replace(/\/+$/, '')}${baseUrl.replace(/\/+$/, '')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal shapes of the parts of the content-docs plugin output we depend on.
+// (The full types live in @docusaurus/plugin-content-docs; we only need these.)
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} DocMetadata
+ * @property {string} id
+ * @property {string} title
+ * @property {string} source `@site/versioned_docs/version-5.2/panes.md`
+ * @property {string} permalink `/lightweight-charts/docs/panes`
+ */
+
+/**
+ * @typedef {object} LoadedVersion
+ * @property {string} versionName
+ * @property {boolean} [isLast]
+ * @property {string} contentPath Absolute path of the folder the version's pages are read from.
+ * @property {DocMetadata[]} docs
+ * @property {Record<string, SidebarItem[]>} sidebars
+ */
+
+/** @typedef {{ type: string, id?: string, label?: string, items?: SidebarItem[], link?: { type: string, id?: string } }} SidebarItem */
+
+/**
+ * In-memory model of a sidebar, resolved to titles/permalinks in real order.
+ *
+ * @typedef {{ kind: 'doc', title: string, permalink: string, source: string, contentRoot: string }} DocNode
+ * @typedef {{ kind: 'category', label: string, children: DocsNode[] }} CategoryNode
+ * @typedef {DocNode | CategoryNode} DocsNode
+ */
+
+/** @typedef {{ depth: number, text: string }} Heading */
+
+/**
+ * A range of the source to drop, optionally replaced by generated Markdown
+ * (the content an MDX component renders).
+ *
+ * @typedef {{ start: number, end: number, text?: string }} Edit
+ */
+
+/**
+ * @param {string} permalink
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+function toRoute(permalink, baseUrl) {
+	let route = permalink;
+	if (baseUrl !== '/' && route.startsWith(baseUrl)) {
+		route = route.slice(baseUrl.length);
+	}
+	return route.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * @param {string} permalink
+ * @param {string} baseUrl
+ * @returns {boolean}
+ */
+function isApiPage(permalink, baseUrl) {
+	return toRoute(permalink, baseUrl).split('/').includes(API_ROUTE_SEGMENT);
+}
+
+/**
+ * The doc-root-relative, extension-less form of a doc's `source`
+ * (`@site/tutorials/a/b.mdx` -> `tutorials/a/b`). Used to map a resolved
+ * relative link back to the target page's permalink.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+function sourceKey(source) {
+	return source.replace(/^@site[\\/]?/, '').replace(/\\/g, '/').replace(/\.mdx?$/, '');
+}
+
+/**
+ * @param {DocMetadata} doc
+ * @param {string} baseUrl
+ * @param {string} contentRoot
+ * @returns {DocNode | null}
+ */
+function toDocNode(doc, baseUrl, contentRoot) {
+	if (isApiPage(doc.permalink, baseUrl)) {
+		return null;
+	}
+	return { kind: 'doc', title: doc.title, permalink: doc.permalink, source: doc.source, contentRoot };
+}
+
+/**
+ * @param {SidebarItem[]} items
+ * @param {Map<string, DocMetadata>} docsById
+ * @param {string} baseUrl
+ * @param {string} contentRoot
+ * @returns {DocsNode[]}
+ */
+function buildDocsNodes(items, docsById, baseUrl, contentRoot) {
+	/** @type {DocsNode[]} */
+	const nodes = [];
+	for (const item of items) {
+		const node = item.type === 'category'
+			? buildCategoryNode(item, docsById, baseUrl, contentRoot)
+			: buildDocItemNode(item, docsById, baseUrl, contentRoot);
+		if (node !== null) {
+			nodes.push(node);
+		}
+	}
+	return nodes;
+}
+
+/**
+ * @param {SidebarItem} item
+ * @param {Map<string, DocMetadata>} docsById
+ * @param {string} baseUrl
+ * @param {string} contentRoot
+ * @returns {CategoryNode | null}
+ */
+function buildCategoryNode(item, docsById, baseUrl, contentRoot) {
+	if ((item.label ?? '').toLowerCase() === API_ROUTE_SEGMENT) {
+		return null;
+	}
+	const children = buildDocsNodes(item.items ?? [], docsById, baseUrl, contentRoot);
+	// Surface the category's own landing page as its first entry, so it is both
+	// mapped and written out.
+	const landingPage = item.link?.type === 'doc' && item.link.id !== undefined ? docsById.get(item.link.id) : undefined;
+	const landingNode = landingPage === undefined ? null : toDocNode(landingPage, baseUrl, contentRoot);
+	if (landingNode !== null) {
+		children.unshift(landingNode);
+	}
+	return children.length === 0 ? null : { kind: 'category', label: item.label ?? '', children };
+}
+
+/**
+ * @param {SidebarItem} item
+ * @param {Map<string, DocMetadata>} docsById
+ * @param {string} baseUrl
+ * @param {string} contentRoot
+ * @returns {DocNode | null}
+ */
+function buildDocItemNode(item, docsById, baseUrl, contentRoot) {
+	if ((item.type !== 'doc' && item.type !== 'ref') || item.id === undefined) {
+		return null;
+	}
+	const doc = docsById.get(item.id);
+	return doc === undefined ? null : toDocNode(doc, baseUrl, contentRoot);
+}
+
+/**
+ * Pages that sit at the root of a sidebar (Getting started, Panes, iOS…) have
+ * no category of their own, and a page listed after a category would otherwise
+ * read as if it belonged to it. Hoisting them keeps every page under the
+ * heading it actually belongs to.
+ *
+ * @param {DocsNode[]} nodes
+ * @returns {DocsNode[]}
+ */
+function hoistRootDocs(nodes) {
+	return [
+		...nodes.filter((/** @type {DocsNode} */ node) => node.kind === 'doc'),
+		...nodes.filter((/** @type {DocsNode} */ node) => node.kind === 'category'),
+	];
+}
+
+/**
+ * @param {DocsNode[]} nodes
+ * @param {DocNode[]} accumulator
+ */
+function collectDocNodes(nodes, accumulator) {
+	for (const node of nodes) {
+		if (node.kind === 'category') {
+			collectDocNodes(node.children, accumulator);
+		} else {
+			accumulator.push(node);
+		}
+	}
+}
+
+/**
+ * Drops nodes whose page was not actually written, so the map never links to a
+ * missing .md.
+ *
+ * @param {DocsNode[]} nodes
+ * @param {Set<string>} written
+ * @returns {DocsNode[]}
+ */
+function pruneToWritten(nodes, written) {
+	/** @type {DocsNode[]} */
+	const result = [];
+	for (const node of nodes) {
+		if (node.kind === 'category') {
+			const children = pruneToWritten(node.children, written);
+			if (children.length > 0) {
+				result.push({ kind: 'category', label: node.label, children });
+			}
+		} else if (written.has(node.permalink)) {
+			result.push(node);
+		}
+	}
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown / MDX cleaning
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} raw
+ * @returns {string}
+ */
+function stripFrontmatter(raw) {
+	const match = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/.exec(raw);
+	return match ? raw.slice(match[0].length) : raw;
+}
+
+const FENCED_BLOCK = /^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?^[ \t]*\1[^\n]*$/gm;
+
+/**
+ * Runs `transform` on the parts of `body` outside fenced code blocks (of any
+ * fence length), so code samples are never rewritten. Inline `code` spans are
+ * deliberately not protected: link labels are regularly written as
+ * ``[`method`](…)``, and treating the label as code would split it from its URL
+ * and leave the link unrewritten.
+ *
+ * @param {string} body
+ * @param {(segment: string) => string} transform
+ * @param {(block: string) => string} [transformBlock] Applied to each fenced block instead of keeping it verbatim.
+ * @returns {string}
+ */
+function transformOutsideFences(body, transform, transformBlock) {
+	const fence = new RegExp(FENCED_BLOCK.source, 'gm');
+	let result = '';
+	let lastIndex = 0;
+	let match = fence.exec(body);
+	while (match !== null) {
+		result += transform(body.slice(lastIndex, match.index));
+		result += transformBlock === undefined ? match[0] : transformBlock(match[0]);
+		lastIndex = fence.lastIndex;
+		match = fence.exec(body);
+	}
+	return result + transform(body.slice(lastIndex));
+}
+
+const MDX_REMOVE_WHOLE = new Set(['mdxjsEsm', 'mdxFlowExpression', 'mdxTextExpression']);
+const MDX_JSX = new Set(['mdxJsxFlowElement', 'mdxJsxTextElement']);
+
+/**
+ * @param {MdastNode} node
+ * @returns {[number, number] | null}
+ */
+function nodeOffsets(node) {
+	const start = node.position?.start.offset;
+	const end = node.position?.end.offset;
+	return typeof start === 'number' && typeof end === 'number' ? [start, end] : null;
+}
+
+/**
+ * Text content of a node, ignoring MDX import/expression constructs so a
+ * heading's trailing `{#anchor}` (an mdxTextExpression) never leaks in.
+ *
+ * @param {MdastNode} node
+ * @returns {string}
+ */
+function nodeText(node) {
+	if (MDX_REMOVE_WHOLE.has(node.type)) {
+		return '';
+	}
+	if (typeof node.value === 'string') {
+		return node.value;
+	}
+	return (node.children ?? []).map(nodeText).join('');
+}
+
+/**
+ * @typedef {object} CleanupContext
+ * @property {string} source
+ * @property {Edit[]} edits
+ * @property {Heading[]} headings
+ * @property {MdxComponentContext} components
+ */
+
+/**
+ * Walks the MDX AST, collecting (a) the source ranges to delete — ESM imports,
+ * `{…}` expressions, and JSX tags (keeping their children) — together with the
+ * Markdown that replaces the components which draw their own content, and
+ * (b) the heading outline. Inline code and code blocks are never in the edit
+ * set, so generic type arguments like `Partial<Foo>` survive verbatim.
+ *
+ * @param {MdastNode} node
+ * @param {CleanupContext} ctx
+ */
+function collectCleanup(node, ctx) {
+	if (MDX_REMOVE_WHOLE.has(node.type)) {
+		const range = nodeOffsets(node);
+		if (range) {
+			ctx.edits.push({ start: range[0], end: range[1] });
+		}
+		return;
+	}
+	if (MDX_JSX.has(node.type)) {
+		collectJsxCleanup(node, ctx);
+		return;
+	}
+	if (node.type === 'heading' && typeof node.depth === 'number' && node.depth >= 2 && node.depth <= 4) {
+		const text = nodeText(node).replace(/\s+/g, ' ').trim();
+		if (text.length > 0) {
+			ctx.headings.push({ depth: node.depth, text });
+		}
+	}
+	for (const child of node.children ?? []) {
+		collectCleanup(child, ctx);
+	}
+}
+
+/**
+ * @param {MdastNode} node
+ * @param {CleanupContext} ctx
+ */
+function collectJsxCleanup(node, ctx) {
+	const outer = nodeOffsets(node);
+	if (outer === null) {
+		return;
+	}
+	const replacement = renderMdxComponent(node, ctx.components);
+	const children = node.children ?? [];
+	// Either the component draws its own Markdown, or it has no children a
+	// reader would see: both cases replace the element whole. (A renderer that
+	// only wraps children has nothing to wrap here, and its opening delimiter
+	// alone would corrupt the text.)
+	if (replacement?.text !== undefined || children.length === 0) {
+		ctx.edits.push({ start: outer[0], end: outer[1], text: replacement?.text });
+		return;
+	}
+	unwrapJsxElement(node, children, outer, replacement, ctx);
+}
+
+/**
+ * Drops the tags of a JSX element and keeps what they wrap.
+ *
+ * @param {MdastNode} node
+ * @param {MdastNode[]} children
+ * @param {[number, number]} outer
+ * @param {ComponentReplacement | null} replacement
+ * @param {CleanupContext} ctx
+ */
+function unwrapJsxElement(node, children, outer, replacement, ctx) {
+	const first = nodeOffsets(children[0]);
+	const last = nodeOffsets(children[children.length - 1]);
+	if (first) {
+		ctx.edits.push({ start: outer[0], end: first[0], text: replacement?.before }); // opening tag + attributes
+	}
+	if (last) {
+		ctx.edits.push({ start: last[1], end: outer[1], text: replacement?.after }); // closing tag
+	}
+	const nestedFrom = ctx.edits.length;
+	for (const child of children) {
+		collectCleanup(child, ctx);
+	}
+	// Content nested in a JSX block is usually indented to match the tags. Once
+	// the tags are gone that indentation turns lists into nested lists and
+	// paragraphs into code blocks, so it goes with them.
+	if (node.type === 'mdxJsxFlowElement' && first && last) {
+		collectDedentEdits(ctx, first[0], last[1], nestedFrom);
+	}
+}
+
+/**
+ * Leading whitespace of the line starting at `lineStart`, or null for a line
+ * that holds nothing else (a blank line has no indentation to speak of).
+ *
+ * @param {string} source
+ * @param {number} lineStart
+ * @param {number} limit
+ * @returns {number | null}
+ */
+function measureIndent(source, lineStart, limit) {
+	let index = lineStart;
+	while (index < limit && (source[index] === ' ' || source[index] === '\t')) {
+		index += 1;
+	}
+	if (index >= limit || source[index] === '\n' || source[index] === '\r') {
+		return null;
+	}
+	return index - lineStart;
+}
+
+/**
+ * Removes the indentation shared by every line of a JSX block's children. Only
+ * the common part goes, so the structure inside the block is preserved.
+ *
+ * Lines already claimed by an edit collected inside this block are ignored:
+ * their source is either replaced by generated Markdown or dropped, so their
+ * indentation says nothing about the text that will remain.
+ *
+ * @param {CleanupContext} ctx
+ * @param {number} from
+ * @param {number} to
+ * @param {number} nestedFrom
+ */
+function collectDedentEdits(ctx, from, to, nestedFrom) {
+	const nested = ctx.edits.slice(nestedFrom);
+	const isClaimed = (/** @type {number} */ offset) =>
+		nested.some((/** @type {Edit} */ edit) => offset >= edit.start && offset < edit.end);
+	/** @type {number[]} */
+	const lineStarts = [];
+	let common = Number.MAX_SAFE_INTEGER;
+	let newline = ctx.source.indexOf('\n', from);
+	while (newline !== -1 && newline + 1 < to) {
+		const lineStart = newline + 1;
+		const indent = measureIndent(ctx.source, lineStart, to);
+		if (indent !== null && !isClaimed(lineStart)) {
+			lineStarts.push(lineStart);
+			common = Math.min(common, indent);
+		}
+		newline = ctx.source.indexOf('\n', lineStart);
+	}
+	if (common === 0 || common === Number.MAX_SAFE_INTEGER) {
+		return;
+	}
+	for (const lineStart of lineStarts) {
+		ctx.edits.push({ start: lineStart, end: lineStart + common });
+	}
+}
+
+/**
+ * Edits are applied left to right; where two start together the widest wins, so
+ * a component's replacement swallows the edits collected inside it.
+ *
+ * @param {string} source
+ * @param {Edit[]} edits
+ * @returns {string}
+ */
+function applyEdits(source, edits) {
+	const sorted = edits.slice().sort((/** @type {Edit} */ a, /** @type {Edit} */ b) => a.start - b.start || b.end - a.end);
+	let result = '';
+	let cursor = 0;
+	for (const edit of sorted) {
+		if (edit.start < cursor) {
+			continue;
+		}
+		result += source.slice(cursor, edit.start) + (edit.text ?? '');
+		cursor = edit.end;
+	}
+	return result + source.slice(cursor);
+}
+
+/**
+ * @param {string} content
+ * @returns {MdastNode}
+ */
+function parseMdx(content) {
+	return /** @type {any} */ (fromMarkdown(content, {
+		extensions: [mdxjs()],
+		mdastExtensions: [mdxFromMarkdown()],
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// Link rewriting
+//
+// A page read on its own has no site around it, so every link has to become an
+// absolute URL: a link to another exported page points at that page's Markdown,
+// everything else (the API reference, other versions, images) at the site.
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} LinkContext
+ * @property {string} sourceDir Folder of the page source, e.g. `versioned_docs/version-5.2/plugins`.
+ * @property {string} contentRoot Root the version's pages are addressed from, e.g. `versioned_docs/version-5.2`.
+ * @property {string} routeDir Folder of the page's own route, e.g. `tutorials/react`.
+ * @property {Map<string, string>} permalinkBySourceKey Every doc, including the API pages, by source path.
+ * @property {Map<string, string>} permalinkByRoute Every documentation route, used to tell a link to a real page from one that has moved away.
+ * @property {Set<string>} exported Permalinks of the pages that have a `.md`.
+ * @property {string} baseUrl
+ * @property {string} docsRootUrl
+ * @property {(message: string) => void} warn
+ */
+
+/**
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function ancestorDirectories(dir) {
+	const directories = [];
+	let current = dir;
+	while (current !== '.' && current !== '/' && current.length > 0) {
+		directories.push(current);
+		current = posix.dirname(current);
+	}
+	return directories;
+}
+
+/**
+ * Resolves a link written as a file path against the page's source folder — the
+ * way Docusaurus itself resolves them — and returns the target's permalink.
+ * Most links are written with an extension (`../a/b.md`), but a few omit it or
+ * point at the folder of a landing page, so both forms are looked up.
+ *
+ * @param {string} pathPart
+ * @param {string[]} bases
+ * @param {LinkContext} ctx
+ * @returns {string | undefined}
+ */
+function resolveSourcePath(pathPart, bases, ctx) {
+	for (const base of bases) {
+		const key = posix
+			.normalize(posix.join(base, pathPart))
+			.replace(/\.mdx?$/, '')
+			.replace(/\/+$/, '');
+		const permalink = ctx.permalinkBySourceKey.get(key) ?? ctx.permalinkBySourceKey.get(`${key}/${posix.basename(key)}`);
+		if (permalink !== undefined) {
+			return permalink;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * @param {string} route
+ * @param {LinkContext} ctx
+ * @returns {string | undefined}
+ */
+function resolveRoute(route, ctx) {
+	const normalized = posix.normalize(route).replace(/^\/+/, '').replace(/\/+$/, '');
+	return ctx.permalinkByRoute.get(normalized);
+}
+
+/**
+ * @param {string} permalink
+ * @param {string} hash
+ * @param {LinkContext} ctx
+ * @returns {string}
+ */
+function toDocumentationUrl(permalink, hash, ctx) {
+	const route = toRoute(permalink, ctx.baseUrl);
+	// Only an exported page gets a `.md`; the API reference and the versions we
+	// do not export are linked as the pages they are.
+	return ctx.exported.has(permalink)
+		? `${ctx.docsRootUrl}/${route}.md${hash}`
+		: `${ctx.docsRootUrl}/${route}${hash}`;
+}
+
+/**
+ * Rewrites a single link target to an absolute URL, or returns null to leave it
+ * unchanged (external links, anchors, mail addresses).
+ *
+ * @param {string} target
+ * @param {LinkContext} ctx
+ * @returns {string | null}
+ */
+function rewriteTarget(target, ctx) {
+	if (/^(mailto:|tel:|#)/.test(target)) {
+		return null;
+	}
+	if (/^https?:/i.test(target)) {
+		// A link written as a full URL to this very site still has to become a
+		// Markdown link when it points at an exported page.
+		if (!target.startsWith(`${ctx.docsRootUrl}/`)) {
+			return null;
+		}
+		target = target.slice(ctx.docsRootUrl.length);
+	}
+	const hashIndex = target.indexOf('#');
+	const pathPart = hashIndex === -1 ? target : target.slice(0, hashIndex);
+	const hash = hashIndex === -1 ? '' : target.slice(hashIndex);
+	if (pathPart.length === 0) {
+		return null;
+	}
+
+	const permalink = pathPart.startsWith('/') ? resolveSitePath(pathPart, ctx) : resolveRelativePath(pathPart, ctx);
+	if (permalink !== undefined) {
+		return toDocumentationUrl(permalink, hash, ctx);
+	}
+	if (pathPart.startsWith('/')) {
+		// Images, downloadable files: not documentation pages, but still site
+		// paths that have to survive being read on their own.
+		return `${ctx.docsRootUrl}/${toSiteRoute(pathPart, ctx)}${hash}`;
+	}
+	ctx.warn(`could not resolve the link target ${target}; it is left as it was written`);
+	return null;
+}
+
+/**
+ * @param {string} pathPart
+ * @param {LinkContext} ctx
+ * @returns {string}
+ */
+function toSiteRoute(pathPart, ctx) {
+	return pathPart.replace(new RegExp(`^${ctx.baseUrl}`), '/').replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * @param {string} pathPart
+ * @param {LinkContext} ctx
+ * @returns {string | undefined}
+ */
+function resolveSitePath(pathPart, ctx) {
+	// Inside a version, a path is written from that version's own root:
+	// `/api/interfaces/IChartApi.md` is a file, not a site route.
+	const bySource = /\.mdx?$/.test(pathPart) ? resolveSourcePath(pathPart.slice(1), [ctx.contentRoot], ctx) : undefined;
+	return bySource ?? resolveRoute(toSiteRoute(pathPart, ctx), ctx);
+}
+
+/**
+ * A relative link is either a path to another page's source file, or a route
+ * relative to the current page's URL (`./advanced`, where the file is named
+ * `02-advanced.mdx`). Both readings are tried, the file one first.
+ *
+ * @param {string} pathPart
+ * @param {LinkContext} ctx
+ * @returns {string | undefined}
+ */
+function resolveRelativePath(pathPart, ctx) {
+	const bases = pathPart.startsWith('.') ? [ctx.sourceDir] : ancestorDirectories(ctx.sourceDir);
+	return resolveSourcePath(pathPart, bases, ctx) ?? resolveRoute(posix.join(ctx.routeDir, pathPart.replace(/\.mdx?$/, '')), ctx);
+}
+
+/**
+ * Images are rewritten alongside links: `![x](/img/y.png)` is just as unusable
+ * as a bare route once the Markdown is read outside the site.
+ *
+ * @param {string} body
+ * @param {LinkContext} ctx
+ * @returns {string}
+ */
+function rewriteInlineLinks(body, ctx) {
+	return body.replace(
+		/(!?)\[([^\]]+)\]\(([^)\s]+)(\s+"[^"]*")?\)/g,
+		(/** @type {string} */ match, /** @type {string} */ bang, /** @type {string} */ text, /** @type {string} */ url, /** @type {string | undefined} */ title) => {
+			const rewritten = rewriteTarget(url, ctx);
+			return rewritten === null ? match : `${bang}[${text}](${rewritten}${title ?? ''})`;
+		}
+	);
+}
+
+/**
+ * Reference-style link definitions (`[label]: url`) are line-structural, and
+ * their labels frequently contain inline code. This runs with fenced-only
+ * protection so an inline-code span in the label is not treated as code and does
+ * not split the label from its URL.
+ *
+ * @param {string} body
+ * @param {LinkContext} ctx
+ * @returns {string}
+ */
+function rewriteReferenceDefinitions(body, ctx) {
+	return body.replace(
+		/^(\[[^\]]+\]:\s+)(\S+)/gm,
+		(/** @type {string} */ match, /** @type {string} */ prefix, /** @type {string} */ url) => {
+			const rewritten = rewriteTarget(url, ctx);
+			return rewritten === null ? match : `${prefix}${rewritten}`;
+		}
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Page cleaning
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything about the page being cleaned that the MDX component renderers and
+ * the link rewriter need.
+ *
+ * @typedef {object} PageContext
+ * @property {string} source
+ * @property {string} contentRoot
+ * @property {string} permalink
+ * @property {string} siteDir
+ * @property {string} baseUrl
+ * @property {string} docsRootUrl
+ * @property {Map<string, string>} permalinkBySourceKey
+ * @property {Map<string, string>} permalinkByRoute
+ * @property {Set<string>} exported
+ * @property {(path: string) => string | undefined} emittedAssetUrl
+ * @property {(path: string) => string | undefined} repositoryFileUrl
+ * @property {Set<string>} linkedAssets
+ * @property {(message: string) => void} warn
+ */
+
+// A partial can pull in another partial; the limit only guards against a cycle.
+const MAX_PARTIAL_DEPTH = 3;
+
+/**
+ * Content partials (`import Warning from './_warning.mdx'`) are pages in their
+ * own right, so they go through the same cleaning before being inlined.
+ *
+ * @param {string} path
+ * @param {PageContext} page
+ * @param {number} depth
+ * @returns {string}
+ */
+function renderPartial(path, page, depth) {
+	if (depth >= MAX_PARTIAL_DEPTH) {
+		page.warn(`partials nested deeper than ${MAX_PARTIAL_DEPTH} levels: ${path}`);
+		return '';
+	}
+	try {
+		const raw = readFileSync(path, 'utf-8');
+		/** @type {PageContext} */
+		const partialPage = { ...page, source: `@site/${relativePath(page.siteDir, path)}` };
+		return cleanBody(raw, partialPage, depth + 1).body;
+	} catch (error) {
+		page.warn(`could not read partial ${path}: ${/** @type {Error} */ (error).message}`);
+		return '';
+	}
+}
+
+/**
+ * @param {MdastNode} tree
+ * @param {PageContext} page
+ * @param {Heading[]} headings
+ * @param {number} depth
+ * @returns {MdxComponentContext}
+ */
+function createComponentContext(tree, page, headings, depth) {
+	return {
+		pageDir: pageDirectory(page.source, page.siteDir),
+		siteDir: page.siteDir,
+		docsRootUrl: page.docsRootUrl,
+		bindings: collectBindings(tree),
+		emittedAssetUrl: page.emittedAssetUrl,
+		repositoryFileUrl: page.repositoryFileUrl,
+		linkedAssets: page.linkedAssets,
+		textOf: nodeText,
+		addHeading: (headingDepth, text) => {
+			if (headingDepth >= 2 && headingDepth <= 4) {
+				headings.push({ depth: headingDepth, text });
+			}
+		},
+		renderPartial: path => renderPartial(path, page, depth),
+		warn: page.warn,
+	};
+}
+
+/**
+ * @param {string} raw
+ * @param {PageContext} page
+ * @param {number} depth
+ * @returns {{ body: string, headings: Heading[] }}
+ */
+function cleanBody(raw, page, depth) {
+	// HTML comments and `{#anchor}` heading IDs are not valid MDX expressions and
+	// would break parsing. Strip them outside fenced code (which may legitimately
+	// show them, e.g. an HTML example) before parsing.
+	const content = transformOutsideFences(stripFrontmatter(raw), segment =>
+		segment
+			.replace(/<!--[\s\S]*?-->/g, '')
+			// Only the spaces around the anchor: `\s` would eat the blank line
+			// after the heading and pull the next block onto its line.
+			.replace(/^(#{1,6}[^\n]*?)[ \t]*\{#[-\w]+\}[ \t]*$/gm, '$1')
+	);
+	/** @type {Heading[]} */
+	const headings = [];
+	let body;
+	try {
+		const tree = parseMdx(content);
+		/** @type {CleanupContext} */
+		const cleanup = {
+			source: content,
+			edits: [],
+			headings,
+			components: createComponentContext(tree, page, headings, depth),
+		};
+		collectCleanup(tree, cleanup);
+		body = applyEdits(content, cleanup.edits);
+	} catch (error) {
+		// Parsing succeeds for all current pages; fall back defensively so a
+		// single unusual page can never break the build.
+		page.warn(`MDX parse failed, using the raw source: ${/** @type {Error} */ (error).message}`);
+		body = content;
+	}
+
+	/** @type {LinkContext} */
+	const ctx = {
+		sourceDir: posix.dirname(sourceKey(page.source)),
+		contentRoot: page.contentRoot,
+		routeDir: posix.dirname(toRoute(page.permalink, page.baseUrl)),
+		permalinkBySourceKey: page.permalinkBySourceKey,
+		permalinkByRoute: page.permalinkByRoute,
+		exported: page.exported,
+		baseUrl: page.baseUrl,
+		docsRootUrl: page.docsRootUrl,
+		warn: page.warn,
+	};
+	body = transformOutsideFences(
+		body,
+		segment => {
+			const linked = rewriteInlineLinks(rewriteReferenceDefinitions(segment, ctx), ctx);
+			// Collapse blank-line runs left behind by removed components.
+			return linked.replace(/\n[ \t]*\n(?:[ \t]*\n)+/g, '\n\n');
+		},
+		// A fenced block written directly on the page carries the same styling
+		// comments as the samples passed to `<CodeBlock>`, and they are just as
+		// meaningless once the code is read as text.
+		block => cleanCodeSample(block, false)
+	);
+	return { body: body.trim(), headings };
+}
+
+/**
+ * @param {string} body
+ * @param {string} title
+ * @returns {string}
+ */
+function withTitle(body, title) {
+	// Most pages carry their own `# Title`; only add one where the page relies
+	// on the front matter for it.
+	return /^#\s/.test(body) ? `${body}\n` : `# ${title}\n\n${body}\n`;
+}
+
+/**
+ * Footer appended to every per-page Markdown file so an assistant that reads a
+ * single page can discover the rest of the docs — and knows which version of
+ * the library it is holding. The page's own URL cannot say: the released
+ * version is served from the unversioned path, and the API changed enough
+ * between v4 and v5 that a page taken for the wrong one is worse than no page.
+ *
+ * @param {string} docsRootUrl
+ * @param {string | null} version
+ * @returns {string}
+ */
+function sitemapFooter(docsRootUrl, version) {
+	return [
+		'',
+		'---',
+		'',
+		...(version === null ? [] : [`Documentation for Lightweight Charts™ v${version} (latest released version).`, '']),
+		'## Sitemap',
+		'',
+		`- [All documentation pages](${docsRootUrl}/llms.txt)`,
+		`- [Full page map with headings](${docsRootUrl}/docs_map.md)`,
+		'',
+	].join('\n');
+}
+
+// Files webpack publishes under a content-hashed name — the runnable example
+// pages the tutorials embed. Nothing in the build records which source each one
+// came from, but the copies are byte-for-byte identical, so they are indexed by
+// the digest of their content and looked up the same way.
+const EMITTED_ASSET_NAME = /^[0-9a-f]{16,}\.[a-z0-9]+$/i;
+
+/**
+ * @param {Buffer | string} content
+ * @returns {string}
+ */
+function digestOf(content) {
+	return createHash('md5').update(content).digest('hex');
+}
+
+/**
+ * @param {string} outDir
+ * @param {string} docsRootUrl
+ * @returns {Promise<Map<string, string>>}
+ */
+async function readEmittedAssets(outDir, docsRootUrl) {
+	/** @type {Map<string, string>} */
+	const assets = new Map();
+	let entries;
+	try {
+		entries = await readdir(outDir, { withFileTypes: true });
+	} catch {
+		return assets;
+	}
+	for (const entry of entries) {
+		if (!entry.isFile() || !EMITTED_ASSET_NAME.test(entry.name)) {
+			continue;
+		}
+		try {
+			assets.set(digestOf(await readFile(join(outDir, entry.name))), `${docsRootUrl}/${entry.name}`);
+		} catch {
+			continue;
+		}
+	}
+	return assets;
+}
+
+/**
+ * @param {string} source
+ * @param {string} siteDir
+ * @returns {Promise<string>}
+ */
+function readSource(source, siteDir) {
+	return readFile(join(siteDir, source.replace(/^@site[\\/]?/, '')), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Rendering of docs_map.md / llms.txt
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {{ heading: string, nodes: DocsNode[] }} MappedSection A section as the map and the index file list it.
+ * @typedef {MappedSection & { version: string | null }} RenderedSection A section as the plugin holds it, with the release its pages document.
+ */
+
+/**
+ * @param {DocNode} node
+ * @param {string} baseUrl
+ * @param {string} docsRootUrl
+ * @param {Heading[] | undefined} headings
+ * @returns {string[]}
+ */
+function renderDocLines(node, baseUrl, docsRootUrl, headings) {
+	const lines = [`- [${node.title}](${docsRootUrl}/${toRoute(node.permalink, baseUrl)}.md)`];
+	for (const heading of headings ?? []) {
+		lines.push(`${'  '.repeat(heading.depth - 1)}- ${heading.text}`);
+	}
+	return lines;
+}
+
+/**
+ * @param {DocsNode[]} nodes
+ * @param {string} baseUrl
+ * @param {string} docsRootUrl
+ * @param {Map<string, Heading[]> | null} headingsByPermalink
+ * @param {number} level
+ * @param {string[]} output
+ */
+function renderNodes(nodes, baseUrl, docsRootUrl, headingsByPermalink, level, output) {
+	for (const node of nodes) {
+		if (node.kind === 'category') {
+			output.push('', `${'#'.repeat(Math.min(level, 6))} ${node.label}`, '');
+			renderNodes(node.children, baseUrl, docsRootUrl, headingsByPermalink, level + 1, output);
+		} else {
+			output.push(...renderDocLines(node, baseUrl, docsRootUrl, headingsByPermalink?.get(node.permalink)));
+		}
+	}
+}
+
+/**
+ * @typedef {object} IndexFileConfig
+ * @property {string} title
+ * @property {string} intro
+ * @property {string[]} structureNote
+ * @property {MappedSection[]} sections
+ * @property {string} baseUrl
+ * @property {string} docsRootUrl
+ * @property {Map<string, Heading[]> | null} headingsByPermalink
+ * @property {boolean} hasTypeDefinitions
+ * @property {string | null} version
+ * @property {string} generatedAt
+ */
+
+/**
+ * @param {IndexFileConfig} config
+ * @returns {string}
+ */
+function renderIndexFile(config) {
+	/** @type {string[]} */
+	const body = [];
+	for (const section of config.sections) {
+		body.push('', `## ${section.heading}`, '');
+		renderNodes(section.nodes, config.baseUrl, config.docsRootUrl, config.headingsByPermalink, 3, body);
+	}
+	const typeDefinitions = config.hasTypeDefinitions
+		? [
+			'## Type Definitions',
+			'',
+			`- [Lightweight Charts API (TypeScript declarations)](${config.docsRootUrl}/${TYPE_DEFINITIONS_FILE})`,
+			'',
+		]
+		: [];
+	// `llms.txt` opens with a blockquote summary, and its version and timestamp
+	// belong to that same quote; the map opens with a paragraph, which the two
+	// lines must not run into.
+	const beforeMetadata = config.intro.startsWith('>') ? [] : [''];
+	return [
+		`# ${config.title}`,
+		'',
+		config.intro,
+		...beforeMetadata,
+		...(config.version === null ? [] : [`> Version: ${config.version} (latest released)`]),
+		`> Last updated: ${config.generatedAt}`,
+		'',
+		...config.structureNote,
+		body.join('\n'),
+		'',
+		...typeDefinitions,
+	].join('\n');
+}
+
+/**
+ * @param {Omit<IndexFileConfig, 'title' | 'intro' | 'structureNote'>} config
+ * @returns {string}
+ */
+function renderDocsMap(config) {
+	return renderIndexFile({
+		...config,
+		title: 'Lightweight Charts™ - Documentation Map',
+		intro: 'A map of all documentation pages with their headings, for navigation by LLMs and tools. Every page is available as Markdown at the linked URL.',
+		structureNote: [
+			'This map uses a hierarchical structure:',
+			'',
+			'* `##`/`###` mark documentation groups',
+			'* `- [title](url.md)` marks a page (fetch the `.md` URL for its full content)',
+			'* Nested bullets show the heading structure within each page',
+		],
+	});
+}
+
+/**
+ * @param {Omit<IndexFileConfig, 'title' | 'intro' | 'structureNote'>} config
+ * @returns {string}
+ */
+function renderLlmsTxt(config) {
+	return renderIndexFile({
+		...config,
+		title: 'Lightweight Charts™',
+		intro: [
+			'> Official documentation for Lightweight Charts™, a free, open-source library for building interactive financial charts on the web. Every page below is available as Markdown by appending `.md` to its URL.',
+			`> See [docs_map.md](${config.docsRootUrl}/docs_map.md) for a version that also lists each page's headings.`,
+		].join('\n'),
+		structureNote: [],
+	});
+}
+
+// ---------------------------------------------------------------------------
+// The plugin
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {import('@docusaurus/types').LoadContext} context
+ * @returns {import('@docusaurus/types').Plugin}
+ */
+export function docsMarkdownPlugin(context) {
+	const { siteDir, baseUrl } = context;
+	const docsRootUrl = siteRootUrl(context.siteConfig.url, baseUrl);
+	const { organizationName, projectName } = context.siteConfig;
+	const repositoryUrl = `https://github.com/${organizationName}/${projectName}`;
+
+	/** @type {RenderedSection[]} */
+	let sections = [];
+	// Every doc of every version and instance, so a link to a page we do not
+	// export still resolves to the right URL.
+	/** @type {Map<string, string>} */
+	const permalinkBySourceKey = new Map();
+	/** @type {Map<string, string>} */
+	const permalinkByRoute = new Map();
+	/** @type {string | null} */
+	let releasedVersion = null;
+
+	return {
+		name: 'docs-markdown-plugin',
+
+		/** @param {{ allContent: Record<string, Record<string, unknown>> }} args */
+		allContentLoaded({ allContent }) {
+			const instances = allContent[DOCS_PLUGIN_NAME];
+			if (instances === undefined) {
+				logger.warn('[docs-markdown-plugin] content-docs content not found; skipping.');
+				return;
+			}
+
+			for (const content of Object.values(instances)) {
+				for (const version of /** @type {{ loadedVersions: LoadedVersion[] }} */ (content)?.loadedVersions ?? []) {
+					for (const doc of version.docs) {
+						permalinkBySourceKey.set(sourceKey(doc.source), doc.permalink);
+						permalinkByRoute.set(toRoute(doc.permalink, baseUrl), doc.permalink);
+					}
+				}
+			}
+
+			sections = [];
+			for (const section of EXPORTED_SECTIONS) {
+				const content = /** @type {{ loadedVersions: LoadedVersion[] } | undefined} */ (instances[section.pluginId]);
+				const version = (content?.loadedVersions ?? []).find(section.pickVersion);
+				if (version === undefined) {
+					logger.warn(`[docs-markdown-plugin] no version to export for "${section.pluginId}"; skipping it.`);
+					continue;
+				}
+				if (section.pluginId === 'default') {
+					releasedVersion = version.versionName;
+				}
+				const docsById = new Map(version.docs.map((/** @type {DocMetadata} */ doc) => [doc.id, doc]));
+				const nodes = hoistRootDocs(buildDocsNodes(version.sidebars[section.sidebar] ?? [], docsById, baseUrl, contentRootOf(version, siteDir)));
+				if (nodes.length > 0) {
+					// An instance with a single version of its own (the tutorials) is not
+					// versioned, and nothing about it can be stamped with a release.
+					sections.push({ heading: section.heading, nodes, version: version.versionName === 'current' ? null : version.versionName });
+				}
+			}
+		},
+
+		/** @param {{ outDir: string }} args */
+		async postBuild({ outDir }) {
+			if (sections.length === 0) {
+				return;
+			}
+
+			// Each page is written with the version of the section it belongs to.
+			/** @type {{ node: DocNode, version: string | null }[]} */
+			const pages = [];
+			for (const section of sections) {
+				/** @type {DocNode[]} */
+				const sectionNodes = [];
+				collectDocNodes(section.nodes, sectionNodes);
+				for (const node of sectionNodes) {
+					pages.push({ node, version: section.version });
+				}
+			}
+			// Pages know about each other: a link is only rewritten to a `.md` when
+			// the page it points at is exported too.
+			const exported = new Set(pages.map((/** @type {{ node: DocNode }} */ page) => page.node.permalink));
+
+			const emittedAssets = await readEmittedAssets(outDir, docsRootUrl);
+			const emittedAssetUrl = (/** @type {string} */ path) => {
+				try {
+					return emittedAssets.get(digestOf(readFileSync(path)));
+				} catch {
+					return undefined;
+				}
+			};
+			const repositoryFileUrl = (/** @type {string} */ path) => {
+				const relative = relativePath(siteDir, path).replace(/\\/g, '/');
+				return relative.startsWith('..') ? undefined : `${repositoryUrl}/blob/${DEFAULT_BRANCH}/website/${relative}`;
+			};
+
+			/** @type {Map<string, Heading[]>} */
+			const headingsByPermalink = new Map();
+			/** @type {Set<string>} */
+			const written = new Set();
+
+			const writePage = async (/** @type {DocNode} */ node, /** @type {string | null} */ version) => {
+				let raw;
+				try {
+					raw = await readSource(node.source, siteDir);
+				} catch (error) {
+					logger.warn(`[docs-markdown-plugin] could not read ${node.source}: ${/** @type {Error} */ (error).message}`);
+					return;
+				}
+				const route = toRoute(node.permalink, baseUrl);
+				/** @type {string[]} */
+				const warnings = [];
+				/** @type {PageContext} */
+				const page = {
+					source: node.source,
+					contentRoot: node.contentRoot,
+					permalink: node.permalink,
+					siteDir,
+					baseUrl,
+					docsRootUrl,
+					permalinkBySourceKey,
+					permalinkByRoute,
+					exported,
+					emittedAssetUrl,
+					repositoryFileUrl,
+					// The pages an article embeds are linked once, however many
+					// times the article points at them.
+					linkedAssets: new Set(),
+					warn: message => warnings.push(message),
+				};
+				const { body, headings } = cleanBody(raw, page, 0);
+				for (const warning of warnings) {
+					logger.warn(`[docs-markdown-plugin] ${route}: ${warning}`);
+				}
+				const file = join(outDir, `${route}.md`);
+				try {
+					await mkdir(dirname(file), { recursive: true });
+					await writeFile(file, `${withTitle(body, node.title)}${sitemapFooter(docsRootUrl, version)}`, 'utf-8');
+				} catch (error) {
+					logger.warn(`[docs-markdown-plugin] could not write ${file}: ${/** @type {Error} */ (error).message}`);
+					return;
+				}
+				headingsByPermalink.set(node.permalink, headings);
+				written.add(node.permalink);
+			};
+
+			await Promise.all(pages.map((/** @type {{ node: DocNode, version: string | null }} */ page) => writePage(page.node, page.version)));
+
+			const hasTypeDefinitions = await copyTypeDefinitions(siteDir, outDir, releasedVersion, docsRootUrl);
+
+			// Build the map/index from what was actually written, so no link 404s.
+			const writtenSections = sections
+				.map((/** @type {RenderedSection} */ section) => ({ heading: section.heading, nodes: pruneToWritten(section.nodes, written) }))
+				.filter((/** @type {MappedSection} */ section) => section.nodes.length > 0);
+			const generatedAt = `${new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '')} UTC`;
+			const common = { sections: writtenSections, baseUrl, docsRootUrl, hasTypeDefinitions, version: releasedVersion, generatedAt };
+
+			await writeFile(join(outDir, 'docs_map.md'), renderDocsMap({ ...common, headingsByPermalink }), 'utf-8');
+			await writeFile(join(outDir, 'llms.txt'), renderLlmsTxt({ ...common, headingsByPermalink: null }), 'utf-8');
+
+			logger.info(`[docs-markdown-plugin] wrote ${written.size} .md pages + docs_map.md + llms.txt`);
+		},
+	};
+}
+
+/**
+ * The folder a version's pages are addressed from, relative to the site
+ * (`versioned_docs/version-5.2`, `tutorials`): a link written as
+ * `/api/interfaces/IChartApi.md` is a path from there, not from the site root.
+ *
+ * @param {LoadedVersion} version
+ * @param {string} siteDir
+ * @returns {string}
+ */
+function contentRootOf(version, siteDir) {
+	return typeof version.contentPath === 'string' ? relativePath(siteDir, version.contentPath).replace(/\\/g, '/') : '.';
+}
+
+/**
+ * Publishes the TypeScript declarations the API reference is generated from.
+ * They are the complete API in a form a machine reader can take in at once,
+ * which the per-symbol reference pages are not.
+ *
+ * @param {string} siteDir
+ * @param {string} outDir
+ * @param {string | null} version
+ * @param {string} docsRootUrl
+ * @returns {Promise<boolean>}
+ */
+async function copyTypeDefinitions(siteDir, outDir, version, docsRootUrl) {
+	/** @type {{ path: string, version: string | null }[]} */
+	const candidates = [];
+	if (version !== null) {
+		candidates.push({ path: join(siteDir, TYPINGS_CACHE_DIR, `v${version}.d.ts`), version });
+	}
+	candidates.push({ path: join(siteDir, '..', 'dist', 'typings.d.ts'), version: null });
+	for (const candidate of candidates) {
+		try {
+			const declarations = await readFile(candidate.path, 'utf-8');
+			await writeFile(join(outDir, TYPE_DEFINITIONS_FILE), typeDefinitionsHeader(candidate.version, docsRootUrl) + declarations, 'utf-8');
+			return true;
+		} catch {
+			continue;
+		}
+	}
+	logger.warn('[docs-markdown-plugin] no type definitions found; the index files will not link them.');
+	return false;
+}
+
+/**
+ * The declarations are generated as a bare bundle: the first thing in the file
+ * is `// Generated by dts-bundle-generator`, and nothing in it says which
+ * library — or which version of it — the types belong to. Read on the site,
+ * away from the package that ships them, they need to introduce themselves,
+ * and to say where the prose that goes with them lives.
+ *
+ * @param {string | null} version
+ * @param {string} docsRootUrl
+ * @returns {string}
+ */
+function typeDefinitionsHeader(version, docsRootUrl) {
+	return [
+		'/**',
+		` * TradingView Lightweight Charts™${version === null ? '' : ` v${version}`}`,
+		' * TypeScript declarations for the `lightweight-charts` package.',
+		` * Documentation: ${docsRootUrl}`,
+		' */',
+		'',
+	].join('\n');
+}

--- a/website/src/theme/DocItem/Content/index.tsx
+++ b/website/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,55 @@
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import type { Props } from '@theme/DocItem/Content';
+import Heading from '@theme/Heading';
+import MDXContent from '@theme/MDXContent';
+import clsx from 'clsx';
+import React from 'react';
+
+import { MarkdownActions, MarkdownActionsInContentProvider } from './markdown-actions';
+
+/**
+ * Title can be declared inside md content or declared through front matter and
+ * added manually. To make both cases consistent, the added title is added under
+ * the same div.markdown block.
+ *
+ * We render a "synthetic title" if:
+ * - user doesn't ask to hide it with front matter
+ * - the markdown content does not already contain a top-level h1 heading
+ */
+function useSyntheticTitle(): string | null {
+	const { metadata, frontMatter, contentTitle } = useDoc();
+	const shouldRender = !frontMatter.hide_title && contentTitle === undefined;
+	if (!shouldRender) {
+		return null;
+	}
+	return metadata.title;
+}
+
+// Swizzled from theme-classic to render a Markdown actions row (Copy/View as
+// Markdown) directly under the page title.
+//
+// Where that is depends on the page: a title set in the front matter is the
+// synthetic one rendered here, and the row follows it. A title written as
+// `# Title` in the Markdown itself is rendered from within MDXContent, out of
+// reach from here, so on those pages the row is emitted by the swizzled `h1`
+// instead — the provider is what hands it that job.
+export default function DocItemContent({ children }: Props): React.JSX.Element {
+	const { contentTitle } = useDoc();
+	const syntheticTitle = useSyntheticTitle();
+	return (
+		<div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
+			{syntheticTitle !== null && (
+				<>
+					<header>
+						<Heading as="h1">{syntheticTitle}</Heading>
+					</header>
+					<MarkdownActions />
+				</>
+			)}
+			<MarkdownActionsInContentProvider title={syntheticTitle === null ? contentTitle ?? null : null}>
+				<MDXContent>{children}</MDXContent>
+			</MarkdownActionsInContentProvider>
+		</div>
+	);
+}

--- a/website/src/theme/DocItem/Content/markdown-actions.tsx
+++ b/website/src/theme/DocItem/Content/markdown-actions.tsx
@@ -1,0 +1,154 @@
+import { useDoc, useDocsVersion } from '@docusaurus/plugin-content-docs/client';
+import clsx from 'clsx';
+import React, { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
+
+import styles from './styles.module.css';
+
+// How long the "Copied" confirmation stays before reverting to the idle label.
+const RESET_DELAY_MS = 2000;
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+// The labels share one grid cell so the button keeps the width of its widest
+// label: only the text crossfades, the row never jumps.
+const COPY_LABELS: Record<CopyStatus, string> = {
+	idle: 'Copy as Markdown',
+	copied: 'Copied',
+	failed: 'Copy failed',
+};
+
+/*
+ * The title a page renders from its own Markdown, on the pages that do.
+ *
+ * The actions row belongs directly under the page title, but the title comes
+ * from one of two places: the theme renders it when it is set in the front
+ * matter, and the page's own Markdown renders it when it is written as
+ * `# Title` there. This is what tells the swizzled `h1` (see
+ * theme/MDXComponents) that the row is its job, and under which heading.
+ */
+const MarkdownActionsInContentContext = createContext<string | null>(null);
+
+export function MarkdownActionsInContentProvider({ title, children }: { title: string | null; children: ReactNode }): React.JSX.Element {
+	return <MarkdownActionsInContentContext.Provider value={title}>{children}</MarkdownActionsInContentContext.Provider>;
+}
+
+export function useMarkdownActionsInContent(): string | null {
+	return useContext(MarkdownActionsInContentContext);
+}
+
+function CopyIcon(): React.JSX.Element {
+	return (
+		<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round" aria-hidden={true}>
+			<rect x="9" y="9" width="12" height="12" rx="2" />
+			<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+		</svg>
+	);
+}
+
+function CheckIcon(): React.JSX.Element {
+	return (
+		<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" aria-hidden={true}>
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	);
+}
+
+/*
+ * A row of flat links under the page title: copy the page as Markdown (fetches
+ * the sibling `.md` the docs-markdown plugin emits) and open that `.md` itself.
+ *
+ * Only the pages that plugin exports have a `.md`, so the row is hidden on the
+ * generated API reference and on any version other than the released one.
+ */
+export function MarkdownActions(): React.JSX.Element | null {
+	const { metadata } = useDoc();
+	const { isLast } = useDocsVersion();
+	const [status, setStatus] = useState<CopyStatus>('idle');
+	const resetTimeout = useRef<number | undefined>(undefined);
+
+	// The plugin writes each page's Markdown next to its route (`<permalink>.md`),
+	// and permalink already carries the site baseUrl, so this resolves correctly
+	// on local, staging and production builds alike.
+	const markdownUrl = `${metadata.permalink.replace(/\/$/, '')}.md`;
+
+	useEffect(() => (): void => window.clearTimeout(resetTimeout.current), []);
+
+	const copyMarkdown = useCallback(
+		async (): Promise<void> => {
+			const report = (result: CopyStatus): void => {
+				setStatus(result);
+				window.clearTimeout(resetTimeout.current);
+				resetTimeout.current = window.setTimeout(() => setStatus('idle'), RESET_DELAY_MS);
+			};
+
+			try {
+				const response = await window.fetch(markdownUrl);
+				const contentType = response.headers.get('content-type') ?? '';
+				if (!response.ok || contentType.includes('html')) {
+					throw new Error(`Markdown not available (status ${response.status})`);
+				}
+				const markdown = await response.text();
+				// The dev server (and any SPA fallback) answers unknown routes with
+				// the app shell HTML, not the .md — never put that on the clipboard.
+				if (/^\s*<(?:!doctype|html)\b/i.test(markdown)) {
+					throw new Error('Received HTML instead of Markdown');
+				}
+				await window.navigator.clipboard.writeText(markdown);
+				report('copied');
+			} catch {
+				// If the file or the clipboard is unavailable, fall back to copying
+				// the Markdown URL so the action still does something useful.
+				try {
+					await window.navigator.clipboard.writeText(`${window.location.origin}${markdownUrl}`);
+					report('copied');
+				} catch {
+					// No clipboard at all (an insecure context, say). Say so, rather
+					// than leaving a button that looks like it does nothing.
+					report('failed');
+				}
+			}
+		},
+		[markdownUrl]
+	);
+
+	const onCopy = useCallback(
+		(): void => {
+			void copyMarkdown();
+		},
+		[copyMarkdown]
+	);
+
+	if (!isLast || metadata.permalink.split('/').includes('api')) {
+		return null;
+	}
+
+	return (
+		<div className={styles.actions}>
+			<button
+				type="button"
+				className={styles.action}
+				data-status={status}
+				data-tooltip="Copy this page as Markdown for LLMs"
+				onClick={onCopy}
+			>
+				{status === 'copied' ? <CheckIcon /> : <CopyIcon />}
+				<span className={styles.label}>
+					{Object.entries(COPY_LABELS).map(([value, text]: [string, string]) => (
+						<span key={value} data-active={status === value} aria-hidden={status !== value}>{text}</span>
+					))}
+				</span>
+			</button>
+			<span className={styles.divider} aria-hidden={true} />
+			<a
+				className={clsx(styles.action, styles.view)}
+				href={markdownUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				data-tooltip="View this page as plain text"
+			>
+				<span className={styles.badge} aria-hidden={true}>M↓</span>
+				<span>View as Markdown</span>
+			</a>
+		</div>
+	);
+}

--- a/website/src/theme/DocItem/Content/styles.module.css
+++ b/website/src/theme/DocItem/Content/styles.module.css
@@ -1,0 +1,153 @@
+/*
+ * Markdown actions row shown under the page title. Colours come from Infima
+ * theme tokens so the row follows the docs' light/dark themes automatically.
+ * Selectors are compounded (`.actions .action`) so they win over the global
+ * `.markdown a` rules the row is nested inside.
+ */
+
+.actions {
+	/* Resting label colour: a slate that stays crisp on both themes. The tooltip
+	   is a slate chip, grey-ish rather than black. */
+	--md-action-color: #3c4257;
+	--md-tooltip-bg: #3c4453;
+	--md-tooltip-fg: #ffffff;
+
+	display: flex;
+	width: 100%;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 2px;
+	margin: 0 0 1.25rem;
+	padding-bottom: 0.7rem;
+	border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+:global(html[data-theme='dark']) .actions {
+	--md-action-color: #c7ccd6;
+}
+
+.actions .action {
+	display: inline-flex;
+	position: relative;
+	align-items: center;
+	gap: 7px;
+	padding: 5px 12px;
+	border: none;
+	border-radius: 6px;
+	background: none;
+	color: var(--md-action-color);
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1;
+	text-decoration: none;
+	cursor: pointer;
+	transition: color 0.12s ease, background 0.12s ease;
+}
+
+.actions .action:first-child {
+	padding-inline-start: 2px;
+}
+
+.actions .action:hover {
+	color: var(--ifm-color-primary);
+	text-decoration: none;
+}
+
+.actions .action:focus-visible {
+	outline: 2px solid var(--ifm-color-primary);
+	outline-offset: 1px;
+}
+
+.actions .action svg {
+	width: 14px;
+	height: 14px;
+	flex: none;
+}
+
+.actions .action[data-status='copied'] {
+	color: var(--ifm-color-success);
+}
+
+.actions .action[data-status='failed'] {
+	color: var(--ifm-color-danger);
+}
+
+/* The labels are stacked in one grid cell so the button keeps the width of its
+   widest label — only the text crossfades, the row never jumps. */
+.actions .label {
+	display: inline-grid;
+	justify-items: start;
+}
+
+.actions .label > span {
+	grid-area: 1 / 1;
+	white-space: nowrap;
+	opacity: 0;
+	transition: opacity 0.12s ease;
+}
+
+.actions .label > span[data-active='true'] {
+	opacity: 1;
+}
+
+.actions .badge {
+	padding: 1px 3px;
+	border: 1px solid currentColor;
+	border-radius: 3px;
+	font-family: var(--ifm-font-family-monospace);
+	font-size: 9px;
+	font-weight: 700;
+	letter-spacing: 0.02em;
+	line-height: 1;
+}
+
+.actions .divider {
+	width: 1px;
+	height: 14px;
+	flex: none;
+	align-self: center;
+	background: var(--ifm-color-emphasis-300);
+}
+
+/* Tooltip. The copy link anchors its tooltip to the left edge; the view link,
+   sitting further right, anchors to the right so it never runs off-screen. */
+.actions .action[data-tooltip]::after {
+	content: attr(data-tooltip);
+	position: absolute;
+	bottom: calc(100% + 8px);
+	inset-inline-start: 0;
+	z-index: 10;
+	padding: 5px 9px;
+	border-radius: 6px;
+	background: var(--md-tooltip-bg);
+	color: var(--md-tooltip-fg);
+	font-size: 11px;
+	font-weight: 600;
+	white-space: nowrap;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+	opacity: 0;
+	transform: translateY(3px);
+	pointer-events: none;
+	transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.actions .action.view[data-tooltip]::after {
+	inset-inline: auto 0;
+}
+
+.actions .action[data-tooltip]:hover::after {
+	opacity: 1;
+	transform: translateY(0);
+}
+
+/* Touch devices: no hover, so drop the tooltip and give links a taller tap area. */
+@media (hover: none) {
+	.actions .action[data-tooltip]::after {
+		display: none;
+	}
+
+	.actions .action {
+		padding-top: 9px;
+		padding-bottom: 9px;
+	}
+}

--- a/website/src/theme/MDXComponents/index.tsx
+++ b/website/src/theme/MDXComponents/index.tsx
@@ -1,0 +1,49 @@
+import OriginalMDXComponents from '@theme-original/MDXComponents';
+import type { MDXComponentsObject } from '@theme/MDXComponents';
+import React, { type ComponentProps, type ReactNode } from 'react';
+
+import { MarkdownActions, useMarkdownActionsInContent } from '../DocItem/Content/markdown-actions';
+
+const originalComponents = OriginalMDXComponents as MDXComponentsObject;
+
+/**
+ * The plain text of a heading, or null when it is built from something this
+ * cannot read (an element, an expression). Headings are written as plain text
+ * throughout the docs; the null case only keeps the check below honest.
+ */
+function headingText(children: ReactNode): string | null {
+	if (typeof children === 'string') {
+		return children;
+	}
+	if (!Array.isArray(children)) {
+		return null;
+	}
+	const parts = children.map((child: ReactNode) => (typeof child === 'string' ? child : null));
+	return parts.includes(null) ? null : parts.join('');
+}
+
+/*
+ * A page whose title is written as `# Title` in its own Markdown renders that
+ * heading from here rather than from the theme, so this is the only place the
+ * Markdown actions row can be put directly under it. DocItem/Content decides
+ * which of the two places is used, and only doc pages ever ask for this one.
+ *
+ * The row goes under the page's title, not under every `h1` it happens to
+ * contain, so a heading that is demonstrably a different one is left alone.
+ */
+function Heading1(props: ComponentProps<'h1'>): React.JSX.Element {
+	const pageTitle = useMarkdownActionsInContent();
+	const text = headingText(props.children);
+	const isPageTitle = pageTitle !== null && (text === null || text.trim() === pageTitle.trim());
+	return (
+		<>
+			<originalComponents.h1 {...props} />
+			{isPageTitle && <MarkdownActions />}
+		</>
+	);
+}
+
+export default {
+	...originalComponents,
+	h1: Heading1,
+};

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -3,11 +3,13 @@
 	"compilerOptions": {
 		"strict": true,
 		"resolveJsonModule": true,
-		"jsx": "react",
-		"moduleResolution": "node"
+		"jsx": "react"
 	},
 	"include": [
 		"./**/*.ts",
 		"./**/*.tsx",
+		// The Markdown export plugin is JavaScript with JSDoc types; its
+		// `// @ts-check` only means anything while it is part of the program.
+		"./plugins/docs-markdown/**/*.js",
 	]
 }


### PR DESCRIPTION
**Type of PR:** documentation update

**PR checklist:**

- [ ] Addresses an existing issue: fixes #
- [ ] Includes tests
- [x] Documentation update

**Overview of change:**

Added llms.txt + docs_map.md + lightweight-charts.d.ts + buttons for viewing/coping docs content as MD

**Preview**

- https://fastidious-kelpie-d8c577.netlify.app/lightweight-charts/docs
- https://fastidious-kelpie-d8c577.netlify.app/lightweight-charts/llms.txt
- https://fastidious-kelpie-d8c577.netlify.app/lightweight-charts/docs_map.md
- https://fastidious-kelpie-d8c577.netlify.app/lightweight-charts/lightweight-charts.d.ts