### PR TITLE
Toolkit: custom-series and primitive infrastructure (CLL-378 B1+B2)

### DIFF
--- a/packages/create-lwc-plugin/template-pane-primitive/src/template-entry.ts
+++ b/packages/create-lwc-plugin/template-pane-primitive/src/template-entry.ts
@@ -1,4 +1,5 @@
-import { IPanePrimitive, IPanePrimitivePaneView, PaneAttachedParameter, Time } from 'lightweight-charts';
+import { IPanePrimitivePaneView, Time } from 'lightweight-charts';
+import { PanePluginBase } from '@tradingview/lwc-toolkit/pane-plugin-base';
 import { _CLASSNAME_Options, defaultOptions } from './options';
 import { _CLASSNAME_PaneView } from './pane-view';
 
@@ -8,12 +9,16 @@ import { _CLASSNAME_PaneView } from './pane-view';
  * Pane primitives are attached to a pane rather than to a series, so they are
  * a good fit for pane-level decoration: titles, badges, legends, watermarks.
  */
-export class _CLASSNAME_<T = Time> implements IPanePrimitive<T> {
+export class _CLASSNAME_<T = Time> extends PanePluginBase<T> {
 	private _options: _CLASSNAME_Options;
 	private _paneViews: _CLASSNAME_PaneView[];
-	private _requestUpdate?: () => void;
 
 	constructor(options: Partial<_CLASSNAME_Options> = {}) {
+		//* PanePluginBase implements the attached / detached lifecycle hooks: it
+		//* keeps the chart (this.chart) and provides this.requestUpdate(). Override
+		//* attached() / detached() — calling super — if the primitive needs to
+		//* acquire and release anything of its own.
+		super();
 		this._options = {
 			...defaultOptions,
 			...options,
@@ -31,17 +36,6 @@ export class _CLASSNAME_<T = Time> implements IPanePrimitive<T> {
 		return this._paneViews;
 	}
 
-	attached({ requestUpdate }: PaneAttachedParameter<T>): void {
-		//* Attached lifecycle hook. Keep hold of requestUpdate so the primitive
-		//* can ask the chart to redraw when its own state changes.
-		this._requestUpdate = requestUpdate;
-	}
-
-	detached(): void {
-		//* Detached lifecycle hook. Release anything acquired in attached().
-		this._requestUpdate = undefined;
-	}
-
 	public get options(): _CLASSNAME_Options {
 		return this._options;
 	}
@@ -49,6 +43,7 @@ export class _CLASSNAME_<T = Time> implements IPanePrimitive<T> {
 	applyOptions(options: Partial<_CLASSNAME_Options>) {
 		this._options = { ...this._options, ...options };
 		this.updateAllViews();
-		this._requestUpdate?.();
+		//* Ask the chart to redraw. Does nothing while the primitive is detached.
+		this.requestUpdate();
 	}
 }

--- a/packages/create-lwc-plugin/template-series-primitive/src/axis-view.ts
+++ b/packages/create-lwc-plugin/template-series-primitive/src/axis-view.ts
@@ -1,20 +1,23 @@
-import { Coordinate, ISeriesPrimitiveAxisView } from 'lightweight-charts';
+import { Coordinate } from 'lightweight-charts';
+import { AxisLabelSource } from '@tradingview/lwc-toolkit/axis-label-view';
 import { Point, _CLASSNAME_DataSource } from './data-source';
 
-abstract class _CLASSNAME_AxisView implements ISeriesPrimitiveAxisView {
+/**
+ * What one axis label shows. The toolkit's AxisLabelView turns this into the
+ * ISeriesPrimitiveAxisView the library expects, and hides the label whenever
+ * coordinate() cannot resolve the point.
+ */
+abstract class _CLASSNAME_AxisLabelSource implements AxisLabelSource {
 	protected _source: _CLASSNAME_DataSource;
 	protected _p: Point;
-	protected _pos: Coordinate | null = null;
 	constructor(source: _CLASSNAME_DataSource, p: Point) {
 		this._source = source;
 		this._p = p;
 	}
-	abstract update(): void;
+	//* The coordinate is read on demand, so there is no separate update step:
+	//* return null whenever the point cannot be placed on the axis.
+	abstract coordinate(): Coordinate | null;
 	abstract text(): string;
-
-	coordinate() {
-		return this._pos ?? -1;
-	}
 
 	visible(): boolean {
 		return this._source.options.showLabels;
@@ -32,24 +35,23 @@ abstract class _CLASSNAME_AxisView implements ISeriesPrimitiveAxisView {
 	}
 	movePoint(p: Point) {
 		this._p = p;
-		this.update();
 	}
 }
 
-export class _CLASSNAME_TimeAxisView extends _CLASSNAME_AxisView {
-	update() {
+export class _CLASSNAME_TimeAxisLabelSource extends _CLASSNAME_AxisLabelSource {
+	coordinate() {
 		const timeScale = this._source.chart.timeScale();
-		this._pos = timeScale.timeToCoordinate(this._p.time);
+		return timeScale.timeToCoordinate(this._p.time);
 	}
 	text() {
 		return this._source.options.timeLabelFormatter(this._p.time);
 	}
 }
 
-export class _CLASSNAME_PriceAxisView extends _CLASSNAME_AxisView {
-	update() {
+export class _CLASSNAME_PriceAxisLabelSource extends _CLASSNAME_AxisLabelSource {
+	coordinate() {
 		const series = this._source.series;
-		this._pos = series.priceToCoordinate(this._p.price);
+		return series.priceToCoordinate(this._p.price);
 	}
 	text() {
 		return this._source.options.priceLabelFormatter(this._p.price);

--- a/packages/create-lwc-plugin/template-series-primitive/src/template-entry.ts
+++ b/packages/create-lwc-plugin/template-series-primitive/src/template-entry.ts
@@ -3,10 +3,14 @@ import {
 	_CLASSNAME_PriceAxisPaneView,
 	_CLASSNAME_TimeAxisPaneView,
 } from './axis-pane-view';
-import { _CLASSNAME_PriceAxisView, _CLASSNAME_TimeAxisView } from './axis-view';
+import {
+	_CLASSNAME_PriceAxisLabelSource,
+	_CLASSNAME_TimeAxisLabelSource,
+} from './axis-view';
 import { Point, _CLASSNAME_DataSource } from './data-source';
 import { _CLASSNAME_Options, defaultOptions } from './options';
 import { _CLASSNAME_PaneView } from './pane-view';
+import { AxisLabelView } from '@tradingview/lwc-toolkit/axis-label-view';
 import { PluginBase } from '@tradingview/lwc-toolkit/plugin-base';
 
 export class _CLASSNAME_
@@ -17,8 +21,8 @@ export class _CLASSNAME_
 	private _p1: Point;
 	private _p2: Point;
 	private _paneViews: _CLASSNAME_PaneView[];
-	private _timeAxisViews: _CLASSNAME_TimeAxisView[];
-	private _priceAxisViews: _CLASSNAME_PriceAxisView[];
+	private _timeAxisViews: AxisLabelView[];
+	private _priceAxisViews: AxisLabelView[];
 	private _priceAxisPaneViews: _CLASSNAME_PriceAxisPaneView[];
 	private _timeAxisPaneViews: _CLASSNAME_TimeAxisPaneView[];
 
@@ -35,13 +39,15 @@ export class _CLASSNAME_
 			...options,
 		};
 		this._paneViews = [new _CLASSNAME_PaneView(this)];
+		//* AxisLabelView renders each label from its source, and hides it while
+		//* the point cannot be placed on the axis.
 		this._timeAxisViews = [
-			new _CLASSNAME_TimeAxisView(this, p1),
-			new _CLASSNAME_TimeAxisView(this, p2),
+			new AxisLabelView(new _CLASSNAME_TimeAxisLabelSource(this, p1)),
+			new AxisLabelView(new _CLASSNAME_TimeAxisLabelSource(this, p2)),
 		];
 		this._priceAxisViews = [
-			new _CLASSNAME_PriceAxisView(this, p1),
-			new _CLASSNAME_PriceAxisView(this, p2),
+			new AxisLabelView(new _CLASSNAME_PriceAxisLabelSource(this, p1)),
+			new AxisLabelView(new _CLASSNAME_PriceAxisLabelSource(this, p2)),
 		];
 		this._priceAxisPaneViews = [new _CLASSNAME_PriceAxisPaneView(this, true)];
 		this._timeAxisPaneViews = [new _CLASSNAME_TimeAxisPaneView(this, false)];
@@ -50,9 +56,9 @@ export class _CLASSNAME_
 	updateAllViews() {
 		//* Use this method to update any data required by the
 		//* views to draw.
+		//* The axis labels read their coordinates from the chart on demand, so
+		//* only the pane views need updating here.
 		this._paneViews.forEach(pw => pw.update());
-		this._timeAxisViews.forEach(pw => pw.update());
-		this._priceAxisViews.forEach(pw => pw.update());
 		this._priceAxisPaneViews.forEach(pw => pw.update());
 		this._timeAxisPaneViews.forEach(pw => pw.update());
 	}

--- a/packages/lwc-toolkit/CHANGELOG.md
+++ b/packages/lwc-toolkit/CHANGELOG.md
@@ -25,4 +25,28 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `min-max-in-range` — `UpperLowerInRange`
   - `plugin-base` — `PluginBase`
   - `simple-clone` — `cloneReadonly`
-  - `time` — `convertTime`, `displayTime`, `formattedDateAndTime`
+  - `time` — `convertTime`, `convertTimeUTC`, `displayTime`,
+    `formattedDateAndTime`
+- Custom series infrastructure, extracted from what every custom series
+  plugin repeated:
+  - `custom-series/renderer-base` — `CustomSeriesRendererBase`,
+    `CustomSeriesDrawArgs`
+  - `custom-series/visible-bars` — `forEachVisibleBar`, `mapVisibleBars`,
+    `extendRange`, `visibleSegments`
+  - `custom-series/stacking` — `cumulativeSum`, `stackedPlotValues`
+  - `custom-series/line-paths` — `buildLinePath`, `areaBetween`,
+    `strokeStyledPolyline`
+  - `canvas/round-rect` — `drawRoundRect`, `drawRoundRectWithBorder`,
+    `clampCornerRadius`, `CornerRadii`
+  - `line-style` — `setLineStyle`, `getDashPattern`, `LineStyle`
+- Primitive infrastructure:
+  - `pane-plugin-base` — `PanePluginBase`
+  - `axis-label-view` — `AxisLabelView`, `AxisLabelSource`,
+    `OFFSCREEN_LABEL_COORDINATE`
+  - `dom/pane-element` — `paneContentElement`, `chartTableElement`
+  - `dom/media-query` — `subscribeMediaQuery`, `mediaQueryMatches`,
+    `HIGH_CONTRAST_QUERIES`, `REDUCED_MOTION_QUERY`
+- `dimensions/columns`: `ColumnPositionItem` accepts an optional `time`
+  (logical index); columns on either side of a whitespace gap are no longer
+  aligned to each other, and `endIndex` is exclusive in every pass.
+- `min-max-in-range` results are now actually cached.

--- a/packages/lwc-toolkit/README.md
+++ b/packages/lwc-toolkit/README.md
@@ -34,7 +34,13 @@ setting ignores the `exports` field and will report the imports as unresolved.
 | Sub-path | Provides |
 | --- | --- |
 | `assertions` | `ensureDefined`, `ensureNotNull` — narrow a value or throw |
-| `closest-index` | `ClosestTimeIndexFinder` — cached binary search for the nearest time in sorted data |
+| `axis-label-view` | `AxisLabelView`, `AxisLabelSource` — a price- or time-axis label over a source that may have no coordinate yet |
+| `canvas/round-rect` | `drawRoundRect`, `drawRoundRectWithBorder`, `clampCornerRadius`, `CornerRadii` — rounded rectangles with an inset border |
+| `closest-index` | `ClosestTimeIndexFinder` — cached binary search for the first index at or after (or last at or before) a time |
+| `custom-series/line-paths` | `buildLinePath`, `areaBetween`, `strokeStyledPolyline` — polylines, the band between two lines, and a line whose style changes along its length |
+| `custom-series/renderer-base` | `CustomSeriesRendererBase`, `CustomSeriesDrawArgs` — a custom series renderer with the data and visible-range guards done, leaving `drawImpl` |
+| `custom-series/stacking` | `cumulativeSum`, `stackedPlotValues` — running totals and the autoscale values of a stack that may contain negatives |
+| `custom-series/visible-bars` | `forEachVisibleBar`, `mapVisibleBars`, `extendRange`, `visibleSegments` — iterate the visible bars only, reach the pane edge, split at whitespace gaps |
 | `delegate` | `Delegate`, `ISubscription` — a small subscribe/fire event primitive |
 | `dimensions/candles` | `candlestickWidth` — the body width the chart itself would use at a given bar spacing |
 | `dimensions/columns` | `calculateColumnPositions`, `calculateColumnPositionsInPlace` — evenly spaced column bars with consistent gaps |
@@ -42,10 +48,14 @@ setting ignores the `exports` field and will report the imports as unresolved.
 | `dimensions/crosshair-width` | `gridAndCrosshairMediaWidth`, `gridAndCrosshairBitmapWidth` — line widths matching the grid and crosshair |
 | `dimensions/full-width` | `fullBarWidth` — a bar spanning the whole slot, with no gap |
 | `dimensions/positions` | `positionsBox`, `positionsLine` — pixel-perfect boxes and lines from two coordinates |
+| `dom/media-query` | `subscribeMediaQuery`, `mediaQueryMatches`, `HIGH_CONTRAST_QUERIES`, `REDUCED_MOTION_QUERY` — shared, SSR-safe media query subscriptions |
+| `dom/pane-element` | `paneContentElement`, `chartTableElement` — the pane's canvas wrapper to append DOM overlays to, and the chart table |
+| `line-style` | `setLineStyle`, `getDashPattern`, `LineStyle` — the chart's dash patterns for renderers that receive no drawing utils |
 | `min-max-in-range` | `UpperLowerInRange` — cached upper/lower bounds over a range, for autoscaling |
-| `plugin-base` | `PluginBase` — a primitive base class holding the chart and series references and a `requestUpdate` hook |
+| `pane-plugin-base` | `PanePluginBase` — the pane-primitive counterpart of `PluginBase`: chart reference and `requestUpdate` hook |
+| `plugin-base` | `PluginBase` — a series-primitive base class holding the chart and series references and a `requestUpdate` hook |
 | `simple-clone` | `cloneReadonly` — deep clone that drops readonly-ness |
-| `time` | `convertTime`, `displayTime`, `formattedDateAndTime` — `Time` to timestamp and display strings |
+| `time` | `convertTime`, `convertTimeUTC`, `displayTime`, `formattedDateAndTime` — `Time` to local or UTC timestamps and display strings |
 
 The dimension helpers exist because canvas drawing has to land on whole device
 pixels to look sharp at every device pixel ratio. See

--- a/packages/lwc-toolkit/package.json
+++ b/packages/lwc-toolkit/package.json
@@ -18,9 +18,33 @@
 			"types": "./dist/assertions.d.ts",
 			"default": "./dist/assertions.js"
 		},
+		"./axis-label-view": {
+			"types": "./dist/axis-label-view.d.ts",
+			"default": "./dist/axis-label-view.js"
+		},
+		"./canvas/round-rect": {
+			"types": "./dist/canvas/round-rect.d.ts",
+			"default": "./dist/canvas/round-rect.js"
+		},
 		"./closest-index": {
 			"types": "./dist/closest-index.d.ts",
 			"default": "./dist/closest-index.js"
+		},
+		"./custom-series/line-paths": {
+			"types": "./dist/custom-series/line-paths.d.ts",
+			"default": "./dist/custom-series/line-paths.js"
+		},
+		"./custom-series/renderer-base": {
+			"types": "./dist/custom-series/renderer-base.d.ts",
+			"default": "./dist/custom-series/renderer-base.js"
+		},
+		"./custom-series/stacking": {
+			"types": "./dist/custom-series/stacking.d.ts",
+			"default": "./dist/custom-series/stacking.js"
+		},
+		"./custom-series/visible-bars": {
+			"types": "./dist/custom-series/visible-bars.d.ts",
+			"default": "./dist/custom-series/visible-bars.js"
 		},
 		"./delegate": {
 			"types": "./dist/delegate.d.ts",
@@ -50,9 +74,25 @@
 			"types": "./dist/dimensions/positions.d.ts",
 			"default": "./dist/dimensions/positions.js"
 		},
+		"./dom/media-query": {
+			"types": "./dist/dom/media-query.d.ts",
+			"default": "./dist/dom/media-query.js"
+		},
+		"./dom/pane-element": {
+			"types": "./dist/dom/pane-element.d.ts",
+			"default": "./dist/dom/pane-element.js"
+		},
+		"./line-style": {
+			"types": "./dist/line-style.d.ts",
+			"default": "./dist/line-style.js"
+		},
 		"./min-max-in-range": {
 			"types": "./dist/min-max-in-range.d.ts",
 			"default": "./dist/min-max-in-range.js"
+		},
+		"./pane-plugin-base": {
+			"types": "./dist/pane-plugin-base.d.ts",
+			"default": "./dist/pane-plugin-base.js"
 		},
 		"./plugin-base": {
 			"types": "./dist/plugin-base.d.ts",

--- a/packages/lwc-toolkit/src/axis-label-view.ts
+++ b/packages/lwc-toolkit/src/axis-label-view.ts
@@ -1,0 +1,85 @@
+import { Coordinate, ISeriesPrimitiveAxisView } from 'lightweight-charts';
+
+/**
+ * Everything {@link AxisLabelView} needs to draw one label on a price or a time
+ * axis. `coordinate` returns `null` when the value cannot be placed right now –
+ * an unresolvable time, or a price outside the current scale – and the label is
+ * then hidden instead of being drawn at the top / left edge of the axis.
+ */
+export interface AxisLabelSource {
+	/** Distance from the top (price axis) or from the left (time axis), or `null` when unresolvable. */
+	coordinate(): Coordinate | null;
+	/** Text of the label. */
+	text(): string;
+	/** Text colour of the label. */
+	textColor(): string;
+	/** Background colour of the label. */
+	backColor(): string;
+	/** Whether the label should be drawn at all (default: `true`). */
+	visible?(): boolean;
+	/** Whether the tick mark line should be drawn (default: `true`). */
+	tickVisible?(): boolean;
+}
+
+/**
+ * The coordinate reported for a label whose source coordinate is `null`.
+ *
+ * The library asks for a number, so an unresolvable label is pushed far off the
+ * axis rather than being reported at `0` (which would leave a gap in the label
+ * layout, and draw the label at the very top / left edge if `visible` were
+ * ignored).
+ */
+export const OFFSCREEN_LABEL_COORDINATE = -1e5;
+
+/**
+ * A ready-made `ISeriesPrimitiveAxisView` over an {@link AxisLabelSource}, for
+ * labels on the price axis or on the time axis.
+ *
+ * The source is read on every call, so there is no separate update step to keep
+ * in sync: a view built over a source which resolves its coordinate from the
+ * chart is always current. Whenever the source coordinate is `null` the view
+ * reports {@link OFFSCREEN_LABEL_COORDINATE} and `visible: false`, so a label
+ * for a time or a price which cannot be placed is never drawn at coordinate 0.
+ */
+export class AxisLabelView implements ISeriesPrimitiveAxisView {
+	private readonly _source: AxisLabelSource;
+
+	public constructor(source: AxisLabelSource) {
+		this._source = source;
+	}
+
+	/** The source this view draws, as passed to the constructor. */
+	public source(): AxisLabelSource {
+		return this._source;
+	}
+
+	public coordinate(): number {
+		return this._source.coordinate() ?? OFFSCREEN_LABEL_COORDINATE;
+	}
+
+	public text(): string {
+		return this._source.text();
+	}
+
+	public textColor(): string {
+		return this._source.textColor();
+	}
+
+	public backColor(): string {
+		return this._source.backColor();
+	}
+
+	public visible(): boolean {
+		if (this._source.coordinate() === null) {
+			return false;
+		}
+		return this._source.visible?.() ?? true;
+	}
+
+	public tickVisible(): boolean {
+		if (this._source.coordinate() === null) {
+			return false;
+		}
+		return this._source.tickVisible?.() ?? true;
+	}
+}

--- a/packages/lwc-toolkit/src/canvas/round-rect.ts
+++ b/packages/lwc-toolkit/src/canvas/round-rect.ts
@@ -1,0 +1,115 @@
+/**
+ * Corner radii of a rectangle, in the order used by `CanvasRenderingContext2D.roundRect`:
+ * top-left, top-right, bottom-right, bottom-left.
+ */
+export type CornerRadii = [number, number, number, number];
+
+function changeBorderRadius(borderRadius: CornerRadii, offset: number): CornerRadii {
+	return borderRadius.map((x: number) => (x === 0 ? x : x + offset)) as CornerRadii;
+}
+
+/**
+ * Clamps a desired corner radius so that it can never exceed the rectangle it is
+ * drawn on: no more than half the width, and no more than the height. The result
+ * is floored to a whole bitmap pixel, which keeps the rounded corner crisp.
+ *
+ * Pass bitmap (not media) values: multiply the media radius by the pixel ratio first.
+ *
+ * @param radius - the desired corner radius.
+ * @param width - the width of the rectangle.
+ * @param height - the height of the rectangle; a negative height (a box drawn
+ * upwards from its origin) is handled by taking the absolute value.
+ * @returns a radius which is safe to pass to {@link drawRoundRect}.
+ */
+export function clampCornerRadius(radius: number, width: number, height: number): number {
+	return Math.floor(Math.min(radius, width / 2, Math.abs(height)));
+}
+
+/**
+ * Starts a new path on the context and adds a rounded rectangle to it. The path is
+ * left unfilled and unstroked so that the caller can decide how to paint it.
+ *
+ * @param ctx - the canvas context to draw on.
+ * @param x - left edge of the rectangle.
+ * @param y - top edge of the rectangle.
+ * @param w - width of the rectangle.
+ * @param h - height of the rectangle.
+ * @param radii - corner radii, see {@link CornerRadii}. Use
+ * {@link clampCornerRadius} if the radius may be larger than the rectangle.
+ */
+export function drawRoundRect(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+	w: number,
+	h: number,
+	radii: CornerRadii
+): void {
+	ctx.beginPath();
+	ctx.roundRect(x, y, w, h, radii);
+}
+
+/**
+ * Fills a rounded rect, and strokes a border inside it when one is requested.
+ *
+ * The border is drawn centred on a path inset by half its width, so that the
+ * outer edge of the stroke lines up with the requested rectangle. This assumes
+ * both colours are opaque: with a translucent background the inset fill and the
+ * stroke overlap and the seam becomes visible.
+ *
+ * The border is skipped entirely - and the full rectangle simply filled - when
+ * `borderWidth` is 0, when `borderColor` is undefined, or when the border colour
+ * matches the background (in which case there is nothing to see but a seam).
+ *
+ * @param ctx - the canvas context to draw on.
+ * @param left - left edge of the rectangle.
+ * @param top - top edge of the rectangle.
+ * @param width - width of the rectangle.
+ * @param height - height of the rectangle.
+ * @param backgroundColor - fill colour.
+ * @param borderWidth - width of the border, 0 for no border.
+ * @param outerBorderRadius - corner radii measured on the outer edge of the border.
+ * @param borderColor - border colour, undefined for no border.
+ */
+export function drawRoundRectWithBorder(
+	ctx: CanvasRenderingContext2D,
+	left: number,
+	top: number,
+	width: number,
+	height: number,
+	backgroundColor: string,
+	borderWidth: number = 0,
+	outerBorderRadius: CornerRadii = [0, 0, 0, 0],
+	borderColor?: string
+): void {
+	ctx.save();
+
+	if (borderWidth === 0 || borderColor === undefined || borderColor === backgroundColor) {
+		drawRoundRect(ctx, left, top, width, height, outerBorderRadius);
+		ctx.fillStyle = backgroundColor;
+		ctx.fill();
+		ctx.restore();
+		return;
+	}
+
+	const halfBorderWidth = borderWidth / 2;
+	const radii = changeBorderRadius(outerBorderRadius, -halfBorderWidth);
+
+	drawRoundRect(
+		ctx,
+		left + halfBorderWidth,
+		top + halfBorderWidth,
+		width - borderWidth,
+		height - borderWidth,
+		radii
+	);
+
+	ctx.fillStyle = backgroundColor;
+	ctx.fill();
+
+	ctx.lineWidth = borderWidth;
+	ctx.strokeStyle = borderColor;
+	ctx.stroke();
+
+	ctx.restore();
+}

--- a/packages/lwc-toolkit/src/closest-index.ts
+++ b/packages/lwc-toolkit/src/closest-index.ts
@@ -1,4 +1,24 @@
+/**
+ * Which of the two entries bracketing the target is wanted when the target
+ * itself is not in the array. It names the side the search continues towards,
+ * not the side the answer lies on:
+ *
+ * - `'left'` keeps moving right until it is past the target, and so returns the
+ *   first entry at or *after* it (the right-hand bracket);
+ * - `'right'` returns the last entry at or *before* the target (the left-hand
+ *   bracket).
+ */
 export type SearchDirection = 'left' | 'right';
+
+/**
+ * Binary search over a time-sorted array, returning the index of the entry
+ * bracketing a target time on the requested side.
+ *
+ * It never picks the numerically nearest entry: the side always wins, so a
+ * target one millisecond past an entry still resolves to that entry for
+ * `'right'` and to the next one for `'left'`. Results are memoised per target
+ * and direction, so the array must not be mutated after construction.
+ */
 export class ClosestTimeIndexFinder<T extends { time: number }> {
 	private numbers: T[];
 	private cache: Map<string, number>;
@@ -8,6 +28,11 @@ export class ClosestTimeIndexFinder<T extends { time: number }> {
 		this.cache = new Map();
 	}
 
+	/**
+	 * @param target - the time to look for.
+	 * @param direction - which bracketing entry to return, see {@link SearchDirection}.
+	 * @returns the index of the bracketing entry, clamped to the ends of the array.
+	 */
 	public findClosestIndex(target: number, direction: SearchDirection): number {
 		const cacheKey = `${target}:${direction}`;
 		if (this.cache.has(cacheKey)) {

--- a/packages/lwc-toolkit/src/custom-series/line-paths.ts
+++ b/packages/lwc-toolkit/src/custom-series/line-paths.ts
@@ -1,0 +1,142 @@
+import { BitmapCoordinatesRenderingScope } from './renderer-base.js';
+
+/** A point in bitmap coordinates. */
+export interface Position {
+	/** Horizontal bitmap coordinate. */
+	x: number;
+	/** Vertical bitmap coordinate. */
+	y: number;
+}
+
+/** A built line path together with the points it starts and ends at. */
+export interface LinePathData {
+	/** The path itself, in bitmap coordinates. */
+	path: Path2D;
+	/** First point of the path, in the order the path was built. */
+	first: Position;
+	/** Last point of the path, in the order the path was built. */
+	last: Position;
+}
+
+/** The minimum a bar has to provide to be placed horizontally. */
+export interface XPositioned {
+	/** Horizontal position of the bar, in media coordinates. */
+	x: number;
+}
+
+/**
+ * Builds a polyline through the bars in `[from, to)`, scaling the media
+ * coordinates of the bars into the bitmap coordinates of `scope`.
+ *
+ * `getY` returns the media vertical coordinate for a bar — typically the result
+ * of `priceToCoordinate` — and receives the absolute bar index so a series with
+ * several lines per bar can pick the right one. Pass `reverse` to walk the bars
+ * from `to - 1` down to `from`, which is how the returning edge of a filled
+ * area is built (see {@link areaBetween}).
+ *
+ * The range must be non-empty; for an empty range the returned path is empty
+ * and `first`/`last` are the origin. `Path2D` is only constructed when this is
+ * called, so importing the module in a non-browser environment is safe.
+ */
+export function buildLinePath<TBar extends XPositioned>(
+	bars: readonly TBar[],
+	from: number,
+	to: number,
+	getY: (bar: TBar, index: number) => number,
+	scope: BitmapCoordinatesRenderingScope,
+	reverse: boolean = false
+): LinePathData {
+	const { horizontalPixelRatio, verticalPixelRatio } = scope;
+	const path = new Path2D();
+	const first: Position = { x: 0, y: 0 };
+	const last: Position = { x: 0, y: 0 };
+	if (from >= to) {
+		return { path, first, last };
+	}
+	const start = reverse ? to - 1 : from;
+	const end = reverse ? from - 1 : to;
+	const step = reverse ? -1 : 1;
+	for (let i = start; i !== end; i += step) {
+		const bar = bars[i];
+		const x = bar.x * horizontalPixelRatio;
+		const y = getY(bar, i) * verticalPixelRatio;
+		if (i === start) {
+			path.moveTo(x, y);
+			first.x = x;
+			first.y = y;
+		} else {
+			path.lineTo(x, y);
+		}
+		last.x = x;
+		last.y = y;
+	}
+	return { path, first, last };
+}
+
+/**
+ * Closes the band between two line paths into a fillable path: the `upper`
+ * path, a straight edge across to the start of the `lower` path, the `lower`
+ * path, and a straight edge back to where `upper` began.
+ *
+ * The two lines therefore have to run in opposite directions — build the
+ * `lower` one with `reverse` set in {@link buildLinePath} — otherwise the band
+ * is filled as a bow tie.
+ */
+export function areaBetween(upper: LinePathData, lower: LinePathData): Path2D {
+	const area = new Path2D(upper.path);
+	area.lineTo(lower.first.x, lower.first.y);
+	area.addPath(lower.path);
+	area.lineTo(upper.first.x, upper.first.y);
+	area.closePath();
+	return area;
+}
+
+/** Stroke settings for one run of a styled polyline. */
+export interface PolylineStroke {
+	/** Value assigned to `ctx.strokeStyle`. */
+	strokeStyle: string | CanvasGradient | CanvasPattern;
+	/** Value assigned to `ctx.lineWidth`, in the coordinate space of the points. */
+	lineWidth: number;
+}
+
+/**
+ * Strokes a polyline whose style changes along its length, for example a line
+ * series with highlighted ranges.
+ *
+ * `styleAt(i)` gives the style of the segment from `points[i - 1]` to
+ * `points[i]`, and is called exactly once for each `i` from 1 upwards, so a
+ * resolver may build a fresh style object per call. Consecutive segments
+ * whose style is the *same object* (compared by identity) are stroked as one
+ * path, so a resolver that hands out a shared object per range keeps the number
+ * of strokes down to the number of runs. Points with fewer than two entries
+ * draw nothing.
+ */
+export function strokeStyledPolyline(
+	ctx: CanvasRenderingContext2D,
+	points: readonly Position[],
+	styleAt: (index: number) => PolylineStroke
+): void {
+	if (points.length < 2) {
+		return;
+	}
+	const strokeRun = (style: PolylineStroke): void => {
+		ctx.strokeStyle = style.strokeStyle;
+		ctx.lineWidth = style.lineWidth;
+		ctx.stroke();
+	};
+	let runStyle = styleAt(1);
+	ctx.beginPath();
+	ctx.moveTo(points[0].x, points[0].y);
+	ctx.lineTo(points[1].x, points[1].y);
+	for (let i = 2; i < points.length; i++) {
+		const style = styleAt(i);
+		if (style !== runStyle) {
+			strokeRun(runStyle);
+			runStyle = style;
+			ctx.beginPath();
+			ctx.moveTo(points[i - 1].x, points[i - 1].y);
+		}
+		ctx.lineTo(points[i].x, points[i].y);
+	}
+	strokeRun(runStyle);
+}

--- a/packages/lwc-toolkit/src/custom-series/renderer-base.ts
+++ b/packages/lwc-toolkit/src/custom-series/renderer-base.ts
@@ -1,0 +1,129 @@
+import {
+	CustomData,
+	CustomSeriesOptions,
+	ICustomSeriesPaneRenderer,
+	PaneRendererCustomData,
+	PriceToCoordinateConverter,
+	Time,
+} from 'lightweight-charts';
+
+/**
+ * The canvas rendering target a custom series renderer is handed by the chart.
+ *
+ * Derived from the library's own `draw` signature so that the toolkit does not
+ * have to depend on `fancy-canvas` directly; it is the same type.
+ */
+export type CanvasRenderingTarget2D = Parameters<
+	ICustomSeriesPaneRenderer['draw']
+>[0];
+
+/**
+ * The rendering scope passed to `useBitmapCoordinateSpace`: the 2d context plus
+ * the media/bitmap sizes and the pixel ratios needed for pixel-perfect drawing.
+ */
+export type BitmapCoordinatesRenderingScope = Parameters<
+	Parameters<CanvasRenderingTarget2D['useBitmapCoordinateSpace']>[0]
+>[0];
+
+/**
+ * Everything {@link CustomSeriesRendererBase.drawImpl} needs for one paint,
+ * with the values the base class has already checked narrowed to non-null.
+ */
+export interface CustomSeriesDrawArgs<
+	HorzScaleItem,
+	TData extends CustomData<HorzScaleItem>,
+	TOptions extends CustomSeriesOptions,
+> {
+	/** Bars, bar spacing and visible range for this paint. */
+	data: PaneRendererCustomData<HorzScaleItem, TData>;
+	/** Current series options. */
+	options: TOptions;
+	/** Converts a price into a media coordinate, or `null` when off-scale. */
+	priceToCoordinate: PriceToCoordinateConverter;
+	/** First visible bar index (`data.visibleRange.from`). */
+	from: number;
+	/** End of the visible range, exclusive (`data.visibleRange.to`). */
+	to: number;
+	/** Whether the series is hovered. `false` on hosts which do not pass it. */
+	isHovered: boolean;
+	/** Hit test data for the hovered item, when the host provides it. */
+	hitTestData?: unknown;
+}
+
+/**
+ * Base class for a custom series pane renderer: it stores the data and options
+ * handed over by `update`, performs the checks every renderer has to repeat
+ * (no data, no visible range, empty visible range) and only then enters the
+ * bitmap coordinate space and calls {@link CustomSeriesRendererBase.drawImpl}.
+ *
+ * Subclasses implement `drawImpl` and may read the protected `data` and
+ * `options` fields, although everything needed for a paint is also handed to
+ * `drawImpl` already narrowed.
+ */
+export abstract class CustomSeriesRendererBase<
+	HorzScaleItem = Time,
+	TData extends CustomData<HorzScaleItem> = CustomData<HorzScaleItem>,
+	TOptions extends CustomSeriesOptions = CustomSeriesOptions,
+> implements ICustomSeriesPaneRenderer
+{
+	/** Latest data passed to {@link CustomSeriesRendererBase.update}. */
+	protected data: PaneRendererCustomData<HorzScaleItem, TData> | null = null;
+	/** Latest options passed to {@link CustomSeriesRendererBase.update}. */
+	protected options: TOptions | null = null;
+
+	/** Stores the data and options for the next paint. */
+	public update(
+		data: PaneRendererCustomData<HorzScaleItem, TData>,
+		options: TOptions
+	): void {
+		this.data = data;
+		this.options = options;
+	}
+
+	/**
+	 * Draws the series. `isHovered` and `hitTestData` are optional because
+	 * hosts older than the version which added them call `draw` with two
+	 * arguments; `isHovered` is then reported as `false`.
+	 */
+	public draw(
+		target: CanvasRenderingTarget2D,
+		priceConverter: PriceToCoordinateConverter,
+		isHovered?: boolean,
+		hitTestData?: unknown
+	): void {
+		const data = this.data;
+		const options = this.options;
+		if (data === null || options === null || data.bars.length === 0) {
+			return;
+		}
+		const visibleRange = data.visibleRange;
+		if (visibleRange === null) {
+			return;
+		}
+		const { from, to } = visibleRange;
+		if (from >= to) {
+			return;
+		}
+		target.useBitmapCoordinateSpace(
+			(scope: BitmapCoordinatesRenderingScope) =>
+				this.drawImpl(scope, {
+					data,
+					options,
+					priceToCoordinate: priceConverter,
+					from,
+					to,
+					isHovered: isHovered ?? false,
+					hitTestData,
+				})
+		);
+	}
+
+	/**
+	 * Draws one frame inside the bitmap coordinate space. Called only when
+	 * there is data and a non-empty visible range to draw.
+	 */
+	protected abstract drawImpl(
+		scope: BitmapCoordinatesRenderingScope,
+		args: CustomSeriesDrawArgs<HorzScaleItem, TData, TOptions>
+	): void;
+}

--- a/packages/lwc-toolkit/src/custom-series/stacking.ts
+++ b/packages/lwc-toolkit/src/custom-series/stacking.ts
@@ -1,0 +1,50 @@
+import { CustomSeriesPricePlotValues } from 'lightweight-charts';
+
+/**
+ * Running totals of `values`: entry `i` is the sum of `values[0..i]`, which is
+ * the top edge of the `i`-th band of a stacked series. Negative values pull the
+ * running total back down, so a mixed stack builds up and down from the same
+ * baseline. Returns a new array and leaves the input untouched.
+ */
+export function cumulativeSum(values: readonly number[]): number[] {
+	let sum = 0;
+	const result = new Array<number>(values.length);
+	for (let i = 0; i < values.length; i++) {
+		sum += values[i];
+		result[i] = sum;
+	}
+	return result;
+}
+
+/**
+ * Price plot values for one stacked data item: `[low, high, total]`, where the
+ * extremes are taken over the running totals (see {@link cumulativeSum}) and
+ * the baseline, and the last entry — the value the chart treats as the item's
+ * current value — is the total of the stack.
+ *
+ * Reporting the running extremes rather than just the total is what makes a
+ * stack containing negative values autoscale correctly: positive bands
+ * accumulate above the baseline and negative bands below it, so both ends of
+ * the stack stay in view.
+ *
+ * @param values - the band values of the item, in stacking order
+ * @param base - baseline the stack is drawn from, usually zero
+ */
+export function stackedPlotValues(
+	values: readonly number[],
+	base: number = 0
+): CustomSeriesPricePlotValues {
+	let sum = 0;
+	let min = base;
+	let max = base;
+	for (let i = 0; i < values.length; i++) {
+		sum += values[i];
+		if (sum < min) {
+			min = sum;
+		}
+		if (sum > max) {
+			max = sum;
+		}
+	}
+	return [min, max, values.length === 0 ? base : sum];
+}

--- a/packages/lwc-toolkit/src/custom-series/visible-bars.ts
+++ b/packages/lwc-toolkit/src/custom-series/visible-bars.ts
@@ -1,0 +1,117 @@
+import {
+	CustomBarItemData,
+	CustomData,
+	IRange,
+	PaneRendererCustomData,
+} from 'lightweight-charts';
+
+/**
+ * The minimum a bar has to provide for {@link visibleSegments}: the logical
+ * time scale index of the item (`CustomBarItemData.time`), not a timestamp.
+ */
+export interface TimeIndexed {
+	/** Time scale index (logical index) of the item. */
+	readonly time: number;
+}
+
+function clampedRange(
+	range: IRange<number> | null,
+	length: number
+): IRange<number> {
+	if (range === null) {
+		return { from: 0, to: 0 };
+	}
+	return {
+		from: Math.max(0, range.from),
+		to: Math.min(length, range.to),
+	};
+}
+
+/**
+ * Calls `fn` for every bar inside `data.visibleRange`, so that a renderer only
+ * touches the bars it is about to paint instead of mapping the whole dataset.
+ * The index passed to `fn` is the absolute index into `data.bars`, which is
+ * what the visible range and per-index option lookups are expressed in.
+ * Does nothing when the visible range is `null` or empty.
+ */
+export function forEachVisibleBar<
+	HorzScaleItem,
+	TData extends CustomData<HorzScaleItem>,
+>(
+	data: PaneRendererCustomData<HorzScaleItem, TData>,
+	fn: (bar: CustomBarItemData<HorzScaleItem, TData>, index: number) => void
+): void {
+	const { from, to } = clampedRange(data.visibleRange, data.bars.length);
+	for (let i = from; i < to; i++) {
+		fn(data.bars[i], i);
+	}
+}
+
+/**
+ * Maps only the bars inside `data.visibleRange`. The result is compacted:
+ * `result[0]` is the bar at `visibleRange.from`, so index `k` of the result
+ * corresponds to bar `visibleRange.from + k`. The index handed to `fn` is the
+ * absolute index into `data.bars` (use it for per-index option lookups).
+ * Returns an empty array when the visible range is `null` or empty.
+ */
+export function mapVisibleBars<
+	HorzScaleItem,
+	TData extends CustomData<HorzScaleItem>,
+	TResult,
+>(
+	data: PaneRendererCustomData<HorzScaleItem, TData>,
+	fn: (bar: CustomBarItemData<HorzScaleItem, TData>, index: number) => TResult
+): TResult[] {
+	const { from, to } = clampedRange(data.visibleRange, data.bars.length);
+	if (from >= to) {
+		return [];
+	}
+	const result = new Array<TResult>(to - from);
+	for (let i = from; i < to; i++) {
+		result[i - from] = fn(data.bars[i], i);
+	}
+	return result;
+}
+
+/**
+ * Widens a visible range by `by` bars on each side, clamped to `[0, length]`,
+ * for line-type series whose first and last segments have to leave the pane
+ * rather than stop at the first and last visible bar.
+ */
+export function extendRange(
+	range: IRange<number>,
+	length: number,
+	by: number = 1
+): IRange<number> {
+	return {
+		from: Math.max(0, range.from - by),
+		to: Math.min(length, range.to + by),
+	};
+}
+
+/**
+ * Splits a visible range into the runs of consecutive bars, breaking wherever
+ * `bars[i].time !== bars[i - 1].time + 1`. Whitespace data never reaches a
+ * renderer, so a jump in the logical time index is the only sign of a gap and
+ * a line series has to start a new path there instead of bridging it.
+ * The returned ranges are absolute `[from, to)` index ranges into `bars`.
+ */
+export function visibleSegments(
+	bars: readonly TimeIndexed[],
+	range: IRange<number>
+): IRange<number>[] {
+	const { from, to } = clampedRange(range, bars.length);
+	if (from >= to) {
+		return [];
+	}
+	const segments: IRange<number>[] = [];
+	let segmentStart = from;
+	for (let i = from + 1; i < to; i++) {
+		if (bars[i].time !== bars[i - 1].time + 1) {
+			segments.push({ from: segmentStart, to: i });
+			segmentStart = i;
+		}
+	}
+	segments.push({ from: segmentStart, to });
+	return segments;
+}

--- a/packages/lwc-toolkit/src/dimensions/columns.ts
+++ b/packages/lwc-toolkit/src/dimensions/columns.ts
@@ -182,17 +182,44 @@ export function calculateColumnPositions(
 
 export interface ColumnPositionItem {
 	x: number;
+	/**
+	 * Logical index of the bar (as provided by the library on each bar item).
+	 * When present, it is used to detect gaps in the data: two columns are only
+	 * aligned against each other when they are consecutive (`time` differs by
+	 * exactly one). Leave it undefined if the items are known to be gapless.
+	 */
+	time?: number;
 	column?: ColumnPosition;
+}
+
+/**
+ * Whether two neighbouring items are adjacent bars, and therefore whether the
+ * second one should have its edge aligned against the first. Items without a
+ * `time` are assumed to be adjacent, which keeps callers that do not populate
+ * `time` behaving exactly as before.
+ */
+function isAdjacentBar(
+	current: ColumnPositionItem,
+	previous: ColumnPositionItem
+): boolean {
+	if (current.time === undefined || previous.time === undefined) return true;
+	return current.time === previous.time + 1;
 }
 
 /**
  * Calculates the column positions and widths for bars using the existing the
  * array of items.
- * @param items - bar items which include an `x` property, and will be mutated to contain a column property
+ *
+ * Columns are only aligned against their neighbour when the two bars are
+ * consecutive, so the first column after a whitespace gap is neither widened
+ * nor shifted. This requires the items to carry a `time` (logical index); when
+ * they do not, every item is treated as adjacent to the previous one.
+ *
+ * @param items - bar items which include an `x` property (and optionally a `time` property), and will be mutated to contain a column property
  * @param barSpacingMedia - bar spacing in media coordinates
  * @param horizontalPixelRatio - horizontal pixel ratio
- * @param startIndex - start index for visible bars within the items array
- * @param endIndex - end index for visible bars within the items array
+ * @param startIndex - start index for visible bars within the items array (inclusive)
+ * @param endIndex - end index for visible bars within the items array (exclusive)
  */
 export function calculateColumnPositionsInPlace(
 	items: ColumnPositionItem[],
@@ -202,36 +229,36 @@ export function calculateColumnPositionsInPlace(
 	endIndex: number
 ): void {
 	const common = columnCommon(barSpacingMedia, horizontalPixelRatio);
+	const lastIndex = Math.min(endIndex, items.length);
 	let previous: ColumnPosition | undefined = undefined;
-	for (let i = startIndex; i < Math.min(endIndex, items.length); i++) {
-		items[i].column = calculateColumnPosition(items[i].x, common, previous);
+	for (let i = startIndex; i < lastIndex; i++) {
+		const alignAgainst =
+			previous !== undefined && isAdjacentBar(items[i], items[i - 1])
+				? previous
+				: undefined;
+		items[i].column = calculateColumnPosition(items[i].x, common, alignAgainst);
 		previous = items[i].column;
 	}
-	const minColumnWidth = (items as ColumnPositionItem[]).reduce(
-		(smallest: number, item: ColumnPositionItem, index: number) => {
-			if (!item.column || index < startIndex || index > endIndex)
-				return smallest;
-			if (item.column.right < item.column.left) {
-				item.column.right = item.column.left;
-			}
-			const width = item.column.right - item.column.left + 1;
-			return Math.min(smallest, width);
-		},
-		Math.ceil(barSpacingMedia * horizontalPixelRatio)
-	);
+	let minColumnWidth = Math.ceil(barSpacingMedia * horizontalPixelRatio);
+	for (let i = startIndex; i < lastIndex; i++) {
+		const column = items[i].column;
+		if (!column) continue;
+		if (column.right < column.left) {
+			column.right = column.left;
+		}
+		minColumnWidth = Math.min(minColumnWidth, column.right - column.left + 1);
+	}
 	if (common.spacing > 0 && minColumnWidth < alignToMinimalWidthLimit) {
-		(items as ColumnPositionItem[]).forEach(
-			(item: ColumnPositionItem, index: number) => {
-				if (!item.column || index < startIndex || index > endIndex) return;
-				const width = item.column.right - item.column.left + 1;
-				if (width <= minColumnWidth) return item;
-				if (item.column.shiftLeft) {
-					item.column.right -= 1;
-				} else {
-					item.column.left += 1;
-				}
-				return item.column;
+		for (let i = startIndex; i < lastIndex; i++) {
+			const column = items[i].column;
+			if (!column) continue;
+			const width = column.right - column.left + 1;
+			if (width <= minColumnWidth) continue;
+			if (column.shiftLeft) {
+				column.right -= 1;
+			} else {
+				column.left += 1;
 			}
-		);
+		}
 	}
 }

--- a/packages/lwc-toolkit/src/dimensions/full-width.ts
+++ b/packages/lwc-toolkit/src/dimensions/full-width.ts
@@ -3,6 +3,12 @@ import { BitmapPositionLength } from './common.js';
 /**
  * Calculates the position and width which will completely full the space for the bar.
  * Useful if you want to draw something that will not have any gaps between surrounding bars.
+ *
+ * Unlike `positionsBox` and `positionsLine`, the returned `length` is exclusive
+ * of the right edge (`right - left`, not `right - left + 1`). That is what makes
+ * neighbouring bars abut exactly: one bar's `position + length` is the next
+ * bar's `position`, so nothing is drawn twice.
+ *
  * @param xMedia - x coordinate of the bar defined in media sizing
  * @param halfBarSpacingMedia - half the width of the current barSpacing (un-rounded)
  * @param horizontalPixelRatio - horizontal pixel ratio

--- a/packages/lwc-toolkit/src/dom/media-query.ts
+++ b/packages/lwc-toolkit/src/dom/media-query.ts
@@ -1,0 +1,90 @@
+/**
+ * The OS queries which mean "draw with more contrast": either the user asked
+ * for increased contrast, or a forced-colors mode (e.g. Windows High Contrast)
+ * is active.
+ */
+export const HIGH_CONTRAST_QUERIES: readonly string[] = [
+	'(prefers-contrast: more)',
+	'(forced-colors: active)',
+];
+
+/** The OS query which means "avoid animation". */
+export const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * One `MediaQueryList` per query text, shared by every subscriber: creating a
+ * fresh list per subscriber would attach a listener per subscriber to a new
+ * object each time. Populated lazily, so importing this module touches no DOM
+ * API and is safe on the server.
+ */
+const mediaQueryLists = new Map<string, MediaQueryList>();
+
+function mediaQueryList(query: string): MediaQueryList | null {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+		return null;
+	}
+	let list = mediaQueryLists.get(query);
+	if (list === undefined) {
+		list = window.matchMedia(query);
+		mediaQueryLists.set(query, list);
+	}
+	return list;
+}
+
+/**
+ * Whether any of the given media queries currently matches. Returns `false`
+ * where `matchMedia` is unavailable (server-side rendering), so a caller can
+ * treat it as "the OS asks for nothing special".
+ */
+export function mediaQueryMatches(queries: readonly string[]): boolean {
+	return queries.some((query: string) => mediaQueryList(query)?.matches ?? false);
+}
+
+/**
+ * Watches a set of media queries and calls `onChange` whenever their combined
+ * result – does *any* of them match – flips, passing the new value. The initial
+ * state is not reported: read it with {@link mediaQueryMatches} if it is needed.
+ *
+ * Returns an unsubscribe function; calling it more than once is harmless. Where
+ * `matchMedia` is unavailable (server-side rendering) nothing is watched and the
+ * returned function is a no-op.
+ */
+export function subscribeMediaQuery(
+	queries: readonly string[],
+	onChange: (matches: boolean) => void
+): () => void {
+	const lists: MediaQueryList[] = [];
+	for (const query of queries) {
+		const list = mediaQueryList(query);
+		if (list !== null) {
+			lists.push(list);
+		}
+	}
+	if (lists.length === 0) {
+		return (): void => {};
+	}
+
+	let matches = lists.some((list: MediaQueryList) => list.matches);
+	const handler = (): void => {
+		const next = lists.some((list: MediaQueryList) => list.matches);
+		if (next === matches) {
+			return;
+		}
+		matches = next;
+		onChange(next);
+	};
+	for (const list of lists) {
+		list.addEventListener('change', handler);
+	}
+
+	let subscribed = true;
+	return (): void => {
+		if (!subscribed) {
+			return;
+		}
+		subscribed = false;
+		for (const list of lists) {
+			list.removeEventListener('change', handler);
+		}
+	};
+}

--- a/packages/lwc-toolkit/src/dom/pane-element.ts
+++ b/packages/lwc-toolkit/src/dom/pane-element.ts
@@ -1,0 +1,73 @@
+import { IChartApiBase, IPaneApi, Time } from 'lightweight-charts';
+
+/**
+ * Structural check instead of `instanceof HTMLElement`, so these helpers also
+ * work when the chart lives in another document or realm (an iframe, a popup
+ * window), where `HTMLElement` is a different constructor.
+ */
+function isHtmlElement(node: unknown): node is HTMLElement {
+	return (
+		typeof node === 'object' &&
+		node !== null &&
+		'style' in node &&
+		typeof (node as HTMLElement).querySelector === 'function'
+	);
+}
+
+/**
+ * The element inside a pane which shares the coordinate space of the pane's
+ * canvases – the wrapper an overlay (a DOM legend, a focus ring, a tooltip)
+ * should be appended to so that it lines up with what is drawn.
+ *
+ * Returns `null` while the pane has no HTML element yet: a freshly created pane
+ * only gets one on the next redraw, so call `requestUpdate()` and retry.
+ *
+ * This depends on the DOM structure the library builds (a table row per pane,
+ * whose main cell is the one with `position: relative`, wrapping the canvases in
+ * a single child element) rather than on public API. It is deliberately the one
+ * place in the toolkit that knows about it: if that structure ever changes, this
+ * is the module to update.
+ */
+export function paneContentElement<T = Time>(pane: IPaneApi<T>): HTMLElement | null {
+	const paneElement = pane.getHTMLElement();
+	if (!isHtmlElement(paneElement)) {
+		return null;
+	}
+	const cells = Array.from(paneElement.children).filter(isHtmlElement);
+	// The pane row holds the (optional) left price-axis cell, the main pane cell
+	// and the (optional) right price-axis cell. Every one of them can contain a
+	// canvas, so "first cell with a canvas" would wrongly pick the left axis when
+	// it is visible. The library only sets `position: relative` on the main pane
+	// cell, so we key off that and fall back to the first canvas-bearing cell for
+	// forward compatibility.
+	const paneCell =
+		cells.find((cell: HTMLElement) => cell.style.position === 'relative' && cell.querySelector('canvas') !== null) ??
+		cells.find((cell: HTMLElement) => cell.querySelector('canvas') !== null);
+	if (paneCell === undefined) {
+		return null;
+	}
+	return isHtmlElement(paneCell.firstElementChild) ? paneCell.firstElementChild : paneCell;
+}
+
+/**
+ * The `table` element the chart is laid out in – the common ancestor of every
+ * pane row, the axes and the attribution link. Useful for chart-wide DOM work
+ * (a shared overlay, attributes applied to every canvas at once).
+ *
+ * Returns `null` before the chart has built its panes. Like
+ * {@link paneContentElement}, this reads the library's DOM structure, so both
+ * live here together.
+ */
+export function chartTableElement<T = Time>(chart: IChartApiBase<T>): HTMLElement | null {
+	for (const pane of chart.panes()) {
+		const paneElement = pane.getHTMLElement();
+		if (!isHtmlElement(paneElement)) {
+			continue;
+		}
+		const table = paneElement.closest('table');
+		if (isHtmlElement(table)) {
+			return table;
+		}
+	}
+	return null;
+}

--- a/packages/lwc-toolkit/src/line-style.ts
+++ b/packages/lwc-toolkit/src/line-style.ts
@@ -1,0 +1,67 @@
+/**
+ * The line styles the chart itself draws, by their numeric values. The values
+ * match `LineStyle` in `lightweight-charts`, so an option typed with the
+ * library's enum can be passed straight to {@link setLineStyle}.
+ */
+export const LineStyle = {
+	/** A solid line. */
+	Solid: 0,
+	/** A dotted line. */
+	Dotted: 1,
+	/** A dashed line. */
+	Dashed: 2,
+	/** A dashed line with bigger dashes. */
+	LargeDashed: 3,
+	/** A dotted line with more space between dots. */
+	SparseDotted: 4,
+} as const;
+
+/** One of the {@link LineStyle} values. */
+export type LineStyle = (typeof LineStyle)[keyof typeof LineStyle];
+
+/**
+ * The dash pattern the chart uses for a line style, as multiples of
+ * `lineWidth`: the array to hand to `CanvasRenderingContext2D.setLineDash`.
+ * An unknown style, and `Solid`, give an empty pattern (a solid line).
+ *
+ * @param style - line style to draw
+ * @param lineWidth - width of the line, in the units of the coordinate space being drawn in
+ */
+export function getDashPattern(style: LineStyle, lineWidth: number): number[] {
+	switch (style) {
+		case LineStyle.Solid:
+			return [];
+		case LineStyle.Dotted:
+			return [lineWidth, lineWidth];
+		case LineStyle.Dashed:
+			return [2 * lineWidth, 2 * lineWidth];
+		case LineStyle.LargeDashed:
+			return [6 * lineWidth, 6 * lineWidth];
+		case LineStyle.SparseDotted:
+			return [lineWidth, 4 * lineWidth];
+		default:
+			return [];
+	}
+}
+
+/**
+ * Applies a line style to a canvas context, the way the chart's own lines are
+ * dashed. Set `ctx.lineWidth` first: the dash lengths are multiples of it.
+ *
+ * `pixelRatio` scales the pattern for the coordinate space being drawn in. Its
+ * default of `1` is right whenever `ctx.lineWidth` is already in the units of
+ * that space — including the usual bitmap-space renderer, which sets
+ * `ctx.lineWidth = width * verticalPixelRatio`. Pass the pixel ratio only when
+ * drawing in bitmap coordinates with `ctx.lineWidth` left in media units.
+ *
+ * @returns the dash pattern which was applied
+ */
+export function setLineStyle(
+	ctx: CanvasRenderingContext2D,
+	style: LineStyle,
+	pixelRatio: number = 1
+): number[] {
+	const dashPattern = getDashPattern(style, ctx.lineWidth * pixelRatio);
+	ctx.setLineDash(dashPattern);
+	return dashPattern;
+}

--- a/packages/lwc-toolkit/src/min-max-in-range.ts
+++ b/packages/lwc-toolkit/src/min-max-in-range.ts
@@ -2,6 +2,17 @@ interface UpperLowerData {
 	upper: number;
 	lower: number;
 }
+
+/**
+ * Finds the lowest `lower` and highest `upper` over a range of items, which is
+ * what an autoscale provider needs for a band-style series.
+ *
+ * The array is scanned in fixed-size chunks whose extremes are cached, so the
+ * requested range is widened to whole chunks and repeated queries are cheap.
+ * The items are read lazily and the results are cached: the array passed to the
+ * constructor must not be mutated afterwards - build a new instance instead.
+ * The returned object is the cached one, so callers must not mutate it either.
+ */
 export class UpperLowerInRange<T extends UpperLowerData> {
 	private _arr: T[];
 	private _chunkSize: number;
@@ -13,10 +24,17 @@ export class UpperLowerInRange<T extends UpperLowerData> {
 		this._cache = new Map();
 	}
 
+	/**
+	 * @param startIndex - first item of the range (inclusive).
+	 * @param endIndex - last item of the range (inclusive). It is rounded up to
+	 * the end of the chunk it falls in, and clamped to the end of the array.
+	 * @returns the lowest `lower` and the highest `upper` over the range.
+	 */
 	public getMinMax(startIndex: number, endIndex: number): UpperLowerData {
 		const cacheKey = `${startIndex}:${endIndex}`;
-		if (cacheKey in this._cache) {
-			return this._cache.get(cacheKey) as T;
+		const cached = this._cache.get(cacheKey);
+		if (cached !== undefined) {
+			return cached;
 		}
 
 		const result: UpperLowerData = {
@@ -38,9 +56,9 @@ export class UpperLowerInRange<T extends UpperLowerData> {
 			);
 			const chunkCacheKey = `${chunkStart}:${chunkEnd}`;
 
-			if (chunkCacheKey in this._cache.keys()) {
-				const item = this._cache.get(cacheKey) as T;
-				this._check(item, result);
+			const cachedChunk = this._cache.get(chunkCacheKey);
+			if (cachedChunk !== undefined) {
+				this._check(cachedChunk, result);
 			} else {
 				const chunkResult: UpperLowerData = {
 					lower: Infinity,

--- a/packages/lwc-toolkit/src/pane-plugin-base.ts
+++ b/packages/lwc-toolkit/src/pane-plugin-base.ts
@@ -1,0 +1,50 @@
+import {
+	IChartApiBase,
+	IPanePrimitive,
+	PaneAttachedParameter,
+	Time,
+} from 'lightweight-charts';
+
+import { ensureDefined } from './assertions.js';
+
+/**
+ * Base class for pane primitives, the pane-level counterpart of `PluginBase`.
+ *
+ * It holds the chart reference and the `requestUpdate` callback handed over by
+ * the library in `attached`, so a primitive only has to implement its views.
+ * Subclasses which override `attached` / `detached` must call `super.attached(param)`
+ * / `super.detached()`, otherwise `chart` throws and `requestUpdate()` does nothing.
+ *
+ * Reading `chart` before the primitive has been attached (or after it has been
+ * detached) throws, so the getter can be used without a null check everywhere a
+ * view is drawn.
+ */
+export abstract class PanePluginBase<T = Time> implements IPanePrimitive<T> {
+	private _chart: IChartApiBase<T> | undefined = undefined;
+	private _requestUpdate: (() => void) | undefined = undefined;
+
+	/** The chart the primitive is attached to. Throws while the primitive is not attached. */
+	public get chart(): IChartApiBase<T> {
+		return ensureDefined(this._chart);
+	}
+
+	/** Attached lifecycle hook: keeps the chart and the update callback. */
+	public attached({ chart, requestUpdate }: PaneAttachedParameter<T>): void {
+		this._chart = chart;
+		this._requestUpdate = requestUpdate;
+		this.requestUpdate();
+	}
+
+	/** Detached lifecycle hook: releases everything taken in {@link attached}. */
+	public detached(): void {
+		this._chart = undefined;
+		this._requestUpdate = undefined;
+	}
+
+	/** Asks the chart to redraw. Does nothing while the primitive is not attached. */
+	protected requestUpdate(): void {
+		if (this._requestUpdate) {
+			this._requestUpdate();
+		}
+	}
+}

--- a/packages/lwc-toolkit/src/time.ts
+++ b/packages/lwc-toolkit/src/time.ts
@@ -22,6 +22,26 @@ export function convertTime(t: Time): number {
 	return new Date(year, month - 1, day).valueOf();
 }
 
+/**
+ * Converts any of the library's time representations to milliseconds since the
+ * epoch, building business days and date strings as UTC midnight.
+ *
+ * Use this rather than {@link convertTime} whenever the result is compared with
+ * a `UTCTimestamp` from the chart, or formatted with the `getUTC*` date getters:
+ * unlike {@link convertTime} it is independent of the machine's time zone, so
+ * the same input always yields the same number.
+ *
+ * @param t - the time to convert.
+ * @returns milliseconds since the epoch.
+ */
+export function convertTimeUTC(t: Time): number {
+	if (isUTCTimestamp(t)) return t * 1000;
+	// `BusinessDay.month` is 1-based; `Date.UTC`'s month is 0-based.
+	if (isBusinessDay(t)) return Date.UTC(t.year, t.month - 1, t.day);
+	const [year, month, day] = t.split('-').map(part => parseInt(part, 10));
+	return Date.UTC(year, month - 1, day);
+}
+
 export function displayTime(time: Time): string {
 	if (typeof time == 'string') return time;
 	const date = isBusinessDay(time)

--- a/packages/lwc-toolkit/tests/unit/axis-label-view.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/axis-label-view.spec.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+import { Coordinate } from 'lightweight-charts';
+import { describe, it } from 'node:test';
+
+import {
+	AxisLabelSource,
+	AxisLabelView,
+	OFFSCREEN_LABEL_COORDINATE,
+} from '../../src/axis-label-view.js';
+
+class FakeSource implements AxisLabelSource {
+	public pos: Coordinate | null;
+	public label = 'label';
+	public coordinateCalls = 0;
+
+	public constructor(pos: number | null) {
+		this.pos = pos as Coordinate | null;
+	}
+
+	public coordinate(): Coordinate | null {
+		this.coordinateCalls++;
+		return this.pos;
+	}
+
+	public text(): string {
+		return this.label;
+	}
+
+	public textColor(): string {
+		return '#ffffff';
+	}
+
+	public backColor(): string {
+		return '#2962ff';
+	}
+}
+
+class HiddenSource extends FakeSource {
+	public visible(): boolean {
+		return false;
+	}
+
+	public tickVisible(): boolean {
+		return false;
+	}
+}
+
+void describe('AxisLabelView', () => {
+	void it('passes the source values through', () => {
+		const view = new AxisLabelView(new FakeSource(42));
+		expect(view.coordinate()).to.equal(42);
+		expect(view.text()).to.equal('label');
+		expect(view.textColor()).to.equal('#ffffff');
+		expect(view.backColor()).to.equal('#2962ff');
+	});
+
+	void it('is visible by default when the source omits visible()/tickVisible()', () => {
+		const view = new AxisLabelView(new FakeSource(0));
+		expect(view.visible()).to.equal(true);
+		expect(view.tickVisible()).to.equal(true);
+	});
+
+	void it('honours a source which opts out of drawing', () => {
+		const view = new AxisLabelView(new HiddenSource(42));
+		expect(view.visible()).to.equal(false);
+		expect(view.tickVisible()).to.equal(false);
+	});
+
+	void it('hides the label when the coordinate cannot be resolved', () => {
+		const view = new AxisLabelView(new FakeSource(null));
+		expect(view.visible()).to.equal(false);
+		expect(view.tickVisible()).to.equal(false);
+	});
+
+	void it('reports a far-offscreen coordinate rather than 0 for an unresolved value', () => {
+		const view = new AxisLabelView(new FakeSource(null));
+		expect(view.coordinate()).to.equal(OFFSCREEN_LABEL_COORDINATE);
+		expect(view.coordinate()).to.be.lessThan(-1000);
+	});
+
+	void it('keeps a real coordinate of 0 as 0', () => {
+		const view = new AxisLabelView(new FakeSource(0));
+		expect(view.coordinate()).to.equal(0);
+	});
+
+	void it('re-reads the source on every call, so no update step is needed', () => {
+		const source = new FakeSource(null);
+		const view = new AxisLabelView(source);
+		expect(view.visible()).to.equal(false);
+		source.pos = 15 as Coordinate;
+		source.label = 'moved';
+		expect(view.coordinate()).to.equal(15);
+		expect(view.text()).to.equal('moved');
+		expect(view.visible()).to.equal(true);
+		expect(source.coordinateCalls).to.be.greaterThan(1);
+	});
+
+	void it('exposes the source it was built over', () => {
+		const source = new FakeSource(1);
+		expect(new AxisLabelView(source).source()).to.equal(source);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/closest-index.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/closest-index.spec.ts
@@ -35,28 +35,28 @@ void describe('ClosestTimeIndexFinder', () => {
 		expect(finder().findClosestIndex(1000, 'right')).to.equal(3);
 	});
 
-	void it("direction 'left' returns the index to the RIGHT of the target", () => {
-		// Questionable naming, but current behaviour: for a target between two
-		// entries, 'left' yields the following (greater) index.
+	void it("direction 'left' returns the first entry at or after the target", () => {
+		// 'left' names the side the search comes from, not the side of the
+		// answer: it returns the right-hand bracket of the target.
 		expect(finder().findClosestIndex(5, 'left')).to.equal(1);
 		expect(finder().findClosestIndex(15, 'left')).to.equal(2);
 		expect(finder().findClosestIndex(25, 'left')).to.equal(3);
 	});
 
-	void it("direction 'right' returns the index to the LEFT of the target", () => {
+	void it("direction 'right' returns the last entry at or before the target", () => {
 		expect(finder().findClosestIndex(5, 'right')).to.equal(0);
 		expect(finder().findClosestIndex(15, 'right')).to.equal(1);
 		expect(finder().findClosestIndex(25, 'right')).to.equal(2);
 	});
 
-	void it('does not pick the nearest neighbour by distance, only by side', () => {
+	void it('picks by side, never by distance', () => {
 		// 9 is much closer to index 1 (time 10) than to index 0 (time 0)
 		expect(finder().findClosestIndex(9, 'right')).to.equal(0);
 		// 1 is much closer to index 0 (time 0) than to index 1 (time 10)
 		expect(finder().findClosestIndex(1, 'left')).to.equal(1);
 	});
 
-	void it('caches per target and direction, so later mutations of the array are ignored', () => {
+	void it('caches per target and direction, so the array must not be mutated afterwards', () => {
 		const points: Point[] = [{ time: 0 }, { time: 10 }, { time: 20 }];
 		const instance = new ClosestTimeIndexFinder<Point>(points);
 		expect(instance.findClosestIndex(15, 'right')).to.equal(1);

--- a/packages/lwc-toolkit/tests/unit/columns.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/columns.spec.ts
@@ -209,16 +209,15 @@ void describe('calculateColumnPositionsInPlace', () => {
 		).to.deep.equal([false, true, false, true]);
 	});
 
-	void it('narrow-column pass treats endIndex as INCLUSIVE, so it can touch a stale column at endIndex', () => {
-		// Questionable: the position loop stops before endIndex, but the
-		// min-width / narrow-column passes guard with `index > endIndex`, so a
-		// column left over from an earlier call at exactly endIndex is both
-		// measured and mutated.
+	void it('every pass treats endIndex as exclusive, leaving a stale column at endIndex alone', () => {
+		// The min-width and narrow-column passes use the same range as the
+		// position loop, so a column left over from an earlier call at exactly
+		// endIndex is neither measured nor mutated.
 		const bars = items(4, 2.6);
 		bars[2].column = { left: 100, right: 105, shiftLeft: false };
 		calculateColumnPositionsInPlace(bars, 2.6, 1, 0, 2);
 		expect(bars[2].column).to.deep.equal({
-			left: 101,
+			left: 100,
 			right: 105,
 			shiftLeft: false,
 		});
@@ -235,16 +234,82 @@ void describe('calculateColumnPositionsInPlace', () => {
 		});
 	});
 
-	void it('collapses right onto left rather than allowing a negative width', () => {
+	void it('does nothing at all when endIndex is not above startIndex', () => {
 		const bars: ColumnPositionItem[] = [{ x: 10 }];
 		bars[0].column = { left: 20, right: 5, shiftLeft: false };
-		// startIndex above the item keeps the position loop from overwriting it,
-		// but the fixing pass still runs over index 0.
 		calculateColumnPositionsInPlace(bars, 6, 1, 0, 0);
 		expect(bars[0].column).to.deep.equal({
 			left: 20,
-			right: 20,
+			right: 5,
 			shiftLeft: false,
 		});
+	});
+
+	void it('collapses right onto left rather than allowing a negative width', () => {
+		// sub-pixel bar spacing can produce right < left before the fixing pass
+		const bars = items(4, 0.5);
+		calculateColumnPositionsInPlace(bars, 0.5, 1, 0, 4);
+		for (const item of bars) {
+			expect(item.column?.right).to.be.at.least(item.column?.left as number);
+		}
+	});
+
+	void it('is unaffected by a time on every item when there are no gaps', () => {
+		const withoutTime = items(6, 6.3);
+		calculateColumnPositionsInPlace(withoutTime, 6.3, 1.25, 0, 6);
+		const withTime = items(6, 6.3).map(
+			(item: ColumnPositionItem, index: number) => ({ ...item, time: index })
+		);
+		calculateColumnPositionsInPlace(withTime, 6.3, 1.25, 0, 6);
+		expect(withTime.map((item: ColumnPositionItem) => item.column)).to.deep.equal(
+			withoutTime.map((item: ColumnPositionItem) => item.column)
+		);
+	});
+
+	void it('does not align the first column after a whitespace gap', () => {
+		// bar 2 sits two logical bars after bar 1, so it must keep the position
+		// it would have if it were the first bar drawn.
+		const bars: ColumnPositionItem[] = [
+			{ x: 0, time: 0 },
+			{ x: 6.3, time: 1 },
+			{ x: 18.9, time: 3 },
+		];
+		calculateColumnPositionsInPlace(bars, 6.3, 1.25, 0, 3);
+		expect(bars[2].column).to.deep.equal(
+			calculateColumnPositions([18.9], 6.3, 1.25)[0]
+		);
+	});
+
+	void it('does not widen the last column before a whitespace gap', () => {
+		const gapped: ColumnPositionItem[] = [
+			{ x: 0, time: 0 },
+			{ x: 6.3, time: 1 },
+			{ x: 18.9, time: 3 },
+		];
+		calculateColumnPositionsInPlace(gapped, 6.3, 1.25, 0, 3);
+		const consecutive: ColumnPositionItem[] = [
+			{ x: 0, time: 0 },
+			{ x: 6.3, time: 1 },
+		];
+		calculateColumnPositionsInPlace(consecutive, 6.3, 1.25, 0, 2);
+		// the bar before the gap is positioned as if nothing followed it
+		expect(gapped[1].column).to.deep.equal(consecutive[1].column);
+	});
+
+	void it('keeps aligning the columns on each side of a gap to their own neighbours', () => {
+		const bars: ColumnPositionItem[] = [
+			{ x: 0, time: 0 },
+			{ x: 6.3, time: 1 },
+			{ x: 18.9, time: 3 },
+			{ x: 25.2, time: 4 },
+		];
+		calculateColumnPositionsInPlace(bars, 6.3, 1.25, 0, 4);
+		const gap = (a: number, b: number): number =>
+			(bars[b].column as ColumnPosition).left -
+			(bars[a].column as ColumnPosition).right -
+			1;
+		// consecutive pairs keep the reserved one-pixel gap
+		expect(gap(0, 1)).to.equal(1);
+		expect(gap(2, 3)).to.equal(1);
 	});
 });

--- a/packages/lwc-toolkit/tests/unit/full-width.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/full-width.spec.ts
@@ -5,7 +5,8 @@ import { fullBarWidth } from '../../src/dimensions/full-width.js';
 
 void describe('fullBarWidth', () => {
 	void it('spans the whole bar slot at DPR 1', () => {
-		// unlike positionsBox, the length here is exclusive: right - left
+		// unlike positionsBox, the length here is exclusive (right - left), which
+		// is what lets neighbouring bars abut without overlapping
 		expect(fullBarWidth(10, 3, 1)).to.deep.equal({ position: 7, length: 6 });
 	});
 

--- a/packages/lwc-toolkit/tests/unit/line-paths.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/line-paths.spec.ts
@@ -1,0 +1,316 @@
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+
+import {
+	areaBetween,
+	buildLinePath,
+	LinePathData,
+	PolylineStroke,
+	Position,
+	strokeStyledPolyline,
+	XPositioned,
+} from '../../src/custom-series/line-paths.js';
+import { BitmapCoordinatesRenderingScope } from '../../src/custom-series/renderer-base.js';
+
+/**
+ * Stand-in for the browser's `Path2D`, which Node does not provide. Each
+ * instance records the calls made on it; a path copied into another one is
+ * prefixed so that the composition stays visible in the recorded operations.
+ */
+class FakePath2D {
+	public readonly ops: string[] = [];
+
+	public constructor(from?: FakePath2D) {
+		if (from !== undefined) {
+			this.ops.push(...from.ops.map((op: string) => `copy:${op}`));
+		}
+	}
+
+	public moveTo(x: number, y: number): void {
+		this.ops.push(`moveTo(${x},${y})`);
+	}
+
+	public lineTo(x: number, y: number): void {
+		this.ops.push(`lineTo(${x},${y})`);
+	}
+
+	public addPath(path: FakePath2D): void {
+		this.ops.push(...path.ops.map((op: string) => `add:${op}`));
+	}
+
+	public closePath(): void {
+		this.ops.push('closePath');
+	}
+}
+
+(globalThis as unknown as { Path2D: unknown }).Path2D = FakePath2D;
+
+function ops(path: LinePathData | Path2D): string[] {
+	const target = 'path' in path ? path.path : path;
+	return (target as unknown as FakePath2D).ops;
+}
+
+function scope(
+	horizontalPixelRatio: number,
+	verticalPixelRatio: number
+): BitmapCoordinatesRenderingScope {
+	return {
+		horizontalPixelRatio,
+		verticalPixelRatio,
+	} as unknown as BitmapCoordinatesRenderingScope;
+}
+
+interface TestBar extends XPositioned {
+	value: number;
+}
+
+function bars(xs: number[]): TestBar[] {
+	return xs.map((x: number, i: number) => ({ x, value: i }));
+}
+
+const value = (bar: TestBar): number => bar.value;
+
+void describe('buildLinePath', () => {
+	void it('moves to the first point and lines to the rest', () => {
+		const line = buildLinePath(bars([0, 10, 20]), 0, 3, value, scope(1, 1));
+		expect(ops(line)).to.deep.equal([
+			'moveTo(0,0)',
+			'lineTo(10,1)',
+			'lineTo(20,2)',
+		]);
+	});
+
+	void it('scales x by the horizontal and y by the vertical pixel ratio', () => {
+		const line = buildLinePath(bars([0, 10]), 0, 2, value, scope(2, 3));
+		expect(ops(line)).to.deep.equal(['moveTo(0,0)', 'lineTo(20,3)']);
+	});
+
+	void it('only walks the requested range', () => {
+		const line = buildLinePath(bars([0, 10, 20, 30]), 1, 3, value, scope(1, 1));
+		expect(ops(line)).to.deep.equal(['moveTo(10,1)', 'lineTo(20,2)']);
+	});
+
+	void it('reports the first and last points of the path', () => {
+		const line = buildLinePath(bars([0, 10, 20]), 0, 3, value, scope(2, 2));
+		expect(line.first).to.deep.equal({ x: 0, y: 0 });
+		expect(line.last).to.deep.equal({ x: 40, y: 4 });
+	});
+
+	void it('walks the bars backwards when reversed', () => {
+		const line = buildLinePath(
+			bars([0, 10, 20]),
+			0,
+			3,
+			value,
+			scope(1, 1),
+			true
+		);
+		expect(ops(line)).to.deep.equal([
+			'moveTo(20,2)',
+			'lineTo(10,1)',
+			'lineTo(0,0)',
+		]);
+	});
+
+	void it('reports first and last in traversal order when reversed', () => {
+		const line = buildLinePath(
+			bars([0, 10, 20]),
+			0,
+			3,
+			value,
+			scope(1, 1),
+			true
+		);
+		expect(line.first).to.deep.equal({ x: 20, y: 2 });
+		expect(line.last).to.deep.equal({ x: 0, y: 0 });
+	});
+
+	void it('hands the absolute bar index to getY', () => {
+		const indices: number[] = [];
+		buildLinePath(
+			bars([0, 10, 20, 30]),
+			2,
+			4,
+			(_: TestBar, index: number) => {
+				indices.push(index);
+				return 0;
+			},
+			scope(1, 1)
+		);
+		expect(indices).to.deep.equal([2, 3]);
+	});
+
+	void it('draws a single bar as a lone move, with first equal to last', () => {
+		const line = buildLinePath(bars([0, 10, 20]), 1, 2, value, scope(1, 1));
+		expect(ops(line)).to.deep.equal(['moveTo(10,1)']);
+		expect(line.first).to.deep.equal(line.last);
+	});
+
+	void it('returns an empty path for an empty range', () => {
+		const line = buildLinePath(bars([0, 10]), 1, 1, value, scope(1, 1));
+		expect(ops(line)).to.deep.equal([]);
+		expect(line.first).to.deep.equal({ x: 0, y: 0 });
+		expect(line.last).to.deep.equal({ x: 0, y: 0 });
+	});
+});
+
+void describe('areaBetween', () => {
+	void it('closes the band between the two lines', () => {
+		const upper = buildLinePath(bars([0, 10]), 0, 2, value, scope(1, 1));
+		const lower = buildLinePath(
+			bars([0, 10]),
+			0,
+			2,
+			(bar: TestBar) => bar.value + 5,
+			scope(1, 1),
+			true
+		);
+		expect(ops(areaBetween(upper, lower))).to.deep.equal([
+			// the upper line, copied
+			'copy:moveTo(0,0)',
+			'copy:lineTo(10,1)',
+			// across to where the (reversed) lower line starts
+			'lineTo(10,6)',
+			// the lower line, running back the other way
+			'add:moveTo(10,6)',
+			'add:lineTo(0,5)',
+			// and back to the start of the upper line
+			'lineTo(0,0)',
+			'closePath',
+		]);
+	});
+
+	void it('leaves the source paths untouched', () => {
+		const upper = buildLinePath(bars([0, 10]), 0, 2, value, scope(1, 1));
+		const lower = buildLinePath(bars([0, 10]), 0, 2, value, scope(1, 1), true);
+		const before = [...ops(upper)];
+		areaBetween(upper, lower);
+		expect(ops(upper)).to.deep.equal(before);
+	});
+});
+
+interface RecordedStroke {
+	strokeStyle: string;
+	lineWidth: number;
+	points: string[];
+}
+
+interface FakeContext {
+	strokes: RecordedStroke[];
+	strokeStyle: string;
+	lineWidth: number;
+}
+
+/**
+ * Minimal context which records each stroked run: the style in effect and the
+ * points which were added to the path since the last `beginPath`.
+ */
+function fakeContext(): FakeContext & CanvasRenderingContext2D {
+	const strokes: RecordedStroke[] = [];
+	let points: string[] = [];
+	const context = {
+		strokes,
+		strokeStyle: '',
+		lineWidth: 0,
+		beginPath: (): void => {
+			points = [];
+		},
+		moveTo: (x: number, y: number): void => {
+			points.push(`M${x},${y}`);
+		},
+		lineTo: (x: number, y: number): void => {
+			points.push(`L${x},${y}`);
+		},
+	} as unknown as FakeContext & CanvasRenderingContext2D;
+	context.stroke = (): void => {
+		strokes.push({
+			strokeStyle: context.strokeStyle as string,
+			lineWidth: context.lineWidth,
+			points: [...points],
+		});
+	};
+	return context;
+}
+
+function points(xs: number[]): Position[] {
+	return xs.map((x: number) => ({ x, y: x }));
+}
+
+void describe('strokeStyledPolyline', () => {
+	const red: PolylineStroke = { strokeStyle: 'red', lineWidth: 1 };
+	const blue: PolylineStroke = { strokeStyle: 'blue', lineWidth: 3 };
+
+	void it('strokes a single-styled line once', () => {
+		const ctx = fakeContext();
+		strokeStyledPolyline(ctx, points([0, 1, 2, 3]), () => red);
+		expect(ctx.strokes).to.have.length(1);
+		expect(ctx.strokes[0]).to.deep.equal({
+			strokeStyle: 'red',
+			lineWidth: 1,
+			points: ['M0,0', 'L1,1', 'L2,2', 'L3,3'],
+		});
+	});
+
+	void it('starts a new run when the style object changes', () => {
+		const ctx = fakeContext();
+		strokeStyledPolyline(ctx, points([0, 1, 2, 3]), (i: number) =>
+			i < 3 ? red : blue
+		);
+		expect(ctx.strokes.map((s: RecordedStroke) => s.strokeStyle)).to.deep.equal(
+			['red', 'blue']
+		);
+		expect(ctx.strokes[0].points).to.deep.equal(['M0,0', 'L1,1', 'L2,2']);
+		// the new run restarts at the last point of the previous one, so the
+		// line stays joined up
+		expect(ctx.strokes[1].points).to.deep.equal(['M2,2', 'L3,3']);
+	});
+
+	void it('applies the line width of each run', () => {
+		const ctx = fakeContext();
+		strokeStyledPolyline(ctx, points([0, 1, 2]), (i: number) =>
+			i < 2 ? red : blue
+		);
+		expect(ctx.strokes.map((s: RecordedStroke) => s.lineWidth)).to.deep.equal([
+			1, 3,
+		]);
+	});
+
+	void it('styles the segment ending at a point by that point index', () => {
+		const seen: number[] = [];
+		strokeStyledPolyline(fakeContext(), points([0, 1, 2]), (i: number) => {
+			seen.push(i);
+			return red;
+		});
+		// each segment is styled once, and there is no segment for point 0
+		expect(seen).to.deep.equal([1, 2]);
+	});
+
+	void it('strokes once per run, not once per segment', () => {
+		const ctx = fakeContext();
+		const styles = [red, red, blue, blue, red];
+		strokeStyledPolyline(
+			ctx,
+			points([0, 1, 2, 3, 4]),
+			(i: number) => styles[i]
+		);
+		expect(ctx.strokes.map((s: RecordedStroke) => s.strokeStyle)).to.deep.equal(
+			['red', 'blue', 'red']
+		);
+	});
+
+	void it('treats equal-looking but distinct style objects as separate runs', () => {
+		const ctx = fakeContext();
+		strokeStyledPolyline(ctx, points([0, 1, 2]), () => ({
+			strokeStyle: 'red',
+			lineWidth: 1,
+		}));
+		expect(ctx.strokes).to.have.length(2);
+	});
+
+	void it('draws nothing for fewer than two points', () => {
+		const ctx = fakeContext();
+		strokeStyledPolyline(ctx, points([0]), () => red);
+		strokeStyledPolyline(ctx, [], () => red);
+		expect(ctx.strokes).to.deep.equal([]);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/line-style.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/line-style.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+
+import {
+	getDashPattern,
+	LineStyle,
+	setLineStyle,
+} from '../../src/line-style.js';
+
+interface FakeContext {
+	patterns: number[][];
+	lineWidth: number;
+}
+
+/**
+ * Minimal `CanvasRenderingContext2D` stand-in which records every dash pattern
+ * applied to it.
+ */
+function fakeContext(lineWidth: number): FakeContext & CanvasRenderingContext2D {
+	const patterns: number[][] = [];
+	return {
+		patterns,
+		lineWidth,
+		setLineDash: (segments: number[]): void => {
+			patterns.push(segments);
+		},
+	} as unknown as FakeContext & CanvasRenderingContext2D;
+}
+
+void describe('getDashPattern', () => {
+	void it('gives a solid line no dash pattern', () => {
+		expect(getDashPattern(LineStyle.Solid, 2)).to.deep.equal([]);
+	});
+
+	void it('scales every pattern by the line width', () => {
+		expect(getDashPattern(LineStyle.Dotted, 1)).to.deep.equal([1, 1]);
+		expect(getDashPattern(LineStyle.Dotted, 3)).to.deep.equal([3, 3]);
+		expect(getDashPattern(LineStyle.Dashed, 2)).to.deep.equal([4, 4]);
+		expect(getDashPattern(LineStyle.LargeDashed, 2)).to.deep.equal([12, 12]);
+		expect(getDashPattern(LineStyle.SparseDotted, 2)).to.deep.equal([2, 8]);
+	});
+
+	void it('matches the numeric values the chart uses', () => {
+		expect(getDashPattern(0, 1)).to.deep.equal([]);
+		expect(getDashPattern(1, 1)).to.deep.equal([1, 1]);
+		expect(getDashPattern(2, 1)).to.deep.equal([2, 2]);
+		expect(getDashPattern(3, 1)).to.deep.equal([6, 6]);
+		expect(getDashPattern(4, 1)).to.deep.equal([1, 4]);
+	});
+
+	void it('falls back to a solid line for an unknown style', () => {
+		expect(getDashPattern(9 as LineStyle, 1)).to.deep.equal([]);
+	});
+});
+
+void describe('setLineStyle', () => {
+	void it('applies the pattern for the style to the context', () => {
+		const ctx = fakeContext(1);
+		setLineStyle(ctx, LineStyle.Dashed);
+		expect(ctx.patterns).to.deep.equal([[2, 2]]);
+	});
+
+	void it('clears the dash pattern for a solid line', () => {
+		const ctx = fakeContext(2);
+		setLineStyle(ctx, LineStyle.Solid);
+		expect(ctx.patterns).to.deep.equal([[]]);
+	});
+
+	void it('derives the dash lengths from the current line width', () => {
+		const ctx = fakeContext(4);
+		setLineStyle(ctx, LineStyle.Dotted);
+		expect(ctx.patterns).to.deep.equal([[4, 4]]);
+	});
+
+	void it('leaves the pattern in media units by default', () => {
+		const ctx = fakeContext(2);
+		expect(setLineStyle(ctx, LineStyle.Dashed)).to.deep.equal([4, 4]);
+	});
+
+	void it('scales the pattern by the pixel ratio when one is given', () => {
+		const ctx = fakeContext(2);
+		expect(setLineStyle(ctx, LineStyle.Dashed, 2)).to.deep.equal([8, 8]);
+		expect(ctx.patterns).to.deep.equal([[8, 8]]);
+	});
+
+	void it('handles a fractional pixel ratio', () => {
+		const ctx = fakeContext(1);
+		expect(setLineStyle(ctx, LineStyle.Dotted, 1.5)).to.deep.equal([1.5, 1.5]);
+	});
+
+	void it('returns the pattern it applied', () => {
+		const ctx = fakeContext(1);
+		const pattern = setLineStyle(ctx, LineStyle.SparseDotted);
+		expect(pattern).to.deep.equal([1, 4]);
+		expect(ctx.patterns[0]).to.deep.equal(pattern);
+	});
+
+	void it('applies a new pattern on every call', () => {
+		const ctx = fakeContext(1);
+		setLineStyle(ctx, LineStyle.Dashed);
+		setLineStyle(ctx, LineStyle.Solid);
+		expect(ctx.patterns).to.deep.equal([[2, 2], []]);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/media-query.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/media-query.spec.ts
@@ -1,0 +1,202 @@
+import { expect } from 'chai';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+	HIGH_CONTRAST_QUERIES,
+	REDUCED_MOTION_QUERY,
+	mediaQueryMatches,
+	subscribeMediaQuery,
+} from '../../src/dom/media-query.js';
+
+/** Minimal stand-in for a `MediaQueryList`, with a way to flip its state. */
+class FakeMediaQueryList {
+	public readonly media: string;
+	public matches = false;
+	public listeners: (() => void)[] = [];
+
+	public constructor(media: string) {
+		this.media = media;
+	}
+
+	public addEventListener(type: string, listener: () => void): void {
+		if (type === 'change') {
+			this.listeners.push(listener);
+		}
+	}
+
+	public removeEventListener(type: string, listener: () => void): void {
+		if (type === 'change') {
+			this.listeners = this.listeners.filter((item: () => void) => item !== listener);
+		}
+	}
+
+	/** Flips the state and notifies, the way the browser does. */
+	public set(matches: boolean): void {
+		this.matches = matches;
+		for (const listener of [...this.listeners]) {
+			listener();
+		}
+	}
+}
+
+const globals = globalThis as unknown as {
+	window?: { matchMedia?: (query: string) => unknown };
+};
+
+let created: Map<string, FakeMediaQueryList> = new Map();
+let matchMediaCalls = 0;
+
+/** Installs a fake `window.matchMedia`, as a browser-less environment has none. */
+function installMatchMedia(): Map<string, FakeMediaQueryList> {
+	created = new Map();
+	matchMediaCalls = 0;
+	globals.window = {
+		matchMedia: (query: string): unknown => {
+			matchMediaCalls++;
+			let list = created.get(query);
+			if (list === undefined) {
+				list = new FakeMediaQueryList(query);
+				created.set(query, list);
+			}
+			return list;
+		},
+	};
+	return created;
+}
+
+function list(query: string): FakeMediaQueryList {
+	const found = created.get(query);
+	if (found === undefined) {
+		throw new Error(`matchMedia was never called with ${query}`);
+	}
+	return found;
+}
+
+// The module caches one MediaQueryList per query text for the lifetime of the
+// process, so every test uses query strings of its own.
+let uniqueId = 0;
+function uniqueQueries(count: number): string[] {
+	const id = ++uniqueId;
+	return Array.from({ length: count }, (_: unknown, index: number) => `(test-${id}-${index}: on)`);
+}
+
+afterEach(() => {
+	delete globals.window;
+});
+
+void describe('subscribeMediaQuery', () => {
+	void it('reports a flip to matching, with the new value', () => {
+		installMatchMedia();
+		const [query] = uniqueQueries(1);
+		const seen: boolean[] = [];
+		subscribeMediaQuery([query], (matches: boolean) => seen.push(matches));
+		expect(seen).to.deep.equal([], 'the initial state is not reported');
+		list(query).set(true);
+		expect(seen).to.deep.equal([true]);
+	});
+
+	void it('reports each flip once, and ignores changes which do not flip the result', () => {
+		installMatchMedia();
+		const queries = uniqueQueries(2);
+		const seen: boolean[] = [];
+		subscribeMediaQuery(queries, (matches: boolean) => seen.push(matches));
+		list(queries[0]).set(true);
+		// A second query starting to match while the first still does: no flip.
+		list(queries[1]).set(true);
+		expect(seen).to.deep.equal([true]);
+		// Only the last one going quiet flips the combined result back.
+		list(queries[0]).set(false);
+		expect(seen).to.deep.equal([true]);
+		list(queries[1]).set(false);
+		expect(seen).to.deep.equal([true, false]);
+	});
+
+	void it('starts from the current state, so an already-matching query does not fire', () => {
+		installMatchMedia();
+		const [query] = uniqueQueries(1);
+		// Materialise the list and set it before subscribing.
+		expect(mediaQueryMatches([query])).to.equal(false);
+		list(query).set(true);
+		let calls = 0;
+		subscribeMediaQuery([query], () => calls++);
+		list(query).set(true);
+		expect(calls).to.equal(0);
+		list(query).set(false);
+		expect(calls).to.equal(1);
+	});
+
+	void it('shares one MediaQueryList between subscribers of the same query', () => {
+		installMatchMedia();
+		const [query] = uniqueQueries(1);
+		const seen: string[] = [];
+		subscribeMediaQuery([query], (matches: boolean) => seen.push(`a${String(matches)}`));
+		subscribeMediaQuery([query], (matches: boolean) => seen.push(`b${String(matches)}`));
+		expect(matchMediaCalls).to.equal(1);
+		expect(list(query).listeners.length).to.equal(2);
+		list(query).set(true);
+		expect(seen).to.deep.equal(['atrue', 'btrue']);
+	});
+
+	void it('stops listening on unsubscribe, and leaves other subscribers alone', () => {
+		installMatchMedia();
+		const [query] = uniqueQueries(1);
+		const seen: string[] = [];
+		const unsubscribe = subscribeMediaQuery([query], () => seen.push('a'));
+		subscribeMediaQuery([query], () => seen.push('b'));
+		unsubscribe();
+		expect(list(query).listeners.length).to.equal(1);
+		list(query).set(true);
+		expect(seen).to.deep.equal(['b']);
+	});
+
+	void it('tolerates unsubscribing twice', () => {
+		installMatchMedia();
+		const [query] = uniqueQueries(1);
+		const unsubscribe = subscribeMediaQuery([query], () => {});
+		unsubscribe();
+		expect(() => unsubscribe()).to.not.throw();
+		expect(list(query).listeners.length).to.equal(0);
+	});
+
+	void it('is a no-op without matchMedia, so it is safe on the server', () => {
+		delete globals.window;
+		const [query] = uniqueQueries(1);
+		let calls = 0;
+		const unsubscribe = subscribeMediaQuery([query], () => calls++);
+		expect(() => unsubscribe()).to.not.throw();
+		expect(calls).to.equal(0);
+	});
+});
+
+void describe('mediaQueryMatches', () => {
+	void it('is true when any of the queries matches', () => {
+		installMatchMedia();
+		const queries = uniqueQueries(2);
+		expect(mediaQueryMatches(queries)).to.equal(false);
+		list(queries[1]).set(true);
+		expect(mediaQueryMatches(queries)).to.equal(true);
+	});
+
+	void it('is false without matchMedia', () => {
+		delete globals.window;
+		expect(mediaQueryMatches(uniqueQueries(1))).to.equal(false);
+	});
+
+	void it('is false for an empty list of queries', () => {
+		installMatchMedia();
+		expect(mediaQueryMatches([])).to.equal(false);
+	});
+});
+
+void describe('query constants', () => {
+	void it('cover the OS high-contrast signals', () => {
+		expect([...HIGH_CONTRAST_QUERIES]).to.deep.equal([
+			'(prefers-contrast: more)',
+			'(forced-colors: active)',
+		]);
+	});
+
+	void it('names the reduced-motion query', () => {
+		expect(REDUCED_MOTION_QUERY).to.equal('(prefers-reduced-motion: reduce)');
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/min-max-in-range.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/min-max-in-range.spec.ts
@@ -59,14 +59,35 @@ void describe('UpperLowerInRange', () => {
 		expect(instance.getMinMax(0, 0)).to.deep.equal({ lower: -9, upper: 9 });
 	});
 
-	void it('re-reads the array on every call: the range cache never hits', () => {
-		// Questionable: `getMinMax` looks up its cache with `cacheKey in this._cache`
-		// on a Map, which is always false, so results are recomputed each time.
+	void it('caches the result for a range, so later mutations of the array are ignored', () => {
 		const data = ramp(10);
 		const instance = new UpperLowerInRange<Band>(data, 10);
 		expect(instance.getMinMax(0, 9)).to.deep.equal({ lower: -9, upper: 9 });
 		data[0].upper = 100;
-		expect(instance.getMinMax(0, 9)).to.deep.equal({ lower: -9, upper: 100 });
+		expect(instance.getMinMax(0, 9)).to.deep.equal({ lower: -9, upper: 9 });
+	});
+
+	void it('reuses a cached chunk for a different range over the same chunk', () => {
+		const data = ramp(20);
+		const instance = new UpperLowerInRange<Band>(data, 10);
+		expect(instance.getMinMax(0, 5)).to.deep.equal({ lower: -9, upper: 9 });
+		data[1].upper = 100;
+		// chunk 0 is already cached, so the mutation is not picked up...
+		expect(instance.getMinMax(3, 7)).to.deep.equal({ lower: -9, upper: 9 });
+		// ...and chunk 1 is still computed correctly alongside it
+		expect(instance.getMinMax(0, 19)).to.deep.equal({ lower: -19, upper: 19 });
+	});
+
+	void it('gives the same answer whether or not the cache is warm', () => {
+		const cold = new UpperLowerInRange<Band>(ramp(25), 10);
+		const warm = new UpperLowerInRange<Band>(ramp(25), 10);
+		warm.getMinMax(0, 9);
+		warm.getMinMax(10, 19);
+		for (const [start, end] of [[0, 2], [5, 12], [20, 24], [0, 40]]) {
+			expect(warm.getMinMax(start, end)).to.deep.equal(
+				cold.getMinMax(start, end)
+			);
+		}
 	});
 
 	void it('returns an infinite range for an empty array', () => {

--- a/packages/lwc-toolkit/tests/unit/pane-element.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/pane-element.spec.ts
@@ -1,0 +1,131 @@
+import { expect } from 'chai';
+import { IChartApiBase, IPaneApi, Time } from 'lightweight-charts';
+import { describe, it } from 'node:test';
+
+import { chartTableElement, paneContentElement } from '../../src/dom/pane-element.js';
+
+/**
+ * The smallest element shape the helpers touch: a `style`, `children`,
+ * `firstElementChild`, `querySelector` and `closest`. Plain objects keep the
+ * test free of a DOM implementation.
+ */
+interface FakeElement {
+	name: string;
+	style: { position: string };
+	children: FakeElement[];
+	firstElementChild: FakeElement | null;
+	querySelector(selector: string): unknown;
+	closest(selector: string): FakeElement | null;
+}
+
+function element(
+	name: string,
+	options: {
+		position?: string;
+		canvas?: boolean;
+		children?: FakeElement[];
+		table?: FakeElement | null;
+	} = {}
+): FakeElement {
+	const children = options.children ?? [];
+	return {
+		name,
+		style: { position: options.position ?? '' },
+		children,
+		firstElementChild: children[0] ?? null,
+		querySelector: (selector: string): unknown =>
+			selector === 'canvas' && options.canvas === true ? { name: `${name}-canvas` } : null,
+		closest: (selector: string): FakeElement | null =>
+			selector === 'table' ? options.table ?? null : null,
+	};
+}
+
+function asElement(fake: FakeElement | null): HTMLElement | null {
+	return fake as unknown as HTMLElement | null;
+}
+
+function pane(paneElement: FakeElement | null): IPaneApi<Time> {
+	return {
+		getHTMLElement: (): HTMLElement | null => asElement(paneElement),
+	} as unknown as IPaneApi<Time>;
+}
+
+function chart(panes: IPaneApi<Time>[]): IChartApiBase<Time> {
+	return { panes: (): IPaneApi<Time>[] => panes } as unknown as IChartApiBase<Time>;
+}
+
+/** A pane row: optional left axis cell, the main cell, optional right axis cell. */
+function paneRow(options: { leftAxis?: boolean; rightAxis?: boolean; wrapper?: boolean } = {}): FakeElement {
+	const mainChildren = options.wrapper === false ? [] : [element('canvas-wrapper')];
+	const cells: FakeElement[] = [];
+	if (options.leftAxis) {
+		cells.push(element('left-axis', { canvas: true }));
+	}
+	cells.push(element('main-cell', { position: 'relative', canvas: true, children: mainChildren }));
+	if (options.rightAxis) {
+		cells.push(element('right-axis', { canvas: true }));
+	}
+	return element('pane-row', { children: cells });
+}
+
+void describe('paneContentElement', () => {
+	void it('returns the canvas wrapper inside the main pane cell', () => {
+		const result = paneContentElement(pane(paneRow()));
+		expect((result as unknown as FakeElement).name).to.equal('canvas-wrapper');
+	});
+
+	void it('skips a visible left price-axis cell which also holds a canvas', () => {
+		const row = paneRow({ leftAxis: true, rightAxis: true });
+		const result = paneContentElement(pane(row));
+		expect((result as unknown as FakeElement).name).to.equal('canvas-wrapper');
+	});
+
+	void it('falls back to the first canvas-bearing cell when none is position:relative', () => {
+		const row = element('pane-row', {
+			children: [
+				element('spacer'),
+				element('some-cell', { canvas: true, children: [element('wrapper-2')] }),
+			],
+		});
+		const result = paneContentElement(pane(row));
+		expect((result as unknown as FakeElement).name).to.equal('wrapper-2');
+	});
+
+	void it('returns the cell itself when it has no child element', () => {
+		const row = paneRow({ wrapper: false });
+		const result = paneContentElement(pane(row));
+		expect((result as unknown as FakeElement).name).to.equal('main-cell');
+	});
+
+	void it('returns null while the pane has no HTML element yet', () => {
+		expect(paneContentElement(pane(null))).to.equal(null);
+	});
+
+	void it('returns null when no cell holds a canvas', () => {
+		const row = element('pane-row', { children: [element('empty', { position: 'relative' })] });
+		expect(paneContentElement(pane(row))).to.equal(null);
+	});
+});
+
+void describe('chartTableElement', () => {
+	void it('returns the table the pane row lives in', () => {
+		const table = element('chart-table');
+		const row = element('pane-row', { table });
+		const result = chartTableElement(chart([pane(row)]));
+		expect(result).to.equal(asElement(table));
+	});
+
+	void it('skips panes which have no element yet', () => {
+		const table = element('chart-table');
+		const result = chartTableElement(chart([pane(null), pane(element('pane-row', { table }))]));
+		expect(result).to.equal(asElement(table));
+	});
+
+	void it('returns null when the chart has no panes', () => {
+		expect(chartTableElement(chart([]))).to.equal(null);
+	});
+
+	void it('returns null when the pane row is not inside a table', () => {
+		expect(chartTableElement(chart([pane(element('detached-row'))]))).to.equal(null);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/pane-plugin-base.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/pane-plugin-base.spec.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { IChartApiBase, PaneAttachedParameter, Time } from 'lightweight-charts';
+import { describe, it } from 'node:test';
+
+import { PanePluginBase } from '../../src/pane-plugin-base.js';
+
+class TestPanePlugin extends PanePluginBase {
+	public attachedCalls = 0;
+	public detachedCalls = 0;
+
+	public update(): void {
+		this.requestUpdate();
+	}
+
+	public attached(param: PaneAttachedParameter<Time>): void {
+		this.attachedCalls++;
+		super.attached(param);
+	}
+
+	public detached(): void {
+		this.detachedCalls++;
+		super.detached();
+	}
+}
+
+function fakeChart(): IChartApiBase<Time> {
+	return { id: 'chart' } as unknown as IChartApiBase<Time>;
+}
+
+void describe('PanePluginBase', () => {
+	void it('throws when the chart is read before the primitive is attached', () => {
+		const plugin = new TestPanePlugin();
+		expect(() => plugin.chart).to.throw();
+	});
+
+	void it('exposes the chart handed over by attached()', () => {
+		const plugin = new TestPanePlugin();
+		const chart = fakeChart();
+		plugin.attached({ chart, requestUpdate: (): void => {} });
+		expect(plugin.chart).to.equal(chart);
+	});
+
+	void it('requests an initial update when attached', () => {
+		const plugin = new TestPanePlugin();
+		let updates = 0;
+		plugin.attached({ chart: fakeChart(), requestUpdate: (): void => void updates++ });
+		expect(updates).to.equal(1);
+	});
+
+	void it('forwards requestUpdate() to the callback from attached()', () => {
+		const plugin = new TestPanePlugin();
+		let updates = 0;
+		plugin.attached({ chart: fakeChart(), requestUpdate: (): void => void updates++ });
+		plugin.update();
+		plugin.update();
+		expect(updates).to.equal(3);
+	});
+
+	void it('ignores requestUpdate() before attaching and after detaching', () => {
+		const plugin = new TestPanePlugin();
+		let updates = 0;
+		expect(() => plugin.update()).to.not.throw();
+		plugin.attached({ chart: fakeChart(), requestUpdate: (): void => void updates++ });
+		plugin.detached();
+		plugin.update();
+		expect(updates).to.equal(1);
+	});
+
+	void it('releases the chart on detach', () => {
+		const plugin = new TestPanePlugin();
+		plugin.attached({ chart: fakeChart(), requestUpdate: (): void => {} });
+		plugin.detached();
+		expect(() => plugin.chart).to.throw();
+	});
+
+	void it('can be re-attached to another chart', () => {
+		const plugin = new TestPanePlugin();
+		plugin.attached({ chart: fakeChart(), requestUpdate: (): void => {} });
+		plugin.detached();
+		const second = fakeChart();
+		plugin.attached({ chart: second, requestUpdate: (): void => {} });
+		expect(plugin.chart).to.equal(second);
+		expect(plugin.attachedCalls).to.equal(2);
+		expect(plugin.detachedCalls).to.equal(1);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/renderer-base.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/renderer-base.spec.ts
@@ -1,0 +1,205 @@
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import {
+	CustomBarItemData,
+	CustomData,
+	CustomSeriesOptions,
+	IRange,
+	PaneRendererCustomData,
+	PriceToCoordinateConverter,
+	Time,
+} from 'lightweight-charts';
+
+import {
+	BitmapCoordinatesRenderingScope,
+	CanvasRenderingTarget2D,
+	CustomSeriesDrawArgs,
+	CustomSeriesRendererBase,
+} from '../../src/custom-series/renderer-base.js';
+
+interface TestData extends CustomData<Time> {
+	value: number;
+}
+
+type TestBar = CustomBarItemData<Time, TestData>;
+
+function makeBars(count: number): TestBar[] {
+	return Array.from({ length: count }, (_: unknown, i: number) => ({
+		x: i * 10,
+		time: i,
+		barColor: '#000000',
+		originalData: { time: i as unknown as Time, value: i },
+	}));
+}
+
+function paneData(
+	bars: TestBar[],
+	visibleRange: IRange<number> | null
+): PaneRendererCustomData<Time, TestData> {
+	return {
+		bars,
+		barSpacing: 10,
+		visibleRange,
+		conflationFactor: 1,
+	} as unknown as PaneRendererCustomData<Time, TestData>;
+}
+
+const options = {} as unknown as CustomSeriesOptions;
+
+const priceToCoordinate: PriceToCoordinateConverter = (price: number) =>
+	price as unknown as ReturnType<PriceToCoordinateConverter>;
+
+interface FakeTarget {
+	target: CanvasRenderingTarget2D;
+	/** How many times the renderer entered the bitmap coordinate space. */
+	entered: () => number;
+}
+
+/**
+ * Stands in for the chart's rendering target, recording whether the renderer
+ * entered the bitmap coordinate space at all.
+ */
+function fakeTarget(): FakeTarget {
+	let entered = 0;
+	const scope = {
+		context: {} as unknown as CanvasRenderingContext2D,
+		mediaSize: { width: 100, height: 50 },
+		bitmapSize: { width: 200, height: 100 },
+		horizontalPixelRatio: 2,
+		verticalPixelRatio: 2,
+	} as unknown as BitmapCoordinatesRenderingScope;
+	const target = {
+		useBitmapCoordinateSpace: <T>(
+			fn: (renderingScope: BitmapCoordinatesRenderingScope) => T
+		): T => {
+			entered++;
+			return fn(scope);
+		},
+	} as unknown as CanvasRenderingTarget2D;
+	return { target, entered: () => entered };
+}
+
+class TestRenderer extends CustomSeriesRendererBase<Time, TestData> {
+	public calls: CustomSeriesDrawArgs<Time, TestData, CustomSeriesOptions>[] = [];
+	public scopes: BitmapCoordinatesRenderingScope[] = [];
+
+	protected drawImpl(
+		scope: BitmapCoordinatesRenderingScope,
+		args: CustomSeriesDrawArgs<Time, TestData, CustomSeriesOptions>
+	): void {
+		this.scopes.push(scope);
+		this.calls.push(args);
+	}
+}
+
+function drawWith(
+	data: PaneRendererCustomData<Time, TestData> | null
+): { renderer: TestRenderer; target: FakeTarget } {
+	const renderer = new TestRenderer();
+	if (data !== null) {
+		renderer.update(data, options);
+	}
+	const target = fakeTarget();
+	renderer.draw(target.target, priceToCoordinate, false);
+	return { renderer, target };
+}
+
+void describe('CustomSeriesRendererBase', () => {
+	void it('draws when there is data and a non-empty visible range', () => {
+		const { renderer, target } = drawWith(
+			paneData(makeBars(5), { from: 1, to: 4 })
+		);
+		expect(target.entered()).to.equal(1);
+		expect(renderer.calls).to.have.length(1);
+	});
+
+	void it('does not draw before update has been called', () => {
+		const { renderer, target } = drawWith(null);
+		expect(target.entered()).to.equal(0);
+		expect(renderer.calls).to.have.length(0);
+	});
+
+	void it('does not draw when there are no bars', () => {
+		const { renderer, target } = drawWith(paneData([], { from: 0, to: 0 }));
+		expect(target.entered()).to.equal(0);
+		expect(renderer.calls).to.have.length(0);
+	});
+
+	void it('does not draw when the visible range is null', () => {
+		const { renderer, target } = drawWith(paneData(makeBars(5), null));
+		expect(target.entered()).to.equal(0);
+		expect(renderer.calls).to.have.length(0);
+	});
+
+	void it('does not draw for an empty visible range (from === to)', () => {
+		const { renderer, target } = drawWith(
+			paneData(makeBars(5), { from: 2, to: 2 })
+		);
+		expect(target.entered()).to.equal(0);
+		expect(renderer.calls).to.have.length(0);
+	});
+
+	void it('does not draw for an inverted visible range (from > to)', () => {
+		const { renderer, target } = drawWith(
+			paneData(makeBars(5), { from: 4, to: 2 })
+		);
+		expect(target.entered()).to.equal(0);
+		expect(renderer.calls).to.have.length(0);
+	});
+
+	void it('hands drawImpl the data, options and visible range bounds', () => {
+		const data = paneData(makeBars(5), { from: 1, to: 4 });
+		const renderer = new TestRenderer();
+		renderer.update(data, options);
+		renderer.draw(fakeTarget().target, priceToCoordinate, false);
+		const args = renderer.calls[0];
+		expect(args.data).to.equal(data);
+		expect(args.options).to.equal(options);
+		expect(args.priceToCoordinate).to.equal(priceToCoordinate);
+		expect(args.from).to.equal(1);
+		expect(args.to).to.equal(4);
+	});
+
+	void it('draws inside the bitmap coordinate space', () => {
+		const { renderer } = drawWith(paneData(makeBars(3), { from: 0, to: 3 }));
+		expect(renderer.scopes[0].horizontalPixelRatio).to.equal(2);
+		expect(renderer.scopes[0].verticalPixelRatio).to.equal(2);
+	});
+
+	void it('passes the hover flag and hit test data through', () => {
+		const renderer = new TestRenderer();
+		renderer.update(paneData(makeBars(3), { from: 0, to: 3 }), options);
+		const hitTestData = { index: 2 };
+		renderer.draw(fakeTarget().target, priceToCoordinate, true, hitTestData);
+		expect(renderer.calls[0].isHovered).to.equal(true);
+		expect(renderer.calls[0].hitTestData).to.equal(hitTestData);
+	});
+
+	void it('reports isHovered as false when the host omits it', () => {
+		const renderer = new TestRenderer();
+		renderer.update(paneData(makeBars(3), { from: 0, to: 3 }), options);
+		renderer.draw(fakeTarget().target, priceToCoordinate);
+		expect(renderer.calls[0].isHovered).to.equal(false);
+		expect(renderer.calls[0].hitTestData).to.equal(undefined);
+	});
+
+	void it('draws with the data from the most recent update', () => {
+		const renderer = new TestRenderer();
+		renderer.update(paneData(makeBars(3), { from: 0, to: 3 }), options);
+		const latest = paneData(makeBars(9), { from: 5, to: 9 });
+		renderer.update(latest, options);
+		renderer.draw(fakeTarget().target, priceToCoordinate, false);
+		expect(renderer.calls[0].data).to.equal(latest);
+		expect(renderer.calls[0].from).to.equal(5);
+	});
+
+	void it('stops drawing again once the visible range goes away', () => {
+		const renderer = new TestRenderer();
+		const target = fakeTarget();
+		renderer.update(paneData(makeBars(3), { from: 0, to: 3 }), options);
+		renderer.draw(target.target, priceToCoordinate, false);
+		renderer.update(paneData(makeBars(3), null), options);
+		renderer.draw(target.target, priceToCoordinate, false);
+		expect(target.entered()).to.equal(1);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/round-rect.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/round-rect.spec.ts
@@ -1,0 +1,203 @@
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+
+import {
+	clampCornerRadius,
+	CornerRadii,
+	drawRoundRect,
+	drawRoundRectWithBorder,
+} from '../../src/canvas/round-rect.js';
+
+interface RecordedCall {
+	method: string;
+	args: unknown[];
+}
+
+interface FakeContext {
+	calls: RecordedCall[];
+	fillStyle: string;
+	strokeStyle: string;
+	lineWidth: number;
+}
+
+/**
+ * Minimal `CanvasRenderingContext2D` stand-in which records the calls made on it,
+ * plus the fill/stroke style in effect at the time of each fill or stroke.
+ */
+function fakeContext(): FakeContext & CanvasRenderingContext2D {
+	const calls: RecordedCall[] = [];
+	const record =
+		(method: string) =>
+			(...args: unknown[]): void => {
+				calls.push({ method, args });
+			};
+	const context = {
+		calls,
+		fillStyle: '',
+		strokeStyle: '',
+		lineWidth: 0,
+		beginPath: record('beginPath'),
+		closePath: record('closePath'),
+		roundRect: record('roundRect'),
+		save: record('save'),
+		restore: record('restore'),
+	} as unknown as FakeContext & CanvasRenderingContext2D;
+	context.fill = (): void => {
+		calls.push({ method: 'fill', args: [context.fillStyle] });
+	};
+	context.stroke = (): void => {
+		calls.push({ method: 'stroke', args: [context.strokeStyle, context.lineWidth] });
+	};
+	return context;
+}
+
+function methods(ctx: FakeContext): string[] {
+	return ctx.calls.map((call: RecordedCall) => call.method);
+}
+
+function call(ctx: FakeContext, method: string): RecordedCall {
+	const found = ctx.calls.find((item: RecordedCall) => item.method === method);
+	expect(found, `no ${method} call recorded`).to.not.equal(undefined);
+	return found as RecordedCall;
+}
+
+void describe('clampCornerRadius', () => {
+	void it('returns the desired radius when the rectangle is big enough', () => {
+		expect(clampCornerRadius(4, 20, 30)).to.equal(4);
+	});
+
+	void it('never exceeds half the width', () => {
+		expect(clampCornerRadius(10, 6, 30)).to.equal(3);
+	});
+
+	void it('never exceeds the height', () => {
+		expect(clampCornerRadius(10, 40, 2)).to.equal(2);
+	});
+
+	void it('treats a negative height as its absolute value', () => {
+		// a box drawn upwards from the zero line has a negative length
+		expect(clampCornerRadius(10, 40, -2)).to.equal(2);
+	});
+
+	void it('floors the result to a whole bitmap pixel', () => {
+		expect(clampCornerRadius(2.9, 40, 30)).to.equal(2);
+		expect(clampCornerRadius(10, 5, 30)).to.equal(2);
+	});
+
+	void it('returns 0 for a zero sized rectangle', () => {
+		expect(clampCornerRadius(5, 0, 0)).to.equal(0);
+	});
+});
+
+void describe('drawRoundRect', () => {
+	void it('starts a new path and adds the rounded rect to it', () => {
+		const ctx = fakeContext();
+		const radii: CornerRadii = [1, 2, 3, 4];
+		drawRoundRect(ctx, 10, 20, 30, 40, radii);
+		expect(methods(ctx)).to.deep.equal(['beginPath', 'roundRect']);
+		expect(call(ctx, 'roundRect').args).to.deep.equal([10, 20, 30, 40, radii]);
+	});
+
+	void it('neither fills nor strokes the path', () => {
+		const ctx = fakeContext();
+		drawRoundRect(ctx, 0, 0, 1, 1, [0, 0, 0, 0]);
+		expect(methods(ctx)).to.not.include('fill');
+		expect(methods(ctx)).to.not.include('stroke');
+	});
+});
+
+void describe('drawRoundRectWithBorder', () => {
+	void it('fills the whole rect and skips the border when the border width is 0', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 10, 20, 30, 40, '#f00', 0, [2, 2, 2, 2], '#00f');
+		expect(methods(ctx)).to.deep.equal([
+			'save',
+			'beginPath',
+			'roundRect',
+			'fill',
+			'restore',
+		]);
+		expect(call(ctx, 'roundRect').args).to.deep.equal([
+			10,
+			20,
+			30,
+			40,
+			[2, 2, 2, 2],
+		]);
+		expect(call(ctx, 'fill').args).to.deep.equal(['#f00']);
+	});
+
+	void it('skips the border when no border colour is given', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 10, 20, 30, 40, '#f00', 2, [2, 2, 2, 2]);
+		expect(methods(ctx)).to.not.include('stroke');
+		expect(call(ctx, 'roundRect').args).to.deep.equal([
+			10,
+			20,
+			30,
+			40,
+			[2, 2, 2, 2],
+		]);
+	});
+
+	void it('skips the border when it is the same colour as the background', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 10, 20, 30, 40, '#f00', 2, [2, 2, 2, 2], '#f00');
+		expect(methods(ctx)).to.not.include('stroke');
+	});
+
+	void it('defaults to no border and square corners', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 10, 20, 30, 40, '#f00');
+		expect(methods(ctx)).to.not.include('stroke');
+		expect(call(ctx, 'roundRect').args).to.deep.equal([
+			10,
+			20,
+			30,
+			40,
+			[0, 0, 0, 0],
+		]);
+	});
+
+	void it('insets the path by half the border width, so the stroke sits inside the rect', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 10, 20, 30, 40, '#f00', 2, [4, 4, 4, 4], '#00f');
+		expect(call(ctx, 'roundRect').args).to.deep.equal([
+			11,
+			21,
+			28,
+			38,
+			[3, 3, 3, 3],
+		]);
+		expect(methods(ctx)).to.deep.equal([
+			'save',
+			'beginPath',
+			'roundRect',
+			'fill',
+			'stroke',
+			'restore',
+		]);
+	});
+
+	void it('fills with the background and strokes with the border colour and width', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 10, 20, 30, 40, '#f00', 2, [4, 4, 4, 4], '#00f');
+		expect(call(ctx, 'fill').args).to.deep.equal(['#f00']);
+		expect(call(ctx, 'stroke').args).to.deep.equal(['#00f', 2]);
+	});
+
+	void it('leaves square corners square when insetting the radii', () => {
+		const ctx = fakeContext();
+		drawRoundRectWithBorder(ctx, 0, 0, 20, 20, '#f00', 4, [6, 0, 6, 0], '#00f');
+		expect(call(ctx, 'roundRect').args[4]).to.deep.equal([4, 0, 4, 0]);
+	});
+
+	void it('always restores the context', () => {
+		for (const borderColor of [undefined, '#00f']) {
+			const ctx = fakeContext();
+			drawRoundRectWithBorder(ctx, 0, 0, 20, 20, '#f00', 2, [1, 1, 1, 1], borderColor);
+			expect(methods(ctx).filter((m: string) => m === 'save')).to.have.length(1);
+			expect(methods(ctx).filter((m: string) => m === 'restore')).to.have.length(1);
+		}
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/stacking.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/stacking.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+
+import {
+	cumulativeSum,
+	stackedPlotValues,
+} from '../../src/custom-series/stacking.js';
+
+void describe('cumulativeSum', () => {
+	void it('returns the running totals', () => {
+		expect(cumulativeSum([1, 2, 3])).to.deep.equal([1, 3, 6]);
+	});
+
+	void it('returns an empty array for no values', () => {
+		expect(cumulativeSum([])).to.deep.equal([]);
+	});
+
+	void it('keeps the length of the input', () => {
+		expect(cumulativeSum([5, 0, 0, 0])).to.deep.equal([5, 5, 5, 5]);
+	});
+
+	void it('lets negative values pull the running total back down', () => {
+		expect(cumulativeSum([3, -2, 4])).to.deep.equal([3, 1, 5]);
+	});
+
+	void it('handles an all-negative stack', () => {
+		expect(cumulativeSum([-1, -2, -3])).to.deep.equal([-1, -3, -6]);
+	});
+
+	void it('does not mutate the input', () => {
+		const values = [1, 2, 3];
+		cumulativeSum(values);
+		expect(values).to.deep.equal([1, 2, 3]);
+	});
+});
+
+void describe('stackedPlotValues', () => {
+	void it('spans the baseline and the total for a positive stack', () => {
+		expect(stackedPlotValues([1, 2, 3])).to.deep.equal([0, 6, 6]);
+	});
+
+	void it('spans the baseline and the total for a negative stack', () => {
+		expect(stackedPlotValues([-1, -2, -3])).to.deep.equal([-6, 0, -6]);
+	});
+
+	void it('covers both ends of a mixed stack, not just the total', () => {
+		// running totals: 3, 1, 5 -> the stack reaches 5 even though the
+		// individual values never exceed 4
+		expect(stackedPlotValues([3, -2, 4])).to.deep.equal([0, 5, 5]);
+	});
+
+	void it('keeps a mid-stack dip below the baseline in view', () => {
+		// running totals: -4, 1 -> the stack goes down to -4 first
+		expect(stackedPlotValues([-4, 5])).to.deep.equal([-4, 1, 1]);
+	});
+
+	void it('reports the total last, even when it is not an extreme', () => {
+		// running totals: 10, 2
+		expect(stackedPlotValues([10, -8])).to.deep.equal([0, 10, 2]);
+	});
+
+	void it('always includes the baseline in the range', () => {
+		expect(stackedPlotValues([5, 1])).to.deep.equal([0, 6, 6]);
+		expect(stackedPlotValues([-5, -1])).to.deep.equal([-6, 0, -6]);
+	});
+
+	void it('takes a non-zero baseline', () => {
+		expect(stackedPlotValues([1, 2], 10)).to.deep.equal([1, 10, 3]);
+		expect(stackedPlotValues([-1, -2], -10)).to.deep.equal([-10, -1, -3]);
+	});
+
+	void it('collapses to the baseline for an empty stack', () => {
+		expect(stackedPlotValues([])).to.deep.equal([0, 0, 0]);
+		expect(stackedPlotValues([], 4)).to.deep.equal([4, 4, 4]);
+	});
+
+	void it('returns three values, with the current value last', () => {
+		const plotValues = stackedPlotValues([2, 2]);
+		expect(plotValues).to.have.length(3);
+		expect(plotValues[plotValues.length - 1]).to.equal(4);
+	});
+});

--- a/packages/lwc-toolkit/tests/unit/time.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/time.spec.ts
@@ -2,7 +2,12 @@ import { expect } from 'chai';
 import type { BusinessDay, UTCTimestamp } from 'lightweight-charts';
 import { describe, it } from 'node:test';
 
-import { convertTime, displayTime, formattedDateAndTime } from '../../src/time.js';
+import {
+	convertTime,
+	convertTimeUTC,
+	displayTime,
+	formattedDateAndTime,
+} from '../../src/time.js';
 
 void describe('convertTime', () => {
 	void it('multiplies a UTCTimestamp by 1000', () => {
@@ -54,6 +59,68 @@ void describe('convertTime', () => {
 		expect(convertTime('2021-05-12T12:34:56Z')).to.equal(
 			convertTime('2021-05-12')
 		);
+	});
+});
+
+void describe('convertTimeUTC', () => {
+	void it('multiplies a UTCTimestamp by 1000, exactly like convertTime', () => {
+		expect(convertTimeUTC(1745480000 as UTCTimestamp)).to.equal(1745480000000);
+		expect(convertTimeUTC(0 as UTCTimestamp)).to.equal(0);
+		expect(convertTimeUTC(-1 as UTCTimestamp)).to.equal(-1000);
+	});
+
+	void it('builds a BusinessDay as UTC midnight', () => {
+		const converted = convertTimeUTC({
+			year: 2021,
+			month: 5,
+			day: 12,
+		} as BusinessDay);
+		// `BusinessDay.month` is 1-based, `Date.UTC`'s is 0-based
+		expect(converted).to.equal(Date.UTC(2021, 4, 12));
+		const asDate = new Date(converted);
+		expect(asDate.getUTCFullYear()).to.equal(2021);
+		expect(asDate.getUTCMonth()).to.equal(4);
+		expect(asDate.getUTCDate()).to.equal(12);
+		expect(asDate.getUTCHours()).to.equal(0);
+		expect(asDate.getUTCMinutes()).to.equal(0);
+	});
+
+	void it('builds a date string the same way as the equivalent BusinessDay', () => {
+		expect(convertTimeUTC('2021-05-12')).to.equal(
+			convertTimeUTC({ year: 2021, month: 5, day: 12 } as BusinessDay)
+		);
+		expect(convertTimeUTC('2021-05-12')).to.equal(Date.UTC(2021, 4, 12));
+	});
+
+	void it('is a whole number of days from the epoch for a calendar day', () => {
+		const dayMs = 86_400_000;
+		expect(convertTimeUTC('2021-05-12') % dayMs).to.equal(0);
+		expect(convertTimeUTC('1970-01-01')).to.equal(0);
+		expect(convertTimeUTC('1970-01-02')).to.equal(dayMs);
+	});
+
+	void it('differs from convertTime by exactly the local UTC offset', () => {
+		const offsetMinutes = new Date(2021, 4, 12).getTimezoneOffset();
+		expect(convertTime('2021-05-12')).to.equal(
+			convertTimeUTC('2021-05-12') + offsetMinutes * 60_000
+		);
+	});
+
+	void it('accepts a zero-padded or unpadded date string', () => {
+		expect(convertTimeUTC('2021-5-2')).to.equal(convertTimeUTC('2021-05-02'));
+	});
+
+	void it('ignores anything after the day in a date string', () => {
+		expect(convertTimeUTC('2021-05-12T12:34:56Z')).to.equal(
+			convertTimeUTC('2021-05-12')
+		);
+	});
+
+	void it('round-trips through the UTC date getters', () => {
+		const asDate = new Date(convertTimeUTC('2021-12-25'));
+		expect(
+			`${asDate.getUTCFullYear()}-${asDate.getUTCMonth() + 1}-${asDate.getUTCDate()}`
+		).to.equal('2021-12-25');
 	});
 });
 

--- a/packages/lwc-toolkit/tests/unit/visible-bars.spec.ts
+++ b/packages/lwc-toolkit/tests/unit/visible-bars.spec.ts
@@ -1,0 +1,246 @@
+import { expect } from 'chai';
+import { describe, it } from 'node:test';
+import {
+	CustomBarItemData,
+	CustomData,
+	IRange,
+	PaneRendererCustomData,
+	Time,
+} from 'lightweight-charts';
+
+import {
+	extendRange,
+	forEachVisibleBar,
+	mapVisibleBars,
+	visibleSegments,
+} from '../../src/custom-series/visible-bars.js';
+
+interface TestData extends CustomData<Time> {
+	value: number;
+}
+
+type TestBar = CustomBarItemData<Time, TestData>;
+
+/**
+ * Builds bars with consecutive logical time indices unless `times` is given,
+ * which lets a test punch gaps into the index sequence.
+ */
+function makeBars(count: number, times?: number[]): TestBar[] {
+	return Array.from({ length: count }, (_: unknown, i: number) => {
+		const time = times ? times[i] : i;
+		return {
+			x: i * 10,
+			time,
+			barColor: '#000000',
+			originalData: {
+				time: time as unknown as Time,
+				value: i,
+			},
+		};
+	});
+}
+
+function paneData(
+	bars: TestBar[],
+	visibleRange: IRange<number> | null
+): PaneRendererCustomData<Time, TestData> {
+	return {
+		bars,
+		barSpacing: 10,
+		visibleRange,
+		conflationFactor: 1,
+	} as unknown as PaneRendererCustomData<Time, TestData>;
+}
+
+void describe('forEachVisibleBar', () => {
+	void it('visits only the bars inside the visible range', () => {
+		const seen: number[] = [];
+		forEachVisibleBar(
+			paneData(makeBars(10), { from: 3, to: 6 }),
+			(_: TestBar, index: number) => seen.push(index)
+		);
+		expect(seen).to.deep.equal([3, 4, 5]);
+	});
+
+	void it('passes the absolute bar index, not the visit count', () => {
+		const seen: number[] = [];
+		forEachVisibleBar(
+			paneData(makeBars(10), { from: 7, to: 9 }),
+			(bar: TestBar, index: number) => seen.push(bar.originalData.value - index)
+		);
+		expect(seen).to.deep.equal([0, 0]);
+	});
+
+	void it('does nothing when the visible range is null', () => {
+		let calls = 0;
+		forEachVisibleBar(paneData(makeBars(5), null), () => calls++);
+		expect(calls).to.equal(0);
+	});
+
+	void it('does nothing for an empty range', () => {
+		let calls = 0;
+		forEachVisibleBar(paneData(makeBars(5), { from: 2, to: 2 }), () => calls++);
+		expect(calls).to.equal(0);
+	});
+
+	void it('clamps a range which runs past the ends of the data', () => {
+		const seen: number[] = [];
+		forEachVisibleBar(
+			paneData(makeBars(3), { from: -2, to: 9 }),
+			(_: TestBar, index: number) => seen.push(index)
+		);
+		expect(seen).to.deep.equal([0, 1, 2]);
+	});
+});
+
+void describe('mapVisibleBars', () => {
+	void it('returns one entry per visible bar', () => {
+		const result = mapVisibleBars(
+			paneData(makeBars(10), { from: 4, to: 7 }),
+			(bar: TestBar) => bar.x
+		);
+		expect(result).to.deep.equal([40, 50, 60]);
+	});
+
+	void it('compacts the result, so index 0 is the first visible bar', () => {
+		const result = mapVisibleBars(
+			paneData(makeBars(10), { from: 4, to: 7 }),
+			(_: TestBar, index: number) => index
+		);
+		expect(result).to.deep.equal([4, 5, 6]);
+		expect(result).to.have.length(3);
+	});
+
+	void it('returns an empty array when there is no visible range', () => {
+		expect(
+			mapVisibleBars(paneData(makeBars(5), null), (bar: TestBar) => bar.x)
+		).to.deep.equal([]);
+	});
+
+	void it('returns an empty array for an empty range', () => {
+		expect(
+			mapVisibleBars(
+				paneData(makeBars(5), { from: 3, to: 3 }),
+				(bar: TestBar) => bar.x
+			)
+		).to.deep.equal([]);
+	});
+
+	void it('does not map bars outside the visible range', () => {
+		let calls = 0;
+		mapVisibleBars(paneData(makeBars(100), { from: 0, to: 2 }), () => calls++);
+		expect(calls).to.equal(2);
+	});
+});
+
+void describe('extendRange', () => {
+	void it('widens the range by one bar on each side by default', () => {
+		expect(extendRange({ from: 3, to: 6 }, 10)).to.deep.equal({
+			from: 2,
+			to: 7,
+		});
+	});
+
+	void it('widens by the requested number of bars', () => {
+		expect(extendRange({ from: 5, to: 6 }, 10, 3)).to.deep.equal({
+			from: 2,
+			to: 9,
+		});
+	});
+
+	void it('clamps the start at zero', () => {
+		expect(extendRange({ from: 0, to: 4 }, 10)).to.deep.equal({
+			from: 0,
+			to: 5,
+		});
+	});
+
+	void it('clamps the end at the data length', () => {
+		expect(extendRange({ from: 8, to: 10 }, 10)).to.deep.equal({
+			from: 7,
+			to: 10,
+		});
+	});
+
+	void it('clamps both ends at once', () => {
+		expect(extendRange({ from: 0, to: 3 }, 3, 5)).to.deep.equal({
+			from: 0,
+			to: 3,
+		});
+	});
+
+	void it('leaves the range alone when asked to extend by zero', () => {
+		expect(extendRange({ from: 2, to: 5 }, 10, 0)).to.deep.equal({
+			from: 2,
+			to: 5,
+		});
+	});
+});
+
+void describe('visibleSegments', () => {
+	void it('returns a single run for consecutive bars', () => {
+		expect(visibleSegments(makeBars(5), { from: 0, to: 5 })).to.deep.equal([
+			{ from: 0, to: 5 },
+		]);
+	});
+
+	void it('breaks where the logical time index skips', () => {
+		// a whitespace item at index 3 leaves a hole between times 2 and 4
+		const bars = makeBars(5, [0, 1, 2, 4, 5]);
+		expect(visibleSegments(bars, { from: 0, to: 5 })).to.deep.equal([
+			{ from: 0, to: 3 },
+			{ from: 3, to: 5 },
+		]);
+	});
+
+	void it('handles several gaps', () => {
+		const bars = makeBars(6, [0, 2, 3, 9, 10, 20]);
+		expect(visibleSegments(bars, { from: 0, to: 6 })).to.deep.equal([
+			{ from: 0, to: 1 },
+			{ from: 1, to: 3 },
+			{ from: 3, to: 5 },
+			{ from: 5, to: 6 },
+		]);
+	});
+
+	void it('only looks at the requested range', () => {
+		const bars = makeBars(6, [0, 5, 6, 7, 20, 21]);
+		expect(visibleSegments(bars, { from: 1, to: 4 })).to.deep.equal([
+			{ from: 1, to: 4 },
+		]);
+	});
+
+	void it('returns one segment per bar when every index is a gap', () => {
+		const bars = makeBars(3, [0, 10, 20]);
+		expect(visibleSegments(bars, { from: 0, to: 3 })).to.deep.equal([
+			{ from: 0, to: 1 },
+			{ from: 1, to: 2 },
+			{ from: 2, to: 3 },
+		]);
+	});
+
+	void it('returns a single-bar segment for a one-bar range', () => {
+		expect(visibleSegments(makeBars(5), { from: 2, to: 3 })).to.deep.equal([
+			{ from: 2, to: 3 },
+		]);
+	});
+
+	void it('returns nothing for an empty range', () => {
+		expect(visibleSegments(makeBars(5), { from: 2, to: 2 })).to.deep.equal([]);
+		expect(visibleSegments([], { from: 0, to: 0 })).to.deep.equal([]);
+	});
+
+	void it('clamps a range running past the data', () => {
+		expect(visibleSegments(makeBars(3), { from: -1, to: 8 })).to.deep.equal([
+			{ from: 0, to: 3 },
+		]);
+	});
+
+	void it('does not treat a repeated index as consecutive', () => {
+		const bars = makeBars(3, [4, 4, 5]);
+		expect(visibleSegments(bars, { from: 0, to: 3 })).to.deep.equal([
+			{ from: 0, to: 1 },
+			{ from: 1, to: 3 },
+		]);
+	});
+});


### PR DESCRIPTION
Stacked on #2128 (→ #2127 → #2126); the diff includes those until they merge.

Toolkit improvements: the shared infrastructure the plugin fixes in the next PR build on. The toolkit is unpublished, so it stays `1.0.0` and the CHANGELOG entry is amended. Plugins are not changed here (they still compile and build against it: `plugins:check-compat` green).

**Custom series (B1)**

- `custom-series/renderer-base` — `CustomSeriesRendererBase`: holds data/options, does the no-data / null-range / empty-range guards every plugin repeated, calls `drawImpl` inside the bitmap scope. Canvas types are derived from the library's `draw` signature, so no `fancy-canvas` dependency.
- `custom-series/visible-bars` — `forEachVisibleBar`, `mapVisibleBars`, `extendRange` (reach the pane edge), `visibleSegments` (split at whitespace gaps, using the logical index).
- `custom-series/stacking` — `cumulativeSum`, `stackedPlotValues` (autoscale values for stacks with negatives).
- `custom-series/line-paths` — `buildLinePath`, `areaBetween`, `strokeStyledPolyline`.
- `line-style` — `setLineStyle`, `getDashPattern`, `LineStyle`: the chart's dash patterns for renderers that never receive `DrawingUtils`.
- `canvas/round-rect` — dual-range's canvas helpers moved in, without the `arcTo` polyfill and the `'transparent'` special case, plus `clampCornerRadius`.
- `dimensions/columns` — optional `time` on items; no neighbour alignment across a whitespace gap; `endIndex` exclusive in every pass.
- `time` — `convertTimeUTC`.
- `min-max-in-range` — the two dead cache lookups fixed; results now cached.
- `closest-index` and `dimensions/full-width` keep their behaviour: callers depend on it (bands-indicator pairs `left`/`right` deliberately; full-width bars must abut). Docs and tests now describe it as intended.

**Primitives (B2)**

- `pane-plugin-base` — `PanePluginBase`, the pane counterpart of `PluginBase`.
- `axis-label-view` — `AxisLabelView` over an `AxisLabelSource`; a label with no coordinate is hidden and parked offscreen.
- `dom/pane-element` — `paneContentElement`, `chartTableElement`: the one place that knows the library's pane DOM.
- `dom/media-query` — `subscribeMediaQuery`, `mediaQueryMatches`, `HIGH_CONTRAST_QUERIES`, `REDUCED_MOTION_QUERY`; SSR-safe, shares `MediaQueryList`s.

The scaffold's pane-primitive and series-primitive templates use `PanePluginBase` and `AxisLabelView`.
