### PR TITLE
Update readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@
 
 TradingView Lightweight Charts™ are one of the smallest and fastest financial HTML5 charts.
 
-The Lightweight Charts™ library is the best choice for you if you want to display financial data as an interactive chart on your web page without affecting your web page loading speed and performance.
-
-It is the best choice for you if you want to replace static image charts with interactive ones.
+The Lightweight Charts™ library is the best choice for you if you want to display financial data as an interactive chart on your web page, or replace static image charts with interactive ones. It does this without affecting your web page's loading speed and performance.
 The size of the library is close to static images but if you have dozens of image charts on a web page then using this library can make the size of your web page smaller.
 
-Take a look at [awesome-tradingview](https://github.com/tradingview/awesome-tradingview?tab=readme-ov-file#lightweight-charts) for related projects created by our community members.
+The library provides a rich set of charting capabilities out of the box, but you can also extend its functionality by building custom plugins. Browse the [plugin catalog](https://tradingview.github.io/lightweight-charts/plugins) for ready-made plugins, or see the [interactive plugin examples](https://tradingview.github.io/lightweight-charts/plugin-examples/) and [plugin-examples/README.md](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples) to build your own.
 
-The library provides a rich set of charting capabilities out of the box, but developers can also extend its functionality by building custom plugins. See the [interactive plugin examples here](https://tradingview.github.io/lightweight-charts/plugin-examples/), or check out [plugin-examples/README.md](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples) for more details.
+Take a look at [awesome-tradingview](https://github.com/tradingview/awesome-tradingview?tab=readme-ov-file#lightweight-charts) for related projects created by our community members.
 
 ## Installing
 
@@ -92,7 +90,7 @@ lineSeries.setData([
 ]);
 ```
 
-### Build Variants
+### Build variants
 
 |Dependencies included|Mode|ES module|IIFE (`window.LightweightCharts`)|
 |-|-|-|-|
@@ -103,7 +101,7 @@ lineSeries.setData([
 
 ## AI coding assistants
 
-This repository ships an [Agent Skill](https://github.com/tradingview/lightweight-charts/blob/master/.github/skills/lightweight-charts/SKILL.md) that teaches AI coding assistants how to work with Lightweight Charts™ - the v5 API conventions, the mental model, and the common time, scale, marker, plugin, and wrapper foot-guns.
+This repository ships an [Agent Skill](https://github.com/tradingview/lightweight-charts/blob/master/.github/skills/lightweight-charts/SKILL.md) for AI coding assistants. It covers the Lightweight Charts™ v5 API conventions, the mental model, and common time, scale, marker, plugin, and wrapper foot-guns.
 
 Install it into your project with the `skills` CLI:
 
@@ -111,7 +109,7 @@ Install it into your project with the `skills` CLI:
 npx skills add https://github.com/tradingview/lightweight-charts
 ```
 
-This makes the skill available to compatible assistants (such as Claude Code, Codex, etc.), streamlining your workflow: they scaffold charts, wire up series and data, and answer API questions against the current v5 conventions out of the box - instead of relying on outdated snippets and stumbling into common foot-guns.
+This makes the skill available to compatible assistants, such as Claude Code and Codex. They scaffold charts, wire up series and data, and answer API questions against current v5 conventions out of the box instead of relying on outdated snippets and stumbling into common foot-guns.
 
 ## Development
 
@@ -120,7 +118,7 @@ See [BUILDING.md](./BUILDING.md) for instructions on how to build `lightweight-c
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this software except in compliance with the License.
-You may obtain a copy of the License at LICENSE file.
+You may obtain a copy of the License in the [LICENSE](./LICENSE) file.
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 This software incorporates several parts of tslib (<https://github.com/Microsoft/tslib>, (c) Microsoft Corporation) that are covered by BSD Zero Clause License.

--- a/packages/create-lwc-plugin/README.md
+++ b/packages/create-lwc-plugin/README.md
@@ -1,39 +1,21 @@
 # create-lwc-plugin
 
-**create-lwc-plugin** is an npm package designed to simplify the process of
-creating a new plugin for Lightweight Charts™. With this generator, you can
-quickly scaffold a project from a template for either
+**create-lwc-plugin** scaffolds a new Lightweight Charts™ plugin project from a
+template, for a series primitive, a pane primitive, or a custom series. Answer
+a few questions in the wizard and it generates a structured, ready-to-publish
+project: its `package.json` already follows the conventions used by the
+[Lightweight Charts™ plugin catalog](https://tradingview.github.io/lightweight-charts/plugins),
+so the plugin can be listed there once it is published to npm.
 
-- a Series primitive plugin,
-- a Pane primitive plugin, or
-- a Custom series plugin.
-
-By using this wizard-like tool, you can customize the initial setup of their
-plugin project by answering a few questions. This allows for a seamless and
-efficient starting point, saving valuable time and effort.
-
-The scaffolded project is ready to publish: its `package.json` follows the
-conventions used by the Lightweight Charts™ plugin catalogue, so the plugin can
-be listed there once it is published to npm.
-
-Whether you are developing a new primitive plugin or a Custom series plugin for
-Lightweight Charts, this generator provides a structured and organized
-foundation. It ensures that your plugin adheres to the best practices and
-conventions of Lightweight Charts, making it easier to develop, maintain, and
-contribute to the community.
-
-Getting started with your Lightweight Charts plugin development has never been
-easier. Let the Lightweight Charts™ Plugin Scaffold Generator
-(`create-lwc-plugin`) handle the initial setup, so you can focus on creating
-outstanding plugins for Lightweight Charts™.
-
-✨ Need some examples for inspiration? Check out the
+✨ Need some examples for inspiration? Browse the
+[plugin catalog](https://tradingview.github.io/lightweight-charts/plugins) or
+check out the
 [plugin-examples](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples)
-folder in the Lightweight Charts repo.
+folder in the Lightweight Charts™ repo.
 
-## Scaffolding Your First Lightweight Charts™ Plugin
+## Scaffold your first Lightweight Charts™ plugin
 
-With NPM:
+With npm:
 
 ```bash
 npm create lwc-plugin@latest
@@ -45,20 +27,20 @@ With Yarn:
 yarn create lwc-plugin
 ```
 
-With PNPM:
+With pnpm:
 
 ```bash
 pnpm create lwc-plugin
 ```
 
-The wizard asks for the plugin's name, description, author, licence, the minimum
+The wizard asks for the plugin's name, description, author, license, the minimum
 version of Lightweight Charts™ it supports, and the tags to list it under. Those
 answers populate the generated `package.json`, including the `lwcPlugin` block
-read by the plugin catalogue.
+read by the plugin catalog.
 
-## Using the generated project
+## Use the generated project
 
-### Running Locally (during development)
+### Run it locally (during development)
 
 ```shell
 npm install
@@ -67,19 +49,21 @@ npm run dev
 
 Visit `localhost:5173` in the browser.
 
-### Building the Plugin
+### Build the plugin
 
 ```shell
 npm run build
 ```
 
-This writes three files into the `dist` folder: the package entry point
-(`<name>.js`), a standalone build for use over a CDN
-(`<name>.standalone.js`) which inlines every dependency except
-Lightweight Charts™ itself, and the bundled type declarations (`<name>.d.ts`).
+This writes three files into the `dist` folder:
+
+- the package entry point (`<name>.js`)
+- a standalone build for use over a CDN (`<name>.standalone.js`), which inlines every dependency except Lightweight Charts™ itself
+- the bundled type declarations (`<name>.d.ts`)
+
 Plugins are published as ES modules only.
 
-### Publishing To NPM
+### Publish to npm
 
 The `package.json` in the project root is the published manifest. Check its
 `description`, `version`, `license` and `lwcPlugin` fields, then publish from
@@ -89,10 +73,10 @@ the project root:
 npm publish
 ```
 
-Hint: append `--dry-run` to the end of the publish command to see the results of
-the publish command without actually uploading the package to NPM.
+**Hint:** append `--dry-run` to the end of the publish command to see the results of
+the publish command without actually uploading the package to npm.
 
-## Scaffolding an official in-repo plugin
+## Scaffold an official in-repo plugin
 
 Maintainers working inside the Lightweight Charts™ repository can scaffold a
 workspace package instead of a standalone project:
@@ -104,4 +88,4 @@ pnpm create lwc-plugin --workspace
 Workspace mode targets `packages/`, scopes the package name to `@tradingview/`,
 depends on the library and the shared plugin utilities through `workspace:*`,
 seeds a `CHANGELOG.md`, `LICENSE` and `NOTICE`, and marks the plugin as an
-official catalogue entry.
+official catalog entry.

--- a/plugin-examples/README.md
+++ b/plugin-examples/README.md
@@ -1,10 +1,32 @@
-# Lightweight Charts™ Plugin Examples
+# Lightweight Charts™ plugin examples
 
-This folder contains a collection of example plugins designed to extend the
-functionality of Lightweight Charts™ and inspire the development of your own
-plugins.
+This folder hosts the demo gallery for Lightweight Charts™ plugins, and is
+split into two kinds of content:
 
-**Disclaimer:** These plugins are provided as-is, and are primarily intended as
+- **Official plugins** — maintained, published npm packages, listed in the
+  [plugin catalog](https://tradingview.github.io/lightweight-charts/plugins).
+  Their demo here just imports the published package; the source lives under
+  [`packages/lwc-plugin-*`](https://github.com/tradingview/lightweight-charts/tree/master/packages)
+  instead of in this folder.
+- **Example plugins** — proof-of-concept starting points that live entirely in
+  this folder, meant to be copied and adapted rather than installed.
+
+## Official plugins
+
+Browse the [plugin catalog](https://tradingview.github.io/lightweight-charts/plugins)
+for the full, current list, each with its README, options and an `npm install`
+command. These are maintained packages: expect updates, versioned releases and
+a `CHANGELOG.md`, unlike the example plugins below.
+
+Install one from npm, as directed on its catalog page, for example:
+
+```shell
+npm install @tradingview/lwc-plugin-accessibility
+```
+
+## Example plugins
+
+**Disclaimer:** these plugins are provided as-is, and are primarily intended as
 proof-of-concept examples and starting points. They have not been fully
 optimized for production and may not receive updates or improvements over time.
 
@@ -12,35 +34,22 @@ We believe in the power of community collaboration, and we warmly welcome any
 pull requests (PRs) aimed at enhancing and fixing the existing examples.
 Additionally, we encourage you to create your own plugins and share them with
 the community. We would be delighted to showcase the best plugins our users
-create in this readme document.
+create in this README.
 
-✨ If you have something cool to share or if you need assistance, please don't
+✨ If you have something cool to share or if you need assistance, don't
 hesitate to get in touch.
 
-🚀 Need a starting point for your plugin idea? Check out
-[create-lwc-plugin](https://www.npmjs.com/package/create-lwc-plugin) package.
+### Run the demo gallery locally
 
-📊 You can view a demo page of the plugins within this repo at his link:
-[Plugin Examples](https://tradingview.github.io/lightweight-charts/plugin-examples)
-
-## Learning More
-
-- [Documentation for Plugins](https://tradingview.github.io/lightweight-charts/docs/next/plugins/intro)
-- [Learn more about Lightweight Charts™](https://www.tradingview.com/lightweight-charts/)
-
-## Running Locally
-
-To run this repo locally, follow these steps:
-
-1. Clone the repo to your local machine
-2. First install the dependencies (the repository is a pnpm workspace, so a single install in the root directory covers all the projects) and build the library
+1. Clone the repo to your local machine.
+2. Install the dependencies (the repository is a pnpm workspace, so a single install in the root directory covers all the projects) and build the library:
 
    ```shell
    pnpm install
    pnpm build:prod
    ```
 
-3. Switch to the Plugin Examples Folder and start the development server
+3. Switch to the `plugin-examples` folder and start the development server:
 
    ```shell
    cd plugin-examples
@@ -49,18 +58,20 @@ To run this repo locally, follow these steps:
 
 4. Visit `localhost:5173` in the browser.
 
-## Compiling the Examples
+You can also view a demo page of every plugin in this repo, official and
+example alike, without running anything locally:
+[Plugin examples](https://tradingview.github.io/lightweight-charts/plugin-examples).
+
+### Compile and use one in your project
+
+Example plugins are not published, so instead you compile them from source
+and copy the output into your project.
 
 ```shell
 pnpm compile
 ```
 
-Check the output in the `compiled` folder.
-
-## Using an Example
-
-Once you have compiled the examples then simply copy that folder into your
-project and import the JS module in your code.
+Check the output in the `compiled` folder, then:
 
 1. Copy the compiled plugin folder into your project, example:
    `plugins/background-shade-series` (from `compiled/background-shade-series`)
@@ -78,18 +89,25 @@ project and import the JS module in your code.
    });
    ```
 
-## Creating your own Plugin
+## Create your own plugin
 
 [create-lwc-plugin](https://github.com/tradingview/lightweight-charts/tree/master/packages/create-lwc-plugin) is an npm
 package designed to simplify the process of creating a new plugin for
 Lightweight Charts™. With this generator, you can quickly scaffold a project
 from a template for either
 
-- a Drawing primitive plugin, or
-- a Custom series plugin.
+- a series primitive plugin,
+- a pane primitive plugin, or
+- a custom series plugin.
 
 You can get started with this simple command:
 
 ```shell
 npm create lwc-plugin@latest
 ```
+
+## Learn more
+
+- [Plugin catalog](https://tradingview.github.io/lightweight-charts/plugins)
+- [Documentation for plugins](https://tradingview.github.io/lightweight-charts/docs/next/plugins/intro)
+- [Learn more about Lightweight Charts™](https://www.tradingview.com/lightweight-charts/)

--- a/website/docs/plugins/intro.md
+++ b/website/docs/plugins/intro.md
@@ -10,6 +10,13 @@ series types, drawing tools, indicators, watermarks, and other custom elements
 rendered as part of the chart. This section explains how plugins work and how
 to build your own.
 
+:::tip
+
+Looking for a ready-made plugin instead of building one? Browse the
+[plugin catalog](/plugins).
+
+:::
+
 ## Choosing a plugin type
 
 | You want to build | Plugin type | Attach with |

--- a/website/docs/series-types.mdx
+++ b/website/docs/series-types.mdx
@@ -166,7 +166,7 @@ The library enables you to create custom series types, also known as series plug
 To define a custom series type, create a class that implements the [`ICustomSeriesPaneView`](/api/interfaces/ICustomSeriesPaneView.md) interface. This class defines the rendering code that Lightweight Charts&trade; uses to draw the series on the chart.
 Once your custom series type is defined, it can be added to any chart instance using the [`addCustomSeries()`](/api/interfaces/IChartApi.md#addcustomseries) method. Custom series types function like any other series.
 
-For more information, refer to the [Plugin development](./plugins/intro.md) section.
+For more information, refer to the [Plugin development](./plugins/intro.md) section, or browse the [plugin catalog](/plugins) for ready-made series plugins.
 
 ## Customization
 

--- a/website/tutorials/a11y/conclusion.mdx
+++ b/website/tutorials/a11y/conclusion.mdx
@@ -49,9 +49,9 @@ discussed in this tutorial.
 :::info Ready-made plugin
 
 If you would rather not wire these techniques up by hand, the
-[Accessibility plugin](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples/src/plugins/accessibility)
-in the plugin examples packages the keyboard navigation and ARIA layer described
-here into a chart-level helper built on pane primitives:
+[Accessibility plugin](/plugins/accessibility)
+packages the keyboard navigation and ARIA layer described here into a
+chart-level helper built on pane primitives:
 
 ```js
 addAccessibilityPlugin(chart, { chartTitle: 'My chart' });

--- a/website/tutorials/a11y/intro.mdx
+++ b/website/tutorials/a11y/intro.mdx
@@ -37,10 +37,9 @@ intended to be a comprehensive tutorial.**
 :::tip Ready-made plugin
 
 If you would rather not wire these techniques up by hand, the
-[Accessibility plugin](https://github.com/tradingview/lightweight-charts/tree/master/plugin-examples/src/plugins/accessibility)
-in the plugin examples packages the keyboard navigation, ARIA markup and
-screen-reader announcements covered in this tutorial into a single chart-level
-helper:
+[Accessibility plugin](/plugins/accessibility)
+packages the keyboard navigation, ARIA markup and screen-reader announcements
+covered in this tutorial into a single chart-level helper:
 
 ```js
 addAccessibilityPlugin(chart, { chartTitle: 'My chart' });

--- a/website/versioned_docs/version-5.2/plugins/intro.md
+++ b/website/versioned_docs/version-5.2/plugins/intro.md
@@ -10,6 +10,13 @@ series types, drawing tools, indicators, watermarks, and other custom elements
 rendered as part of the chart. This section explains how plugins work and how
 to build your own.
 
+:::tip
+
+Looking for a ready-made plugin instead of building one? Browse the
+[plugin catalog](/plugins).
+
+:::
+
 ## Choosing a plugin type
 
 | You want to build | Plugin type | Attach with |

--- a/website/versioned_docs/version-5.2/series-types.mdx
+++ b/website/versioned_docs/version-5.2/series-types.mdx
@@ -166,7 +166,7 @@ The library enables you to create custom series types, also known as series plug
 To define a custom series type, create a class that implements the [`ICustomSeriesPaneView`](/api/interfaces/ICustomSeriesPaneView.md) interface. This class defines the rendering code that Lightweight Charts&trade; uses to draw the series on the chart.
 Once your custom series type is defined, it can be added to any chart instance using the [`addCustomSeries()`](/api/interfaces/IChartApi.md#addcustomseries) method. Custom series types function like any other series.
 
-For more information, refer to the [Plugin development](./plugins/intro.md) section.
+For more information, refer to the [Plugin development](./plugins/intro.md) section, or browse the [plugin catalog](/plugins) for ready-made series plugins.
 
 ## Customization
 


### PR DESCRIPTION
**Overview of change:**
Cross-links between the docs, the repo READMEs, and the upcoming plugin catalog (/plugins), plus a general cleanup pass on the READMEs touched along the way.

The `/plugins` links use plain paths, so CI is expected to be red (onBrokenLinks + broken-link checks) until CLL-405 (catalog pages) merges. Do not merge this before CLL-405, ideally after cll-394-403 (plugin graduation) too.
